### PR TITLE
Replace minimized transport arrow with meatball menu dots

### DIFF
--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -412,12 +412,14 @@
 
 .coty-transport__trigger-icon {
   display: block;
-  width: var(--size-64);
-  height: var(--size-24);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
   flex-shrink: 0;
   background-color: currentColor;
-  -webkit-mask: url("/img/svg/arrow-up.svg") center / contain no-repeat;
-  mask: url("/img/svg/arrow-up.svg") center / contain no-repeat;
+  box-shadow:
+    -8px 0 0 currentColor,
+    8px 0 0 currentColor;
   opacity: 0;
   transform: translateY(var(--spacing-4));
   transition:
@@ -426,19 +428,13 @@
 }
 
 .coty-transport[data-ui-state="collapsed"] {
-  padding: 0;
-  background: transparent;
-  border-color: transparent;
+  padding: var(--spacing-8);
   color: var(--text-default);
-  box-shadow: none;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  bottom: var(--spacing-4);
   transform: scale(0.97);
 }
 
 .coty-transport[data-ui-state="collapsed"] .coty-transport__trigger {
-  width: var(--size-64);
+  width: var(--size-48);
   padding: 0;
   opacity: 1;
   transform: scale(1);

--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -434,7 +434,7 @@
 }
 
 .coty-transport[data-ui-state="collapsed"] .coty-transport__trigger {
-  width: 10rem;
+  width: var(--size-48);
   height: 20px;
   padding: 0;
   opacity: 1;

--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -428,13 +428,14 @@
 }
 
 .coty-transport[data-ui-state="collapsed"] {
-  padding: var(--spacing-8);
+  padding: var(--spacing-4) var(--spacing-8);
   color: var(--text-default);
   transform: scale(0.97);
 }
 
 .coty-transport[data-ui-state="collapsed"] .coty-transport__trigger {
-  width: var(--size-48);
+  width: 10rem;
+  height: 20px;
   padding: 0;
   opacity: 1;
   transform: scale(1);


### PR DESCRIPTION
The transport control now collapses to three horizontal dots instead
of an up arrow. The container keeps its background, border, shadow,
and backdrop-filter when collapsed (rather than going transparent),
and stays at the same bottom position so the center point is
consistent between minimized and maximized states.

https://claude.ai/code/session_01XpiUDNdmX2jPLZuU4jVcZ8