### PR TITLE
Fix duplicate title fields causing Hugo build failure

### DIFF
--- a/content/english/about/index.md
+++ b/content/english/about/index.md
@@ -1,7 +1,6 @@
 ---
 title: About
 linktitle: About
-title: About
 slug: About
 url: "/about"
 sidemenu: true

--- a/content/swedish/about/index.md
+++ b/content/swedish/about/index.md
@@ -1,7 +1,6 @@
 ---
 title: Om
 linktitle: Om
-title: Om
 slug: om
 url: "/sv/om"
 sidemenu: true

--- a/content/swedish/contact/index.md
+++ b/content/swedish/contact/index.md
@@ -1,20 +1,17 @@
 ---
 title: Kontakt
 linktitle: Kontakt
-title: Kontakt
 slug: kontakt
 url: "/sv/kontakt"
 aliases:
-    - /sv/contact/
+  - /sv/contact/
 sidemenu: true
 description: If you have any questions or suggestions on how we could work together, please get in touch.
 layout: contact
 ---
-
 
 {{< contact_form >}}
 
 {{< contact_info >}}
 
 {{< subscribe >}}
-

--- a/content/swedish/newsletter/index.md
+++ b/content/swedish/newsletter/index.md
@@ -1,7 +1,6 @@
 ---
 title: Nyhetsbrev
 linktitle: Nyhetsbrev
-title: Nyhetsbrev
 slug: nyhetsbrev
 url: "/sv/nyhetsbrev"
 sidemenu: true
@@ -9,4 +8,5 @@ layout: newsletter
 ---
 
 ### Subscribe to my newsletter for news and be notified when new content is added to the site.
+
 {.grid-1-3 .mb-32}

--- a/content/swedish/thankyou/index.md
+++ b/content/swedish/thankyou/index.md
@@ -3,11 +3,10 @@ title: Tack för ditt meddelande
 description: Tack för ditt meddelande
 layout: thankyou
 linktitle: Tack för ditt meddelande
-title: Tack för ditt meddelande
 slug: tack
 url: "/sv/tack"
 aliases:
-    - /sv/thankyou/
+  - /sv/thankyou/
 ---
 
 ### Tack för att du hör av dig. Jag återkommer så snart som möjligt.


### PR DESCRIPTION
- Removed duplicate title fields in 5 content files
- Fixes ERROR: assemble: failed to build site
- Files fixed:
  - content/english/about/index.md
  - content/swedish/about/index.md
  - content/swedish/contact/index.md
  - content/swedish/newsletter/index.md
  - content/swedish/thankyou/index.md

This is a hotfix for the master branch build failure.