### PR TITLE
refactor: optimize pantone theme runtime and transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /themes
 /public
 /node_modules
+/.npm-cache
 /worktrees
 
 # Test coverage

--- a/assets/css/components/button.css
+++ b/assets/css/components/button.css
@@ -55,9 +55,15 @@ button,
 
   /* Interaction */
   cursor: pointer;
-  transition: all
-    var(--theme-transition-duration, var(--motion-duration-base))
-    var(--motion-ease-standard);
+  transition: background-color
+      var(--theme-transition-duration, var(--motion-duration-base))
+      var(--motion-ease-standard),
+    border-color var(--theme-transition-duration, var(--motion-duration-base))
+      var(--motion-ease-standard),
+    color var(--theme-transition-duration, var(--motion-duration-base))
+      var(--motion-ease-standard),
+    box-shadow var(--theme-transition-duration, var(--motion-duration-base))
+      var(--motion-ease-standard);
   user-select: none;
 }
 

--- a/assets/css/components/download-card.css
+++ b/assets/css/components/download-card.css
@@ -86,7 +86,11 @@ p.download-card__item {
   font-size: var(--text-sm);
   color: var(--text-default);
   text-decoration: none;
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
 }
 
 .print-button:hover {

--- a/assets/css/components/form.css
+++ b/assets/css/components/form.css
@@ -29,7 +29,11 @@ textarea,
   background-color: var(--component-form-bg);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-8);
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
 }
 
 textarea {
@@ -129,7 +133,10 @@ textarea.error:focus,
   border: 2px solid var(--border-default);
   border-radius: 50%;
   background-color: var(--surface-page);
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
   flex-shrink: 0;
 }
 
@@ -211,7 +218,10 @@ textarea.error:focus,
   border: 2px solid var(--border-default);
   border-radius: var(--radius-4);
   background-color: var(--surface-page);
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
   flex-shrink: 0;
 }
 
@@ -291,7 +301,11 @@ select,
   border-radius: var(--radius-8);
   cursor: pointer;
   appearance: none;
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
 }
 
 /* Focus State */

--- a/assets/css/components/language-dropdown.css
+++ b/assets/css/components/language-dropdown.css
@@ -15,7 +15,11 @@
   border: calc(var(--spacing-2) / 2) solid var(--border-default);
   border-radius: var(--spacing-8);
   cursor: pointer;
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
   min-width: var(--size-40);
   min-height: var(--size-40);
   color: var(--text-default);

--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -22,7 +22,7 @@
     var(--motion-ease-standard);
   border-bottom-style: solid;
   border-bottom-width: 1px;
-  border-color: var(--surface-page);
+  border-color: transparent;
   display: grid;
   grid-area: header;
 }

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -16,7 +16,11 @@
   border: calc(var(--spacing-2) / 2) solid var(--border-default);
   border-radius: var(--spacing-8);
   cursor: pointer;
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
   min-width: var(--size-40);
   min-height: var(--size-40);
   color: var(--text-default);

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -13,7 +13,9 @@
   background-color: var(--surface-accent);
   background-image: linear-gradient(transparent, transparent);
   letter-spacing: var(--tracking-wider);
-  transition: all var(--motion-duration-slow) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-slow)
+      var(--motion-ease-standard),
+    color var(--motion-duration-slow) var(--motion-ease-standard);
   white-space: nowrap;
   font-family: var(--font-ui);
   font-size: var(--text-xs);

--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -16,7 +16,11 @@
   border: calc(var(--spacing-2) / 2) solid var(--border-default);
   border-radius: var(--spacing-8);
   cursor: pointer;
-  transition: all var(--motion-duration-base) var(--motion-ease-standard);
+  transition: background-color var(--motion-duration-base)
+      var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    color var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard);
   min-width: var(--size-40);
   min-height: var(--size-40);
   color: var(--text-default);
@@ -356,16 +360,14 @@
   -webkit-backdrop-filter: blur(6px) saturate(80%);
   backdrop-filter: blur(6px) saturate(80%);
   transform-origin: center bottom;
-  transition:
-    opacity var(--motion-duration-enter) var(--motion-ease-emphasized),
+  transition: opacity var(--motion-duration-enter) var(--motion-ease-emphasized),
     transform var(--motion-duration-enter) var(--motion-ease-emphasized),
     background-color var(--motion-duration-exit) var(--motion-ease-standard),
     border-color var(--motion-duration-exit) var(--motion-ease-standard),
     border-radius var(--motion-duration-exit) var(--motion-ease-standard),
     padding var(--motion-duration-exit) var(--motion-ease-standard),
     box-shadow var(--motion-duration-exit) var(--motion-ease-standard),
-    -webkit-backdrop-filter var(--motion-duration-exit)
-      var(--motion-ease-standard),
+    -webkit-backdrop-filter var(--motion-duration-exit) var(--motion-ease-standard),
     backdrop-filter var(--motion-duration-exit) var(--motion-ease-standard);
 }
 
@@ -388,8 +390,7 @@
   opacity: 0;
   overflow: hidden;
   transform: scale(0.72);
-  transition:
-    width var(--motion-duration-base) var(--motion-ease-emphasized),
+  transition: width var(--motion-duration-base) var(--motion-ease-emphasized),
     padding var(--motion-duration-base) var(--motion-ease-standard),
     opacity var(--motion-duration-base) var(--motion-ease-standard),
     transform var(--motion-duration-base) var(--motion-ease-emphasized),
@@ -420,8 +421,7 @@
   mask: url("/img/svg/arrow-up.svg") center / contain no-repeat;
   opacity: 0;
   transform: translateY(var(--spacing-4));
-  transition:
-    opacity var(--motion-duration-base) var(--motion-ease-standard),
+  transition: opacity var(--motion-duration-base) var(--motion-ease-standard),
     transform var(--motion-duration-base) var(--motion-ease-emphasized);
 }
 
@@ -494,8 +494,8 @@
   gap: var(--spacing-8);
   max-width: 24rem;
   overflow: hidden;
-  transition:
-    max-width var(--motion-duration-exit) var(--motion-ease-emphasized),
+  transition: max-width var(--motion-duration-exit)
+      var(--motion-ease-emphasized),
     opacity var(--motion-duration-base) var(--motion-ease-standard),
     transform var(--motion-duration-exit) var(--motion-ease-emphasized);
 }
@@ -511,8 +511,7 @@
   .coty-transport,
   .coty-transport__trigger,
   .coty-player--transport {
-    transition:
-      width var(--motion-duration-fast) linear,
+    transition: width var(--motion-duration-fast) linear,
       max-width var(--motion-duration-fast) linear,
       opacity var(--motion-duration-fast) linear,
       visibility var(--motion-duration-fast) linear;

--- a/assets/css/pages/home.css
+++ b/assets/css/pages/home.css
@@ -113,6 +113,11 @@
   padding: 0 var(--spacing-4);
   border-radius: var(--spacing-4);
   font-weight: inherit;
+  transition: background-color
+      var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    color var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,24 +13,117 @@ body {
 
 /* || ========== Transitions ------------------------------------- */
 
-/* Darkmode transition. */
+/* Theme-swap transition for theme-driven surfaces, text, borders, and icons. */
 body.darkmodeTransition,
 body.darkmodeTransition
   :is(
+    #layout,
     #main,
+    footer,
     .top-menu,
+    .top-menu__link,
+    .top-menu__link--button,
+    .hero-emphasis,
+    .theme-toggle,
+    .theme-panel,
+    .theme-option,
+    .theme-options--segmented,
+    .theme-effect-button,
+    .language-toggle,
+    .language-panel,
+    .language-option,
+    .settings-toggle,
+    .settings-panel,
+    .button,
+    button,
+    .tag,
+    .project-info,
+    .project-info__title,
+    .project-info__label,
+    .project-info__value,
+    .project-info__text,
+    .project-info__link,
+    .download-card,
+    .print-button,
+    .tabs-nav,
+    .tab-button,
+    input,
+    textarea,
+    select,
+    .input,
+    .radio__visual,
+    .checkbox__visual,
     path.hyphen,
     .brand__mark,
     .brand__mark path,
     .brand__mark line,
-    button,
     .brand,
-    .brand__hyphen
+    .brand__hyphen,
+    svg,
+    svg *,
+    [class*="icon"]
   ) {
-  transition: stroke var(--motion-duration-xslow) var(--motion-ease-theme),
-    border-color var(--motion-duration-xslow) var(--motion-ease-theme),
-    color var(--motion-duration-xslow) var(--motion-ease-theme),
-    background-color var(--motion-duration-xslow) var(--motion-ease-theme);
+  transition: stroke
+      var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    fill var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    border-color var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    color var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    background-color
+      var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    box-shadow var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.darkmodeTransition,
+  body.darkmodeTransition
+    :is(
+      #layout,
+      #main,
+      footer,
+      .top-menu,
+      .top-menu__link,
+      .top-menu__link--button,
+      .theme-toggle,
+      .theme-panel,
+      .theme-option,
+      .theme-options--segmented,
+      .theme-effect-button,
+      .language-toggle,
+      .language-panel,
+      .language-option,
+      .settings-toggle,
+      .settings-panel,
+      .button,
+      button,
+      .tag,
+      .download-card,
+      .print-button,
+      .tabs-nav,
+      .tab-button,
+      input,
+      textarea,
+      select,
+      .input,
+      .radio__visual,
+      .checkbox__visual,
+      path.hyphen,
+      .brand__mark,
+      .brand__mark path,
+      .brand__mark line,
+      .brand,
+      .brand__hyphen,
+      svg,
+      svg *,
+      [class*="icon"]
+    ) {
+    transition: none;
+  }
 }
 
 /* || ========== Main section ------------------------------------- */
@@ -399,7 +492,11 @@ video {
   --image-grayscale: 100%;
   --image-shadow-blend-mode: multiply;
   --image-highlight-blend-mode: screen;
-  --image-shadow-background: color-mix(in srgb, var(--primary-strong) 70%, black);
+  --image-shadow-background: color-mix(
+    in srgb,
+    var(--primary-strong) 70%,
+    black
+  );
   --image-highlight-background: color-mix(in srgb, var(--primary) 84%, white);
   --image-shadow-opacity: 0.66;
   --image-highlight-opacity: 0.74;
@@ -543,6 +640,13 @@ p:empty {
   --col: col-start 1 / span 12;
   grid-column: var(--col);
   grid-column-gap: 3rem;
+  transition: background-color
+      var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    border-color var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme),
+    color var(--theme-transition-duration, var(--motion-duration-xslow))
+      var(--motion-ease-theme);
 }
 
 .content.post > .project-info.project-info--cols-2 {
@@ -570,6 +674,9 @@ p:empty {
   text-transform: uppercase;
   color: var(--text-accent);
   margin: 0 0 var(--spacing-8);
+  transition: color
+    var(--theme-transition-duration, var(--motion-duration-xslow))
+    var(--motion-ease-theme);
 }
 
 .project-info__label {
@@ -579,6 +686,9 @@ p:empty {
   line-height: var(--line-height-tight);
   color: var(--text-muted);
   margin: 0 0 var(--spacing-4);
+  transition: color
+    var(--theme-transition-duration, var(--motion-duration-xslow))
+    var(--motion-ease-theme);
 }
 
 .project-info__value,
@@ -589,6 +699,9 @@ p:empty {
   line-height: var(--line-height-normal);
   color: var(--text-default);
   margin: 0 0 var(--spacing-12);
+  transition: color
+    var(--theme-transition-duration, var(--motion-duration-xslow))
+    var(--motion-ease-theme);
 }
 
 .project-info__section > .project-info__text:last-child {
@@ -601,6 +714,9 @@ p:empty {
   gap: var(--spacing-4);
   text-decoration: underline;
   text-decoration-style: dotted;
+  transition: color
+    var(--theme-transition-duration, var(--motion-duration-xslow))
+    var(--motion-ease-theme);
 }
 
 .project-info__link .icon {

--- a/assets/css/utilities/typography.css
+++ b/assets/css/utilities/typography.css
@@ -572,7 +572,9 @@ figcaption {
 a {
   color: var(--text-default);
   text-decoration: none;
-  transition: all var(--motion-duration-slow) var(--motion-ease-standard);
+  transition: color var(--motion-duration-slow) var(--motion-ease-standard),
+    text-decoration-color var(--motion-duration-slow)
+      var(--motion-ease-standard);
 }
 
 body a:hover,

--- a/assets/js/__tests__/header-line.test.js
+++ b/assets/js/__tests__/header-line.test.js
@@ -430,4 +430,89 @@ describe("Header Line - Scroll-based Bottom Line", () => {
       expect(header.classList.contains("bottom-line")).toBe(false);
     });
   });
+
+  describe("Navigation handoff", () => {
+    const is_plain_primary_navigation = (event) =>
+      event.button === 0 &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.shiftKey &&
+      !event.altKey;
+
+    const should_clear_line_for_link = (link) => {
+      if (!link) {
+        return false;
+      }
+      if (link.hasAttribute("download")) {
+        return false;
+      }
+      if (link.target && link.target !== "_self") {
+        return false;
+      }
+
+      const rawHref = link.getAttribute("href");
+      if (
+        !rawHref ||
+        rawHref.startsWith("#") ||
+        rawHref.startsWith("mailto:") ||
+        rawHref.startsWith("tel:") ||
+        rawHref.startsWith("javascript:")
+      ) {
+        return false;
+      }
+
+      const url = new URL(link.href, window.location.href);
+      if (url.origin !== window.location.origin) {
+        return false;
+      }
+      if (
+        url.pathname === window.location.pathname &&
+        url.search === window.location.search &&
+        url.hash
+      ) {
+        return false;
+      }
+      return true;
+    };
+
+    test("should treat plain left click as navigation intent", () => {
+      const event = {
+        button: 0,
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+      };
+
+      expect(is_plain_primary_navigation(event)).toBe(true);
+    });
+
+    test("should ignore modified clicks", () => {
+      const event = {
+        button: 0,
+        metaKey: true,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+      };
+
+      expect(is_plain_primary_navigation(event)).toBe(false);
+    });
+
+    test("should clear line only for same-origin page navigation", () => {
+      document.body.innerHTML = `
+        <a id="internal" href="/works/test/">Internal</a>
+        <a id="hash" href="#section">Hash</a>
+        <a id="external" href="https://example.com/">External</a>
+      `;
+
+      const internal = document.getElementById("internal");
+      const hash = document.getElementById("hash");
+      const external = document.getElementById("external");
+
+      expect(should_clear_line_for_link(internal)).toBe(true);
+      expect(should_clear_line_for_link(hash)).toBe(false);
+      expect(should_clear_line_for_link(external)).toBe(false);
+    });
+  });
 });

--- a/assets/js/coty-scale.js
+++ b/assets/js/coty-scale.js
@@ -457,17 +457,26 @@
       );
       transfer.setAttribute("in", "gray");
 
-      var funcR = document.createElementNS("http://www.w3.org/2000/svg", "feFuncR");
+      var funcR = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "feFuncR"
+      );
       funcR.setAttribute("type", "table");
       funcR.setAttribute("tableValues", "0 0 0");
       funcR.setAttribute("id", TRITONE_FILTER_ID + "-r");
 
-      var funcG = document.createElementNS("http://www.w3.org/2000/svg", "feFuncG");
+      var funcG = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "feFuncG"
+      );
       funcG.setAttribute("type", "table");
       funcG.setAttribute("tableValues", "0 0 0");
       funcG.setAttribute("id", TRITONE_FILTER_ID + "-g");
 
-      var funcB = document.createElementNS("http://www.w3.org/2000/svg", "feFuncB");
+      var funcB = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "feFuncB"
+      );
       funcB.setAttribute("type", "table");
       funcB.setAttribute("tableValues", "0 0 0");
       funcB.setAttribute("id", TRITONE_FILTER_ID + "-b");
@@ -500,15 +509,27 @@
     }
     nodes.r.setAttribute(
       "tableValues",
-      round3(shadowRgb.r) + " " + round3(midRgb.r) + " " + round3(highlightRgb.r)
+      round3(shadowRgb.r) +
+        " " +
+        round3(midRgb.r) +
+        " " +
+        round3(highlightRgb.r)
     );
     nodes.g.setAttribute(
       "tableValues",
-      round3(shadowRgb.g) + " " + round3(midRgb.g) + " " + round3(highlightRgb.g)
+      round3(shadowRgb.g) +
+        " " +
+        round3(midRgb.g) +
+        " " +
+        round3(highlightRgb.g)
     );
     nodes.b.setAttribute(
       "tableValues",
-      round3(shadowRgb.b) + " " + round3(midRgb.b) + " " + round3(highlightRgb.b)
+      round3(shadowRgb.b) +
+        " " +
+        round3(midRgb.b) +
+        " " +
+        round3(highlightRgb.b)
     );
   }
 
@@ -594,6 +615,28 @@
         hex: hex,
         role_mode: String(item.role_mode || ""),
         anchor_step: Number(item.anchor_step || 0),
+        secondary_name: String(item.secondary_name || ""),
+        secondary_hex: normalizeHex(item.secondary_hex),
+        secondary_role_mode: String(item.secondary_role_mode || ""),
+        secondary_anchor_step: Number(item.secondary_anchor_step || 0),
+        source_step_light: Number(item.source_step_light || 0),
+        source_step_dark: Number(item.source_step_dark || 0),
+        secondary_source_step_light: Number(
+          item.secondary_source_step_light || 0
+        ),
+        secondary_source_step_dark: Number(
+          item.secondary_source_step_dark || 0
+        ),
+        scale_light: normalizeScaleDefinition(item.scale_light, "coty"),
+        scale_dark: normalizeScaleDefinition(item.scale_dark, "coty"),
+        secondary_scale_light: normalizeScaleDefinition(
+          item.secondary_scale_light,
+          "coty-secondary"
+        ),
+        secondary_scale_dark: normalizeScaleDefinition(
+          item.secondary_scale_dark,
+          "coty-secondary"
+        ),
         overrides:
           item.overrides && typeof item.overrides === "object"
             ? item.overrides
@@ -618,7 +661,19 @@
         }
 
         var primary = colors[0];
-        var secondary = colors[1] || null;
+        var secondary =
+          primary.secondary_hex && primary.secondary_name
+            ? {
+                name: primary.secondary_name,
+                hex: primary.secondary_hex,
+                role_mode: primary.secondary_role_mode || "",
+                anchor_step: primary.secondary_anchor_step || 0,
+                source_step_light: primary.secondary_source_step_light || 0,
+                source_step_dark: primary.secondary_source_step_dark || 0,
+                scale_light: primary.secondary_scale_light || null,
+                scale_dark: primary.secondary_scale_dark || null,
+              }
+            : colors[1] || null;
 
         return {
           year: year,
@@ -631,9 +686,23 @@
           secondary_hex: secondary ? secondary.hex : "",
           secondary_role_mode: secondary ? secondary.role_mode || "" : "",
           secondary_anchor_step: secondary ? secondary.anchor_step || 0 : 0,
+          secondary_source_step_light: secondary
+            ? secondary.source_step_light || 0
+            : 0,
+          secondary_source_step_dark: secondary
+            ? secondary.source_step_dark || 0
+            : 0,
+          secondary_scale_light: secondary
+            ? secondary.scale_light || null
+            : null,
+          secondary_scale_dark: secondary ? secondary.scale_dark || null : null,
           tone_mode: secondary ? "duo" : "mono",
           role_mode: primary.role_mode || "",
           anchor_step: primary.anchor_step || 0,
+          source_step_light: primary.source_step_light || 0,
+          source_step_dark: primary.source_step_dark || 0,
+          scale_light: primary.scale_light || null,
+          scale_dark: primary.scale_dark || null,
           overrides: normalizeOverrides(primary.overrides || {}),
           overrides_light: normalizeOverrides(primary.overrides_light || {}),
           overrides_dark: normalizeOverrides(primary.overrides_dark || {}),
@@ -659,6 +728,93 @@
       out[String(key)] = String(value);
     });
     return out;
+  }
+
+  function normalizeScaleValue(raw) {
+    var value = String(raw || "").trim();
+    if (!value) {
+      return "";
+    }
+    if (value.indexOf("#") === 0) {
+      return normalizeHex(value) || "";
+    }
+    if (
+      value.indexOf("oklch(") === 0 ||
+      value.indexOf("rgb(") === 0 ||
+      value.indexOf("hsl(") === 0 ||
+      value.indexOf("var(") === 0
+    ) {
+      return value;
+    }
+    return value;
+  }
+
+  function normalizeScaleDefinition(raw, prefix) {
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+    var tokenPrefix = prefix || "coty";
+    var out = {};
+    for (var step = 1; step <= 12; step += 1) {
+      var value = normalizeScaleValue(raw[String(step)]);
+      if (!value) {
+        return null;
+      }
+      out["--" + tokenPrefix + "-" + step] = value;
+    }
+    return out;
+  }
+
+  function getExplicitScaleForMode(entry, mode) {
+    if (!entry) {
+      return null;
+    }
+    if (mode === "dark" && entry.scale_dark) {
+      return entry.scale_dark;
+    }
+    if (mode !== "dark" && entry.scale_light) {
+      return entry.scale_light;
+    }
+    return null;
+  }
+
+  function getSourceStepForMode(entry, mode, fallbackStep) {
+    if (!entry) {
+      return fallbackStep || 0;
+    }
+    var explicit =
+      mode === "dark"
+        ? Number(entry.source_step_dark || 0)
+        : Number(entry.source_step_light || 0);
+    if (explicit >= 1 && explicit <= 12) {
+      return explicit;
+    }
+    return Number(fallbackStep || 0);
+  }
+
+  function hasExplicitSourceStepForMode(entry, mode) {
+    if (!entry) {
+      return false;
+    }
+    var explicit =
+      mode === "dark"
+        ? Number(entry.source_step_dark || 0)
+        : Number(entry.source_step_light || 0);
+    return explicit >= 1 && explicit <= 12;
+  }
+
+  function getSecondarySourceStepForMode(entry, mode, fallbackStep) {
+    if (!entry) {
+      return Number(fallbackStep || 0);
+    }
+    var explicit =
+      mode === "dark"
+        ? Number(entry.secondary_source_step_dark || 0)
+        : Number(entry.secondary_source_step_light || 0);
+    if (explicit >= 1 && explicit <= 12) {
+      return explicit;
+    }
+    return Number(fallbackStep || 0);
   }
 
   function resolveAnchorStep(entry, mode, sourceLightness) {
@@ -811,6 +967,11 @@
   }
 
   function buildScale(entry, mode) {
+    var explicitScale = getExplicitScaleForMode(entry, mode);
+    if (explicitScale) {
+      return explicitScale;
+    }
+
     var rgb = hexToRgb(entry.primary_hex || entry.hex);
     if (!rgb) {
       return null;
@@ -859,6 +1020,13 @@
   function buildSecondaryScale(entry, mode) {
     if (!entry.secondary_hex) {
       return null;
+    }
+    var explicitScale =
+      mode === "dark"
+        ? entry.secondary_scale_dark || null
+        : entry.secondary_scale_light || null;
+    if (explicitScale) {
+      return explicitScale;
     }
     var rgb = hexToRgb(entry.secondary_hex);
     if (!rgb) {
@@ -1540,7 +1708,11 @@
     );
     document.documentElement.style.setProperty(
       "--coty-source-step",
-      String(roles.anchor)
+      String(getSourceStepForMode(entry, resolvedMode, roles.anchor))
+    );
+    document.documentElement.setAttribute(
+      "data-coty-source-explicit",
+      hasExplicitSourceStepForMode(entry, resolvedMode) ? "true" : "false"
     );
 
     // Pantone rule: on-primary must come from COTY scale (never pure black/white).
@@ -1588,10 +1760,15 @@
     );
 
     var secondaryAnchor = resolveSecondaryAnchorStep(entry, resolvedMode);
-    if (secondaryAnchor) {
+    var secondarySourceStep = getSecondarySourceStepForMode(
+      entry,
+      resolvedMode,
+      secondaryAnchor
+    );
+    if (secondarySourceStep) {
       document.documentElement.style.setProperty(
         "--coty-secondary-source-step",
-        String(secondaryAnchor)
+        String(secondarySourceStep)
       );
     } else {
       document.documentElement.style.removeProperty(

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -40,11 +40,14 @@
   const COTY_LOOP_INTERVAL_MS = 30000;
   const COTY_TRANSPORT_AUTO_COLLAPSE_MS = 4000;
   const COTY_TRANSPORT_HOVER_ENTER_DELAY_MS = 120;
-  const COTY_TRANSPORT_HOVER_EXIT_DELAY_MS =
-    COTY_TRANSPORT_AUTO_COLLAPSE_MS;
+  const COTY_TRANSPORT_HOVER_EXIT_DELAY_MS = COTY_TRANSPORT_AUTO_COLLAPSE_MS;
   const COTY_TRANSPORT_REOPEN_GUARD_MS = 220;
+  const THEME_SWAP_TRANSITION_DEFAULT_MS = 700;
+  const PANTONE_MANUAL_TRANSITION_MS = 4000;
+  const PANTONE_AUTO_TRANSITION_MS = 1400;
   let appliedCustomTokenNames = [];
   let cotyLoopTimer = null;
+  let themeTransitionTimer = null;
   let cotyTransportCollapseTimer = null;
   let cotyTransportHoverEnterTimer = null;
   let cotyShuffleEnabled = false;
@@ -64,12 +67,39 @@
     );
   }
 
+  function stopThemeTransitionTimer() {
+    if (themeTransitionTimer) {
+      window.clearTimeout(themeTransitionTimer);
+      themeTransitionTimer = null;
+    }
+  }
+
+  function runThemeTransition(durationMs) {
+    if (!document.body) {
+      return;
+    }
+    var duration = Number(durationMs) || THEME_SWAP_TRANSITION_DEFAULT_MS;
+    stopThemeTransitionTimer();
+    document.body.classList.remove("darkmodeTransition");
+    document.body.style.setProperty(
+      "--theme-transition-duration",
+      duration + "ms"
+    );
+    void document.body.offsetWidth;
+    document.body.classList.add("darkmodeTransition");
+    themeTransitionTimer = window.setTimeout(function () {
+      document.body.classList.remove("darkmodeTransition");
+      document.body.style.removeProperty("--theme-transition-duration");
+      themeTransitionTimer = null;
+    }, duration);
+  }
+
   function getPlayerSpriteUrl() {
     if (playerSpriteUrl) {
       return playerSpriteUrl;
     }
 
-    const uses = document.querySelectorAll('svg use');
+    const uses = document.querySelectorAll("svg use");
     for (let i = 0; i < uses.length; i += 1) {
       const href = getUseHref(uses[i]);
       if (href && href.indexOf("sprite.svg") !== -1) {
@@ -272,6 +302,7 @@
 
   function setMode(mode) {
     localStorage.setItem("theme-mode", mode);
+    runThemeTransition(THEME_SWAP_TRANSITION_DEFAULT_MS);
     applyMode(mode);
     updateModeUI(mode);
 
@@ -352,6 +383,7 @@
   // ==========================================================================
 
   function setPalette(palette) {
+    runThemeTransition(THEME_SWAP_TRANSITION_DEFAULT_MS);
     if (!commitPaletteSelection(palette)) {
       return;
     }
@@ -1064,7 +1096,10 @@
         button.getAttribute("data-label-activate") || "Activate Pantone";
       const deactivateLabel =
         button.getAttribute("data-label-deactivate") || "Deactivate Pantone";
-      button.setAttribute("aria-label", active ? deactivateLabel : activateLabel);
+      button.setAttribute(
+        "aria-label",
+        active ? deactivateLabel : activateLabel
+      );
       button.setAttribute("aria-pressed", active ? "true" : "false");
       button.setAttribute("data-active", active ? "true" : "false");
     });
@@ -1148,8 +1183,9 @@
   }
 
   function advanceCotyYear(step, options) {
+    const opts = options || {};
     const nextYear = getNextCotyYear(step);
-    setCotyYear(nextYear, options || {});
+    setCotyYear(nextYear, opts);
   }
 
   function getLatestCotyYear() {
@@ -1170,7 +1206,10 @@
   function startCotyLoopTimer() {
     stopCotyLoopTimer();
     cotyLoopTimer = window.setInterval(function () {
-      advanceCotyYear(1, { activatePantone: true });
+      advanceCotyYear(1, {
+        activatePantone: true,
+        transitionDuration: PANTONE_AUTO_TRANSITION_MS,
+      });
     }, COTY_LOOP_INTERVAL_MS);
   }
 
@@ -1387,6 +1426,10 @@
     const actions = getCotyActions();
     let entry = null;
 
+    if (opts.transitionDuration) {
+      runThemeTransition(opts.transitionDuration);
+    }
+
     if (actions && typeof actions.getEntry === "function" && opts.skipApply) {
       const numericYear = Number(year) || actions.getCurrentYear();
       entry = actions.getEntry(numericYear);
@@ -1467,7 +1510,9 @@
         select.appendChild(option);
       });
       select.addEventListener("change", function () {
-        setCotyYear(this.value);
+        setCotyYear(this.value, {
+          transitionDuration: PANTONE_MANUAL_TRANSITION_MS,
+        });
       });
     });
 
@@ -1490,6 +1535,7 @@
           resetCotyTransportActivity();
           advanceCotyYear(-1, {
             activatePantone: false,
+            transitionDuration: PANTONE_MANUAL_TRANSITION_MS,
           });
         });
       });
@@ -1502,6 +1548,7 @@
           resetCotyTransportActivity();
           advanceCotyYear(1, {
             activatePantone: false,
+            transitionDuration: PANTONE_MANUAL_TRANSITION_MS,
           });
         });
       });
@@ -1631,7 +1678,9 @@
     modeOptions = document.querySelectorAll('[data-js="mode-option"]');
     paletteOptions = document.querySelectorAll('[data-js="palette-option"]');
     cotyYearSelects = document.querySelectorAll('[data-js="coty-year-theme"]');
-    cotyTransportNodes = document.querySelectorAll('[data-js="coty-transport"]');
+    cotyTransportNodes = document.querySelectorAll(
+      '[data-js="coty-transport"]'
+    );
     cotyTransportTriggers = document.querySelectorAll(
       '[data-js="coty-transport-trigger"]'
     );
@@ -1720,7 +1769,9 @@
     updateTypographyUI(storedTypography);
     syncCotyPlaybackTimer();
     setCotyTransportUiState(
-      initialPantoneState !== "inactive" ? storedCotyTransportUiState : "expanded"
+      initialPantoneState !== "inactive"
+        ? storedCotyTransportUiState
+        : "expanded"
     );
     syncCotyPlayerUI();
     if (initialPantoneState !== "inactive") {
@@ -1748,8 +1799,9 @@
       },
       toggleReducedMotion: function () {
         setReducedMotionEnabled(
-          document.documentElement.getAttribute("data-effect-reduced-motion") !==
-            "on"
+          document.documentElement.getAttribute(
+            "data-effect-reduced-motion"
+          ) !== "on"
         );
       },
       playPantone: playPantone,
@@ -1792,7 +1844,10 @@
       "theme:custom-palette-updated",
       refreshCustomPaletteState
     );
-    window.addEventListener("theme:sheet-closed", resumeCotyTransportAutoCollapse);
+    window.addEventListener(
+      "theme:sheet-closed",
+      resumeCotyTransportAutoCollapse
+    );
 
     // Setup event listeners
     if (themeToggle && themePanel) {
@@ -1931,8 +1986,9 @@
       effectMotionButtons.forEach((button) => {
         button.addEventListener("click", function () {
           setReducedMotionEnabled(
-            document.documentElement.getAttribute("data-effect-reduced-motion") !==
-              "on"
+            document.documentElement.getAttribute(
+              "data-effect-reduced-motion"
+            ) !== "on"
           );
         });
       });

--- a/assets/js/header-line.js
+++ b/assets/js/header-line.js
@@ -10,8 +10,7 @@
 
   const add_class_on_scroll = () => header.classList.add("bottom-line");
   const remove_class_on_scroll = () => header.classList.remove("bottom-line");
-
-  window.addEventListener("scroll", function () {
+  const update_header_line = () => {
     scrollpos = window.scrollY;
 
     if (scrollpos >= header_height) {
@@ -19,5 +18,73 @@
     } else {
       remove_class_on_scroll();
     }
-  });
+  };
+
+  const is_plain_primary_navigation = (event) =>
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey;
+
+  const should_clear_line_for_link = (link) => {
+    if (!link) {
+      return false;
+    }
+    if (link.hasAttribute("download")) {
+      return false;
+    }
+    if (link.target && link.target !== "_self") {
+      return false;
+    }
+
+    const rawHref = link.getAttribute("href");
+    if (
+      !rawHref ||
+      rawHref.startsWith("#") ||
+      rawHref.startsWith("mailto:") ||
+      rawHref.startsWith("tel:") ||
+      rawHref.startsWith("javascript:")
+    ) {
+      return false;
+    }
+
+    try {
+      const url = new URL(link.href, window.location.href);
+      if (url.origin !== window.location.origin) {
+        return false;
+      }
+      if (
+        url.pathname === window.location.pathname &&
+        url.search === window.location.search &&
+        url.hash
+      ) {
+        return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  update_header_line();
+
+  window.addEventListener("scroll", update_header_line);
+  document.addEventListener(
+    "click",
+    function (event) {
+      if (!header.classList.contains("bottom-line")) {
+        return;
+      }
+      if (!is_plain_primary_navigation(event)) {
+        return;
+      }
+      const link = event.target.closest("a");
+      if (!should_clear_line_for_link(link)) {
+        return;
+      }
+      remove_class_on_scroll();
+    },
+    true
+  );
 })();

--- a/assets/js/palette-generator.js
+++ b/assets/js/palette-generator.js
@@ -2399,6 +2399,9 @@
       const anchorStep = cotyAnchorStepSelect
         ? (cotyAnchorStepSelect.value || "").trim()
         : "";
+      const hasExplicitSource =
+        document.documentElement.getAttribute("data-coty-source-explicit") ===
+        "true";
       if (!sourceStep) {
         cotySourceStepLabel.textContent = isSwedish
           ? "Source: --coty-?"
@@ -2411,11 +2414,12 @@
       const duoPart = secondaryStep
         ? " · duo: --coty-secondary-" + secondaryStep
         : "";
-      const anchorPart = anchorStep
-        ? isSwedish
-          ? " · manuell anchor: --coty-" + anchorStep
-          : " · manual anchor: --coty-" + anchorStep
-        : "";
+      const anchorPart =
+        !hasExplicitSource && anchorStep
+          ? isSwedish
+            ? " · manuell anchor: --coty-" + anchorStep
+            : " · manual anchor: --coty-" + anchorStep
+          : "";
       cotySourceStepLabel.textContent =
         prefix + sourceStep + duoPart + anchorPart;
     }
@@ -2914,9 +2918,13 @@
       setToken("--surface-subtle", surfaceSubtleValue);
       setToken("--surface-disabled", surfaceDisabledValue);
       setToken("--surface-inverse", surfaceInverseValue);
-      setToken("--component-section-headline-bg", componentSectionHeadlineBgValue);
+      setToken(
+        "--component-section-headline-bg",
+        componentSectionHeadlineBgValue
+      );
       setToken("--surface-headline", componentSectionHeadlineBgValue);
-      const surfaceAccentValue = getDerivedToken("--surface-accent") || ctx.surface.tag;
+      const surfaceAccentValue =
+        getDerivedToken("--surface-accent") || ctx.surface.tag;
       setToken("--surface-accent", surfaceAccentValue);
       setToken("--surface-tag", surfaceAccentValue);
       setDerivedToken("--surface-tag-hover", ctx.surface.tag_hover);
@@ -2947,18 +2955,28 @@
           setToken(name, imageTokens[name])
         );
       } else if (imageTreatment === "pantone-blend") {
-        const isDarkMode = document.documentElement.getAttribute("data-mode") === "dark";
+        const isDarkMode =
+          document.documentElement.getAttribute("data-mode") === "dark";
         const shadowStep = isDarkMode ? 11 : 3;
         const highlightStep = isDarkMode ? 3 : 11;
         setToken("--image-grayscale", "100%");
         setToken("--image-shadow-blend-mode", "multiply");
         setToken("--image-highlight-blend-mode", "screen");
-        setToken("--image-shadow-background", scaleVar(effectiveRoles.surface, shadowStep));
+        setToken(
+          "--image-shadow-background",
+          scaleVar(effectiveRoles.surface, shadowStep)
+        );
         setToken("--image-shadow-opacity", isDarkMode ? "0.9" : "0.78");
         setToken("--image-highlight-opacity", isDarkMode ? "0.72" : "0.68");
         setToken("--image-blend-mode", "screen");
-        setToken("--image-highlight-background", scaleVar(effectiveRoles.surface, highlightStep));
-        setToken("--image-background", scaleVar(effectiveRoles.surface, highlightStep));
+        setToken(
+          "--image-highlight-background",
+          scaleVar(effectiveRoles.surface, highlightStep)
+        );
+        setToken(
+          "--image-background",
+          scaleVar(effectiveRoles.surface, highlightStep)
+        );
       } else {
         setToken("--image-grayscale", "0%");
         setToken("--image-shadow-blend-mode", "normal");

--- a/data/pantone-coty.toml
+++ b/data/pantone-coty.toml
@@ -6,21 +6,99 @@ default_year = 2026
 year = 2000
 name = "Cerulean Blue"
 hex = "#98b4d4"
+role_mode = "surface"
+source_step_dark = 10
+
+[colors.scale_dark]
+"1" = "#00040C"
+"2" = "#000613"
+"3" = "#020E1D"
+"4" = "#0C1C2C"
+"5" = "#1E2E40"
+"6" = "#334457"
+"7" = "#4C5E72"
+"8" = "#687B90"
+"9" = "#879AB0"
+"10" = "#98B4D4"
+"11" = "#D4D8DC"
+"12" = "#F2F5FA"
+
+[colors.overrides_light]
+text_default = "--coty-10"
+text_muted = "--coty-10"
+border_subtle = "--coty-5"
+border_default = "--coty-5"
+border_strong = "--coty-4"
+on_primary = "--coty-1"
+action = "--coty-11"
+on_action = "--coty-1"
 
 [[colors]]
 year = 2001
 name = "Fuscha Rose"
 hex = "#c3447a"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#120005"
+"2" = "#190008"
+"3" = "#270011"
+"4" = "#3E001E"
+"5" = "#561230"
+"6" = "#6E2C46"
+"7" = "#884A60"
+"8" = "#C3447A"
+"9" = "#BC8E9E"
+"10" = "#D4B1BE"
+"11" = "#E9D2DA"
+"12" = "#FEF1F6"
 
 [[colors]]
 year = 2002
 name = "True Red"
 hex = "#bc243c"
+source_step_dark = 7
+
+[colors.scale_dark]
+"1" = "#220003"
+"2" = "#2A0004"
+"3" = "#3A0008"
+"4" = "#530010"
+"5" = "#6A1720"
+"6" = "#7F3438"
+"7" = "#BC243C"
+"8" = "#AB7677"
+"9" = "#C2989A"
+"10" = "#D9BCBD"
+"11" = "#ECD8D9"
+"12" = "#FEF2F2"
 
 [[colors]]
 year = 2003
 name = "Aqua Sky"
 hex = "#7fcdcd"
+role_mode = "surface"
+source_step_dark = 10
+
+[colors.scale_dark]
+"1" = "#000C0C"
+"2" = "#001111"
+"3" = "#001B1B"
+"4" = "#002A2A"
+"5" = "#033E3E"
+"6" = "#215555"
+"7" = "#3C6F6E"
+"8" = "#598C8C"
+"9" = "#77ABAB"
+"10" = "#7FCDCD"
+"11" = "#D4DDDD"
+"12" = "#EFF7F7"
+
+[colors.overrides_light]
+text_muted = "--coty-9"
+border_subtle = "--coty-6"
+border_default = "--coty-7"
+border_strong = "--coty-8"
 
 [[colors]]
 year = 2004
@@ -28,11 +106,65 @@ name = "Tigerlily"
 hex = "#e15d44"
 role_mode = "primary"
 anchor_step = 7
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#200200"
+"2" = "#270300"
+"3" = "#370600"
+"4" = "#500B00"
+"5" = "#6E1200"
+"6" = "#8D2611"
+"7" = "#AA4431"
+"8" = "#E15D44"
+"9" = "#DD8C7E"
+"10" = "#EFB3A9"
+"11" = "#F9D4CE"
+"12" = "#FFF2F0"
+
+[colors.overrides_light]
+border_subtle = "--coty-8"
+border_default = "--coty-8"
+border_strong = "--coty-9"
+on_primary = "--coty-1"
 
 [[colors]]
 year = 2005
 name = "Blue Turquoise"
 hex = "#55b4b0"
+role_mode = "surface"
+source_step_dark = 9
+
+[colors.scale_dark]
+"1" = "#000F0E"
+"2" = "#001312"
+"3" = "#001D1C"
+"4" = "#002D2B"
+"5" = "#004240"
+"6" = "#045B58"
+"7" = "#277774"
+"8" = "#4B938F"
+"9" = "#55B4B0"
+"10" = "#9ECBC9"
+"11" = "#C7E3E2"
+"12" = "#ECF8F7"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+border_subtle = "--coty-7"
+border_default = "--coty-8"
+border_strong = "--coty-9"
+on_action = "--coty-5"
+
+[colors.overrides_dark]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_page = "--coty-5"
+surface_default = "--coty-4"
+primary = "--coty-8"
+action = "--coty-11"
+on_action = "--coty-6"
+component_form_bg = "--coty-4"
 
 [[colors]]
 year = 2006
@@ -40,16 +172,61 @@ name = "Sand Dollar"
 hex = "#dfcfbe"
 role_mode = "surface"
 anchor_step = 4
+source_step_dark = 10
+
+[colors.scale_dark]
+"1" = "#130C05"
+"2" = "#181007"
+"3" = "#22190E"
+"4" = "#31271B"
+"5" = "#44382B"
+"6" = "#5A4D40"
+"7" = "#746658"
+"8" = "#928375"
+"9" = "#AFA295"
+"10" = "#DFCFBE"
+"11" = "#E5DCD5"
+"12" = "#F7F5F2"
 
 [[colors]]
 year = 2007
 name = "Chili Pepper"
 hex = "#9b2335"
+source_step_dark = 7
+
+[colors.scale_dark]
+"1" = "#0D0001"
+"2" = "#130001"
+"3" = "#210003"
+"4" = "#390009"
+"5" = "#570113"
+"6" = "#761D28"
+"7" = "#9B2335"
+"8" = "#A3676A"
+"9" = "#B88D8F"
+"10" = "#CCB2B3"
+"11" = "#E3D5D6"
+"12" = "#FEF1F2"
 
 [[colors]]
 year = 2008
 name = "Blue Izis"
 hex = "#5b5ea6"
+source_step_dark = 7
+
+[colors.scale_dark]
+"1" = "#080529"
+"2" = "#0B0631"
+"3" = "#120F3F"
+"4" = "#1F1F50"
+"5" = "#313266"
+"6" = "#474A7D"
+"7" = "#5B5EA6"
+"8" = "#7E82AE"
+"9" = "#9CA0C6"
+"10" = "#BCBEDC"
+"11" = "#D9DBEF"
+"12" = "#F3F4FF"
 
 [[colors]]
 year = 2009
@@ -57,36 +234,249 @@ name = "Mimosa"
 hex = "#efc050"
 role_mode = "surface"
 anchor_step = 5
+source_step_dark = 10
+
+[colors.scale_dark]
+"1" = "#130C00"
+"2" = "#181000"
+"3" = "#241900"
+"4" = "#352600"
+"5" = "#4B3701"
+"6" = "#664B00"
+"7" = "#846313"
+"8" = "#A48033"
+"9" = "#C39F59"
+"10" = "#EFC050"
+"11" = "#F1DBB5"
+"12" = "#FAF4EB"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+border_subtle = "--coty-6"
+border_default = "--coty-7"
+border_strong = "--coty-8"
+primary = "--coty-9"
+on_action = "--coty-5"
 
 [[colors]]
 year = 2010
 name = "Turquoise"
 hex = "#45B8AC"
+role_mode = "surface"
+source_step_dark = 9
+
+[colors.scale_dark]
+"1" = "#00100E"
+"2" = "#001411"
+"3" = "#001E1A"
+"4" = "#002F2A"
+"5" = "#00443E"
+"6" = "#155C55"
+"7" = "#34766E"
+"8" = "#57938B"
+"9" = "#45B8AC"
+"10" = "#9ECBC6"
+"11" = "#C6E4E0"
+"12" = "#EDF8F6"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+border_subtle = "--coty-8"
+border_default = "--coty-9"
+border_strong = "--coty-10"
+on_action = "--coty-2"
+
+[colors.overrides_dark]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_page = "--coty-5"
+surface_default = "--coty-4"
+primary = "--coty-8"
+action = "--coty-11"
+on_action = "--coty-6"
+component_form_bg = "--coty-4"
 
 [[colors]]
 year = 2011
 name = "Honeysuckle"
 hex = "#d65076"
+role_mode = "surface"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#210008"
+"2" = "#29000C"
+"3" = "#380013"
+"4" = "#51001F"
+"5" = "#6B112F"
+"6" = "#842C44"
+"7" = "#9F495E"
+"8" = "#D65076"
+"9" = "#D58D9D"
+"10" = "#ECB2BF"
+"11" = "#F8D2DB"
+"12" = "#FFF1F4"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+surface_default = "--coty-6"
+border_subtle = "--coty-8"
+border_default = "--coty-9"
+border_strong = "--coty-10"
+on_action = "--coty-2"
+component_form_bg = "--coty-4"
+
+[colors.overrides_dark]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_page = "--coty-5"
+surface_default = "--coty-4"
+primary = "--coty-8"
+action = "--coty-11"
+on_action = "--coty-6"
+component_form_bg = "--coty-4"
 
 [[colors]]
 year = 2012
 name = "Tangerine Tango"
 hex = "#dd4124"
+role_mode = "surface"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#190200"
+"2" = "#210200"
+"3" = "#2F0400"
+"4" = "#470900"
+"5" = "#651100"
+"6" = "#832C1A"
+"7" = "#9F4B3A"
+"8" = "#DD4124"
+"9" = "#D59184"
+"10" = "#ECB5AB"
+"11" = "#FFD8D2"
+"12" = "#FFEDEA"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+surface_default = "--coty-6"
+border_subtle = "--coty-9"
+border_default = "--coty-10"
+border_strong = "--coty-11"
+on_action = "--coty-2"
+component_form_bg = "--coty-4"
+
+[colors.overrides_dark]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_page = "--coty-5"
+surface_default = "--coty-4"
+primary = "--coty-8"
+action = "--coty-11"
+on_action = "--coty-6"
+component_form_bg = "--coty-4"
 
 [[colors]]
 year = 2013
 name = "Emerald"
 hex = "#009b77"
+role_mode = "surface"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#00100A"
+"2" = "#00140D"
+"3" = "#001F15"
+"4" = "#002F22"
+"5" = "#024433"
+"6" = "#175D49"
+"7" = "#387762"
+"8" = "#009B77"
+"9" = "#7FAF9C"
+"10" = "#A4CBBB"
+"11" = "#C8E4D8"
+"12" = "#E9FAF2"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+surface_default = "--coty-6"
+border_subtle = "--coty-9"
+border_default = "--coty-10"
+border_strong = "--coty-11"
+on_action = "--coty-2"
+component_form_bg = "--coty-4"
+
+[colors.overrides_dark]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_page = "--coty-5"
+surface_default = "--coty-4"
+primary = "--coty-8"
+action = "--coty-11"
+on_action = "--coty-6"
+component_form_bg = "--coty-4"
 
 [[colors]]
 year = 2014
 name = "Radiant Orchid"
 hex = "#ad5e99"
+role_mode = "surface"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#160010"
+"2" = "#1B0015"
+"3" = "#2A0021"
+"4" = "#3E0332"
+"5" = "#541946"
+"6" = "#6B335D"
+"7" = "#845176"
+"8" = "#AD5E99"
+"9" = "#B493AB"
+"10" = "#CDB5C7"
+"11" = "#E4D6E1"
+"12" = "#FAF2F9"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+surface_page = "--coty-8"
+surface_default = "--coty-7"
+border_subtle = "--coty-9"
+border_default = "--coty-10"
+border_strong = "--coty-11"
+action = "--coty-1"
+on_action = "--coty-9"
+component_form_bg = "--coty-6"
+
+[colors.overrides_dark]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_page = "--coty-5"
+surface_default = "--coty-4"
+primary = "--coty-8"
+action = "--coty-11"
+on_action = "--coty-6"
+component_form_bg = "--coty-4"
 
 [[colors]]
 year = 2015
 name = "Marsala"
 hex = "#964f4c"
+source_step_dark = 7
+
+[colors.scale_dark]
+"1" = "#1F0102"
+"2" = "#250102"
+"3" = "#320607"
+"4" = "#421615"
+"5" = "#572A28"
+"6" = "#6D4240"
+"7" = "#964F4C"
+"8" = "#9E7D7B"
+"9" = "#B89B9A"
+"10" = "#D0BBBA"
+"11" = "#E7D8D8"
+"12" = "#FCF3F2"
 
 [[colors]]
 year = 2016
@@ -94,16 +484,32 @@ name = "Rose Quartz"
 hex = "#f7caca"
 role_mode = "surface"
 anchor_step = 4
-
-[[colors]]
-year = 2016
-name = "Serenity"
-hex = "#93a9d1"
+secondary_name = "Serenity"
+secondary_hex = "#93a9d1"
+source_step_light = 4
+source_step_dark = 10
+secondary_source_step_light = 10
+secondary_source_step_dark = 10
 
 [[colors]]
 year = 2017
 name = "Greenery"
 hex = "#88b04b"
+source_step_dark = 9
+
+[colors.scale_dark]
+"1" = "#060D00"
+"2" = "#091200"
+"3" = "#101C00"
+"4" = "#1B2B00"
+"5" = "#2A3E02"
+"6" = "#3F561D"
+"7" = "#5A713A"
+"8" = "#778E5A"
+"9" = "#88B04B"
+"10" = "#B5C7A0"
+"11" = "#D5E2C6"
+"12" = "#F1F8E8"
 
 [colors.overrides_light]
 text_muted = "--coty-10"
@@ -126,16 +532,80 @@ component_form_bg = "--coty-3"
 year = 2018
 name = "Ultra Violet"
 hex = "#5f4b8b"
+source_step_dark = 7
+
+[colors.scale_dark]
+"1" = "#060015"
+"2" = "#09001D"
+"3" = "#120329"
+"4" = "#1F1039"
+"5" = "#30244C"
+"6" = "#473C63"
+"7" = "#5F4B8B"
+"8" = "#7E7793"
+"9" = "#9C96AD"
+"10" = "#BCB8C8"
+"11" = "#DAD7E3"
+"12" = "#F6F3FC"
 
 [[colors]]
 year = 2019
 name = "Living Coral"
 hex = "#ff6f61"
+source_step_dark = 9
+
+[colors.scale_dark]
+"1" = "#210000"
+"2" = "#280000"
+"3" = "#380000"
+"4" = "#510000"
+"5" = "#6D0D08"
+"6" = "#8B2B23"
+"7" = "#A7493F"
+"8" = "#C46A5F"
+"9" = "#FF6F61"
+"10" = "#F4B3AC"
+"11" = "#FFD3CF"
+"12" = "#FFEFEE"
+
+[colors.overrides_light]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_default = "--coty-6"
+border_subtle = "--coty-8"
+border_default = "--coty-9"
+border_strong = "--coty-10"
+on_action = "--coty-3"
+component_form_bg = "--coty-6"
+
+[colors.overrides_dark]
+text_default = "--coty-11"
+text_muted = "--coty-10"
+text_link = "--coty-10"
+text_link_hover = "--coty-12"
+surface_page = "--coty-3"
+surface_default = "--coty-4"
+component_form_bg = "--coty-3"
 
 [[colors]]
 year = 2020
 name = "Classic Blue"
 hex = "#0f4c81"
+source_step_dark = 6
+
+[colors.scale_dark]
+"1" = "#000A18"
+"2" = "#000E1F"
+"3" = "#00172E"
+"4" = "#022442"
+"5" = "#163757"
+"6" = "#104C81"
+"7" = "#4F6984"
+"8" = "#6F869E"
+"9" = "#90A2B6"
+"10" = "#B2BFCE"
+"11" = "#D2DCE8"
+"12" = "#EFF6FF"
 
 [[colors]]
 year = 2021
@@ -143,22 +613,53 @@ name = "Ultimate Gray"
 hex = "#939597"
 role_mode = "surface"
 anchor_step = 7
-
-[[colors]]
-year = 2021
-name = "Illuminating"
-hex = "#f5df4d"
-anchor_step = 3
+secondary_name = "Illuminating"
+secondary_hex = "#f5df4d"
+secondary_anchor_step = 3
+source_step_light = 7
+source_step_dark = 8
+secondary_source_step_light = 3
+secondary_source_step_dark = 10
 
 [[colors]]
 year = 2022
 name = "Very Peri"
 hex = "#6667AB"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#020010"
+"2" = "#030018"
+"3" = "#070128"
+"4" = "#120C3A"
+"5" = "#22204F"
+"6" = "#383866"
+"7" = "#535481"
+"8" = "#6667AB"
+"9" = "#9293B5"
+"10" = "#B4B5CE"
+"11" = "#D5D6E7"
+"12" = "#F5F5FE"
 
 [[colors]]
 year = 2023
 name = "Viva Magenta"
 hex = "#BE3455"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#070001"
+"2" = "#0D0002"
+"3" = "#1B0004"
+"4" = "#31000C"
+"5" = "#51031A"
+"6" = "#6F1A2D"
+"7" = "#8C3A49"
+"8" = "#BE3455"
+"9" = "#C8838E"
+"10" = "#E3ABB4"
+"11" = "#F9D3D9"
+"12" = "#FFEEF1"
 
 [[colors]]
 year = 2024
@@ -166,11 +667,66 @@ name = "Peach Fuzz"
 hex = "#FEBD99"
 role_mode = "surface"
 anchor_step = 4
+source_step_light = 4
+source_step_dark = 10
+
+[colors.scale_dark]
+"1" = "#1A0700"
+"2" = "#210A00"
+"3" = "#2F1100"
+"4" = "#441C01"
+"5" = "#5E2A06"
+"6" = "#793D1A"
+"7" = "#965633"
+"8" = "#B67452"
+"9" = "#D39475"
+"10" = "#FEBD99"
+"11" = "#F9D5C5"
+"12" = "#FBF3F0"
 
 [[colors]]
 year = 2025
 name = "Mocha Mousse"
 hex = "#A57865"
+source_step_dark = 8
+
+[colors.scale_dark]
+"1" = "#190601"
+"2" = "#1F0801"
+"3" = "#2A1105"
+"4" = "#3B1E11"
+"5" = "#4E3023"
+"6" = "#634639"
+"7" = "#7C6053"
+"8" = "#A57865"
+"9" = "#B59C93"
+"10" = "#D0BDB6"
+"11" = "#E6D8D4"
+"12" = "#F7F1F0"
+
+[colors.overrides_light]
+text_muted = "--coty-10"
+surface_page = "--coty-7"
+surface_default = "--coty-7"
+border_subtle = "--coty-9"
+border_default = "--coty-10"
+border_strong = "--coty-11"
+on_action = "--coty-2"
+component_form_bg = "--coty-7"
+
+[colors.overrides_dark]
+text_default = "--coty-10"
+text_muted = "--coty-9"
+surface_page = "--coty-3"
+surface_default = "--coty-3"
+surface_elevated = "--coty-4"
+border_subtle = "--coty-5"
+border_default = "--coty-6"
+border_strong = "--coty-7"
+primary = "--coty-8"
+action = "--coty-1"
+on_action = "--coty-11"
+component_form_bg = "--coty-4"
 
 [[colors]]
 year = 2026
@@ -178,3 +734,18 @@ name = "Cloud Dancer"
 hex = "#F0EFEB"
 role_mode = "surface"
 anchor_step = 2
+source_step_dark = 12
+
+[colors.scale_dark]
+"1" = "#0E0D0B"
+"2" = "#12120F"
+"3" = "#1B1B18"
+"4" = "#2A2926"
+"5" = "#3B3A38"
+"6" = "#50504D"
+"7" = "#6A6966"
+"8" = "#878683"
+"9" = "#A5A4A1"
+"10" = "#C5C4C0"
+"11" = "#DFDEDA"
+"12" = "#F0EFEB"


### PR DESCRIPTION
## Summary
- move Pantone/COTY theme handling toward curated per-year runtime data instead of relying on generated dark scales
- improve Pantone palette behavior in both the runtime and the internal palette generator
- expand and restore theme-transition behavior across UI surfaces while leaving tritone-image experiments out

## Changes
- add explicit Pantone/COTY per-year scale support in the runtime, including mode-specific source-step handling
- update Pantone data in `data/pantone-coty.toml` with curated dark scales, duo-year structure improvements, and refined per-year light/dark overrides
- update `palette-generator` labeling so explicit source steps are reflected correctly and legacy/manual anchor text is hidden where appropriate
- add support for explicit secondary Pantone metadata for duo years
- restore active theme-swap transition triggering in `darkmode.js`, with separate durations for manual Pantone switching and autoplay
- broaden theme-transition coverage across navigation, controls, forms, tags, project info, and related theme-driven UI
- replace several `transition: all` rules with narrower color/border/shadow transitions
- fix header bottom-line handoff during navigation so the top-menu border no longer flashes when moving between pages after scrolling
- include `.npm-cache` in `.gitignore`

## Testing
- `hugo --quiet`
- `npm test -- --runInBand header-line`
- `npm test -- --runInBand darkmode-pantone`