### PR TITLE
feat: block search engine indexing for clients and employers pages

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,8 +19,8 @@
     content="#18181b"
     media="(prefers-color-scheme: dark)"
   />
-  {{ if eq .Params.index false }}
-    <meta name="robots" content="noindex" />
+  {{ if or (eq .Params.index false) (eq .Type "clients") (eq .Type "employers") }}
+    <meta name="robots" content="noindex, nofollow" />
   {{ end }}
 
   <!-- Google Search Console verification -->

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,4 +1,8 @@
 User-agent: *
 Allow: /
+Disallow: /clients/
+Disallow: /employers/
+Disallow: /sv/clients/
+Disallow: /sv/employers/
 
 Sitemap: {{ .Site.BaseURL }}sitemap.xml


### PR DESCRIPTION
Added double protection against search engine indexing:
- Meta tags: Added noindex/nofollow for all pages of type 'clients' and 'employers'
- robots.txt: Disallowed /clients/ and /employers/ paths for all languages

This ensures that client and employer application pages remain private
and are not indexed by search engines like Google.