### PR TITLE
fix: stabilize about cv columns in Safari

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -392,9 +392,6 @@ p:empty {
 /* || ========== About page ------------------------------------- */
 .about-cv {
   grid-column: content-start / content-end;
-  column-count: 1;
-  column-gap: var(--spacing-32);
-  column-fill: balance;
 }
 
 .about-cv__icon,
@@ -402,15 +399,10 @@ p:empty {
   display: block;
 }
 
-@supports (column-span: all) {
-  .about-cv {
-    column-count: 3;
-  }
-
-  .about-cv__icon,
-  .about-cv__title {
-    column-span: all;
-  }
+ .about-cv__columns {
+  column-count: 3;
+  column-gap: var(--spacing-32);
+  column-fill: balance;
 }
 
 .about-cv__icon {
@@ -438,19 +430,15 @@ p:empty {
 
 /* md: <= 63.9375em */
 @media (max-width: 63.9375em) {
-  @supports (column-span: all) {
-    .about-cv {
-      column-count: 2;
-    }
+  .about-cv__columns {
+    column-count: 2;
   }
 }
 
 /* sm: <= 47.9375em */
 @media (max-width: 47.9375em) {
-  @supports (column-span: all) {
-    .about-cv {
-      column-count: 1;
-    }
+  .about-cv__columns {
+    column-count: 1;
   }
 }
 

--- a/layouts/partials/about_cv.html
+++ b/layouts/partials/about_cv.html
@@ -3,6 +3,7 @@
 
 <h3 class="about-cv__title type-headline-3">What I’ve been up to</h3>
 
+<div class="about-cv__columns">
 <div class="about-cv__section reveal">
 <h4 class="about-cv__heading type-headline-small">Work</h4>
 <p class="about-cv__text type-body-sm">
@@ -77,4 +78,5 @@ Estrid Ericsons Stiftelse / Adlerbertska Premiestiftelsen / Helge Ax:son Johnson
 Adlerbertska Premiestiftelsen</p>
 </div>
 
+</div>
 </div>

--- a/layouts/shortcodes/about_skills.html
+++ b/layouts/shortcodes/about_skills.html
@@ -3,6 +3,7 @@
 
 <h3 class="about-cv__title type-headline-3">What I’ve been up to</h3>
 
+<div class="about-cv__columns">
 <div class="about-cv__section">
 <h4 class="about-cv__heading type-headline-small">Work</h4>
 <p class="about-cv__text type-body-sm">
@@ -53,4 +54,5 @@ Estrid Ericsons Stiftelse / Adlerbertska Premiestiftelsen / Helge Ax:son Johnson
 Adlerbertska Premiestiftelsen</p>
 </div>
 
+</div>
 </div>


### PR DESCRIPTION
What
Force uniform summary‑card title sizing under 690px.
Fix Safari column rendering in the About CV block.
Add per‑language languageCode metadata.
Update home meta descriptions for cleaner Google snippets.
Ensure summary-card.css is included in production bundle.
Why
Match mobile typography across summary card variants.
Prevent Safari column quirks that overlay headings.
Improve SEO signals (language metadata + snippet text).
Fix missing component CSS in preview/prod.
Checklist
 Verify summary title sizes at 622–690px on mobile
 Verify About CV heading in Safari (desktop + iOS)
 Verify preview loads summary-card__meta styles