### PR TITLE
fix: use dynamic baseURL for Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 
 [build]
   publish = "public"
-  command = "hugo --minify"
+  command = "hugo --minify --baseURL $URL"
 
 [build.environment]
   HUGO_VERSION = "0.154.2"
@@ -13,10 +13,10 @@
   environment = { HUGO_ENV = "production" }
 
 [context.deploy-preview]
-  command = "hugo --minify --buildFuture --buildDrafts"
+  command = "hugo --minify --buildFuture --buildDrafts --baseURL $DEPLOY_PRIME_URL"
 
 [context.branch-deploy]
-  command = "hugo --minify --buildFuture --buildDrafts"
+  command = "hugo --minify --buildFuture --buildDrafts --baseURL $DEPLOY_PRIME_URL"
 
 # Redirects - English
 [[redirects]]


### PR DESCRIPTION
Use $URL for production and $DEPLOY_PRIME_URL for previews to ensure CSS/JS resources load correctly regardless of domain.

https://claude.ai/code/session_01D6VvpKUphk7SExZb1qmLgi