### PR TITLE
fix: remove scrollbar-width offset that was causing grid overlay left shift

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -107,7 +107,7 @@ jobs:
               '',
               `---`,
               `<sub>Built from ${context.sha.substring(0, 7)}</sub>`,
-            ].join('\\n');
+            ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/assets/css/components/grid-overlay.css
+++ b/assets/css/components/grid-overlay.css
@@ -2,10 +2,7 @@
 
 .grid-overlay {
   position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: var(--scrollbar-width, 0px);
+  inset: 0;
   z-index: 900;
   pointer-events: none;
   display: none;

--- a/assets/js/grid-overlay.js
+++ b/assets/js/grid-overlay.js
@@ -126,14 +126,6 @@
     el.textContent = title + " " + label;
   }
 
-  // Track scrollbar width so the fixed-position overlay matches content alignment
-  function syncScrollbarWidth() {
-    var sw = window.innerWidth - document.documentElement.clientWidth;
-    document.documentElement.style.setProperty("--scrollbar-width", sw + "px");
-  }
-  syncScrollbarWidth();
-  window.addEventListener("resize", syncScrollbarWidth);
-
   // Restore state from localStorage — no animation on page load
   if (localStorage.getItem(STORAGE_KEY) === "true") {
     document.documentElement.setAttribute("data-grid-overlay", "");


### PR DESCRIPTION
The fixed-position overlay's containing block already excludes the scrollbar
(CSS viewport = clientWidth), so subtracting scrollbar-width via `right:`
was making the overlay narrower than #main and centering it too far left.

Using `inset: 0` with `max-width` + `margin: auto` is sufficient and correct
for both desktop (with or without scrollbar) and mobile.

https://claude.ai/code/session_01LKW6Pf9dygrjmc6g7P7hnh