### PR TITLE
fix: correct JSON-LD escaping in schema markup

### DIFF
--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -86,5 +86,5 @@
 {{ end }}
 
 {{ range $schemas }}
-  <script type="application/ld+json">{{ . | jsonify | safeHTML }}</script>
+  <script type="application/ld+json">{{ . | jsonify | safeJS }}</script>
 {{ end }}


### PR DESCRIPTION
Change safeHTML to safeJS for JSON-LD script tags to prevent double-escaping of JSON content. This ensures search engines can properly parse the schema.org structured data.

- Fixed: WebSite and ProfilePage schemas now output valid JSON
- Before: Entire JSON object was wrapped as escaped string
- After: Clean, parseable JSON-LD markup

Fixes double-escape issue where output was:
<script>"{\"@context\":\"https://schema.org\"...}"</script>

Now outputs valid:
<script>{"@context":"https://schema.org"...}</script>