### PR TITLE
refine liquid glass effect on toast and coty transport

### DIFF
--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -352,9 +352,9 @@
   border: 1px solid var(--component-toast-border);
   border-radius: var(--radius-pill);
   background: var(--component-toast-bg);
-  box-shadow: var(--shadow-01);
-  -webkit-backdrop-filter: blur(6px) saturate(80%);
-  backdrop-filter: blur(6px) saturate(80%);
+  box-shadow: inset 0 1px 0 var(--component-glass-highlight), var(--shadow-01);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  backdrop-filter: blur(12px) saturate(140%);
   transform-origin: center bottom;
   transition:
     opacity var(--motion-duration-enter) var(--motion-ease-emphasized),

--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -410,6 +410,15 @@
   );
 }
 
+.coty-transport__trigger:focus-visible {
+  outline: none;
+}
+
+.coty-transport:has(.coty-transport__trigger:focus-visible) {
+  outline: 2px solid var(--state-focus);
+  outline-offset: 3px;
+}
+
 .coty-transport__trigger-icon {
   display: block;
   width: 4px;
@@ -428,7 +437,7 @@
 }
 
 .coty-transport[data-ui-state="collapsed"] {
-  padding: var(--spacing-4) var(--spacing-8);
+  padding: 0;
   color: var(--text-default);
   transform: scale(0.97);
 }
@@ -518,6 +527,14 @@
   .coty-transport[data-ui-state="collapsed"],
   .coty-transport[data-ui-state="expanded"] {
     transform: none;
+  }
+}
+
+/* Progressive enhancement: SVG refraction on Chromium */
+@supports (backdrop-filter: url(#x)) {
+  .coty-transport {
+    -webkit-backdrop-filter: url(#liquid-glass) blur(12px) saturate(140%);
+    backdrop-filter: url(#liquid-glass) blur(12px) saturate(140%);
   }
 }
 

--- a/assets/css/components/toast.css
+++ b/assets/css/components/toast.css
@@ -29,9 +29,9 @@
   color: var(--text-default);
   background: var(--component-toast-bg);
   border: 1px solid var(--component-toast-border);
-  box-shadow: var(--shadow-02);
-  -webkit-backdrop-filter: blur(6px) saturate(80%);
-  backdrop-filter: blur(6px) saturate(80%);
+  box-shadow: inset 0 1px 0 var(--component-glass-highlight), var(--shadow-02);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  backdrop-filter: blur(12px) saturate(140%);
 
   opacity: 0;
   pointer-events: none;

--- a/assets/css/components/toast.css
+++ b/assets/css/components/toast.css
@@ -137,3 +137,11 @@
     opacity: 0;
   }
 }
+
+/* Progressive enhancement: SVG refraction on Chromium */
+@supports (backdrop-filter: url(#x)) {
+  .toast {
+    -webkit-backdrop-filter: url(#liquid-glass) blur(12px) saturate(140%);
+    backdrop-filter: url(#liquid-glass) blur(12px) saturate(140%);
+  }
+}

--- a/assets/css/dimensions/mode/dark.css
+++ b/assets/css/dimensions/mode/dark.css
@@ -168,8 +168,9 @@
   /* Dark mode specific overrides */
   --surface-page: var(--gray-1);
   --surface-elevated: color-mix(in srgb, var(--surface-page) 88%, white);
-  --component-toast-bg: color-mix(in srgb, var(--gray-1) 52%, transparent);
-  --component-toast-border: color-mix(in srgb, var(--white) 8%, transparent);
+  --component-toast-bg: color-mix(in srgb, var(--gray-1) 50%, transparent);
+  --component-toast-border: color-mix(in srgb, var(--white) 12%, transparent);
+  --component-glass-highlight: rgba(255, 255, 255, 0.07);
   --shadow-01: rgba(0, 0, 0, 0.2) 0px 10px 15px -3px,
     rgba(0, 0, 0, 0.1) 0px 4px 6px -2px;
   --shadow-02: rgba(0, 0, 0, 0.45) 0px 8px 20px -6px,

--- a/assets/css/tokens/components.css
+++ b/assets/css/tokens/components.css
@@ -21,14 +21,15 @@
   --component-newsletter-button-text: var(--iris-11);
   --component-toast-bg: color-mix(
     in srgb,
-    var(--surface-page) 52%,
+    var(--surface-page) 45%,
     transparent
   );
   --component-toast-border: color-mix(
     in srgb,
-    var(--text-default) 6%,
+    var(--text-default) 9%,
     transparent
   );
+  --component-glass-highlight: rgba(255, 255, 255, 0.55);
 
   /* ==========================================================================
      LAYOUT TOKENS - Max-width constraints

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -226,6 +226,16 @@
   </div>
 </div>
 
+<!-- Liquid glass SVG filter (Chromium progressive enhancement for backdrop-filter) -->
+<svg style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true">
+  <defs>
+    <filter id="liquid-glass" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feTurbulence type="fractalNoise" baseFrequency="0.006 0.006" numOctaves="2" seed="5" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="8" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+  </defs>
+</svg>
+
 <!-- Grid overlay (toggled via theme panel or chord key G) -->
 <div class="grid-overlay" aria-hidden="true">
   <div class="grid-overlay__col"></div>


### PR DESCRIPTION
- Increase blur from 6px to 12px for a more immersive glass look
- Swap saturate(80%) for saturate(140%) to simulate glass refraction
- Lower toast background opacity from 52% to 45% (light) / 50% (dark)
  so more of the underlying content shows through
- Slightly raise border opacity for better glass edge definition
- Add --component-glass-highlight token (0.55 light / 0.07 dark) for a
  specular inset highlight along the top edge of both elements

https://claude.ai/code/session_01WGcQtxL6MpvYQxVZamqCCE