### PR TITLE
fix: update Swedish brand-identity tag URL to match footer link

### DIFF
--- a/content/swedish/tags/varumarke-identitet/_index.md
+++ b/content/swedish/tags/varumarke-identitet/_index.md
@@ -2,5 +2,5 @@
 translationKey: "brand identity"
 title: Varumärke & Identitet
 slug: arbeten
-url: "/sv/arbeten/tags/varumarke-identitet/"
+url: "/sv/arbeten/tags/varumärke-identitet/"
 ---


### PR DESCRIPTION
The footer uses Hugo's urlize function which preserves the ä character
when preserveTaxonomyNames is enabled. Changed the tag URL from
/sv/arbeten/tags/varumarke-identitet/ to /sv/arbeten/tags/varumärke-identitet/
to match the generated footer link.