### PR TITLE
feat: create GitHub issues from Lighthouse audits

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,11 @@ on:
       - claude/**
   pull_request:
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -165,6 +170,46 @@ https://tor2dbear.github.io/portfolio/preview/${{ env.PREVIEW_BRANCH }}/
 [View full report](${reportUrl})${todoSection}`;
 
             core.setOutput('comment', comment);
+            core.setOutput('todos', JSON.stringify(todos));
+
+      - name: Create Lighthouse issues
+        if: ${{ steps.lighthouse_score.outputs.todos != '[]' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const todos = JSON.parse(`${{ steps.lighthouse_score.outputs.todos }}`);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const links = ${{ steps.lighthouse.outputs.links }};
+            const reportUrl = Object.values(links)[0] || '';
+
+            for (const todo of todos) {
+              const title = `Lighthouse: ${todo.title} (${todo.category})`;
+              const queryTitle = title.replace(/"/g, '\\"');
+              const query = `repo:${owner}/${repo} is:issue in:title "${queryTitle}"`;
+              const existing = await github.rest.search.issuesAndPullRequests({ q: query });
+
+              if (existing.data.items.length > 0) {
+                core.info(`Issue already exists: ${title}`);
+                continue;
+              }
+
+              const body = [
+                `**Category:** ${todo.category}`,
+                `**Score:** ${todo.score}`,
+                '',
+                `Source: ${reportUrl}`,
+                '',
+                `Found in preview build: ${process.env.PREVIEW_BRANCH}`
+              ].join('\n');
+
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body
+              });
+            }
 
       - name: Comment preview URL with Lighthouse
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Motivation
- Automatically surface Lighthouse improvement opportunities as GitHub issues for preview builds to make regressions visible and trackable.
- Avoid creating duplicate issues by detecting existing issues with the same title before opening a new one.

### Description
- Added top-level `permissions` to `.github/workflows/gh-pages.yml` (`contents: read`, `issues: write`, `pull-requests: write`).
- Exposed Lighthouse TODOs as an output (`todos`) from the `lighthouse_score` step via `core.setOutput('todos', JSON.stringify(todos))`.
- Added a `Create Lighthouse issues` step using `actions/github-script@v7` that parses the `todos` output, constructs an escaped search query to detect existing issues, and creates deduplicated issues containing category, score, report URL and preview branch info.
- Improved handling of Lighthouse report links and escaped quote characters in issue title searches to prevent query errors.

### Testing
- No automated tests were executed for this change because it is a workflow-only modification and was not run in CI here.
- The repository commit completed locally, but workflow behavior must be validated by triggering a preview build (GitHub Actions) where the new steps will run.
- The workflow still includes the existing `test` job (`npm run lint`, `npm test`) which will execute when the workflow is triggered in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698309a377fc832da4f90712e820cdd2)