### PR TITLE
Add tritone step pickers and animated theme transition

### DIFF
--- a/assets/css/components/form.css
+++ b/assets/css/components/form.css
@@ -293,10 +293,6 @@ select,
   line-height: var(--line-height-normal);
   color: var(--text-default);
   background-color: var(--surface-page);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%231d2124' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right var(--spacing-12) center;
-  background-size: 20px;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-8);
   cursor: pointer;
@@ -331,10 +327,33 @@ select:disabled,
   opacity: 0.6;
 }
 
-/* Dark Mode Arrow */
-[data-mode="dark"] select,
-[data-mode="dark"] .select {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23edeef0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+/* Select wrapper — provides theme-aware chevron via CSS mask */
+.select-wrap {
+  position: relative;
+  display: block;
+}
+
+.select-wrap select,
+.select-wrap .select {
+  background-image: none;
+}
+
+.select-wrap::after {
+  content: '';
+  position: absolute;
+  right: var(--spacing-12);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  pointer-events: none;
+  background-color: var(--text-muted);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: 20px;
+  mask-size: 20px;
 }
 
 /* ==========================================================================

--- a/assets/css/components/form.css
+++ b/assets/css/components/form.css
@@ -293,7 +293,7 @@ select,
   line-height: var(--line-height-normal);
   color: var(--text-default);
   background-color: var(--surface-page);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%231d2124' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right var(--spacing-12) center;
   background-size: 20px;
@@ -329,6 +329,12 @@ select:disabled,
   color: var(--text-muted);
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+/* Dark Mode Arrow */
+[data-mode="dark"] select,
+[data-mode="dark"] .select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23edeef0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
 /* ==========================================================================

--- a/assets/js/coty-scale.js
+++ b/assets/js/coty-scale.js
@@ -16,6 +16,7 @@
   var DARK_L = [12, 14, 18, 24, 31, 39, 48, 58, 68, 78, 86, 93];
   var DEFAULT_ANCHOR_STEP = 9;
   var APPLIED_MANUAL_OVERRIDES = [];
+  var _tritoneAnimFrame = null;
   var PANTONE_RUNTIME_TOKEN_NAMES = [
     "--coty-role-mode",
     "--coty-role-anchor-step",
@@ -533,7 +534,74 @@
     );
   }
 
-  function applyPantoneTritone(scale, secondaryScale, roles) {
+  function parseFuncTableValues(node) {
+    if (!node) return null;
+    var parts = (node.getAttribute("tableValues") || "").trim().split(/\s+/);
+    if (parts.length !== 3) return null;
+    var vals = [parseFloat(parts[0]), parseFloat(parts[1]), parseFloat(parts[2])];
+    return vals.some(isNaN) ? null : vals;
+  }
+
+  function easeOutTheme(t) {
+    // Matches cubic-bezier(0.075, 0.82, 0.165, 1) closely
+    return 1 - Math.pow(1 - t, 3);
+  }
+
+  function getThemeTransitionDuration() {
+    if (!document.body || !document.body.classList.contains("darkmodeTransition")) {
+      return 0;
+    }
+    var val = document.body.style.getPropertyValue("--theme-transition-duration") || "";
+    var ms = parseFloat(val);
+    return isNaN(ms) || ms <= 0 ? 0 : ms;
+  }
+
+  function animateTritoneTableValues(nodes, shadow, mid, highlight, durationMs) {
+    if (_tritoneAnimFrame) {
+      cancelAnimationFrame(_tritoneAnimFrame);
+      _tritoneAnimFrame = null;
+    }
+    var toShadow = colorValueToRgbUnit(shadow);
+    var toMid = colorValueToRgbUnit(mid);
+    var toHighlight = colorValueToRgbUnit(highlight);
+    if (!toShadow || !toMid || !toHighlight) {
+      setTritoneTableValues(nodes, shadow, mid, highlight);
+      return;
+    }
+    var fromR = parseFuncTableValues(nodes.r);
+    var fromG = parseFuncTableValues(nodes.g);
+    var fromB = parseFuncTableValues(nodes.b);
+    if (!fromR || !fromG || !fromB) {
+      setTritoneTableValues(nodes, shadow, mid, highlight);
+      return;
+    }
+    var startTime = null;
+    function step(ts) {
+      if (!startTime) startTime = ts;
+      var t = Math.min((ts - startTime) / durationMs, 1);
+      var e = easeOutTheme(t);
+      nodes.r.setAttribute("tableValues",
+        round3(fromR[0] + (toShadow.r - fromR[0]) * e) + " " +
+        round3(fromR[1] + (toMid.r - fromR[1]) * e) + " " +
+        round3(fromR[2] + (toHighlight.r - fromR[2]) * e));
+      nodes.g.setAttribute("tableValues",
+        round3(fromG[0] + (toShadow.g - fromG[0]) * e) + " " +
+        round3(fromG[1] + (toMid.g - fromG[1]) * e) + " " +
+        round3(fromG[2] + (toHighlight.g - fromG[2]) * e));
+      nodes.b.setAttribute("tableValues",
+        round3(fromB[0] + (toShadow.b - fromB[0]) * e) + " " +
+        round3(fromB[1] + (toMid.b - fromB[1]) * e) + " " +
+        round3(fromB[2] + (toHighlight.b - fromB[2]) * e));
+      if (t < 1) {
+        _tritoneAnimFrame = requestAnimationFrame(step);
+      } else {
+        _tritoneAnimFrame = null;
+      }
+    }
+    _tritoneAnimFrame = requestAnimationFrame(step);
+  }
+
+  function applyPantoneTritone(scale, secondaryScale, roles, stepOverrides) {
     if (!scale || !roles) {
       document.documentElement.removeAttribute("data-image-tone");
       return;
@@ -570,7 +638,17 @@
       highlightColor = duoHighlight;
     }
 
-    setTritoneTableValues(nodes, shadowColor, midColor, highlightColor);
+    var overrides = stepOverrides || {};
+    if (overrides.shadow) shadowColor = overrides.shadow;
+    if (overrides.mid) midColor = overrides.mid;
+    if (overrides.highlight) highlightColor = overrides.highlight;
+
+    var transitionMs = getThemeTransitionDuration();
+    if (transitionMs > 0) {
+      animateTritoneTableValues(nodes, shadowColor, midColor, highlightColor, transitionMs);
+    } else {
+      setTritoneTableValues(nodes, shadowColor, midColor, highlightColor);
+    }
     document.documentElement.setAttribute("data-image-tone", "tritone");
   }
 
@@ -1832,7 +1910,28 @@
       );
     }
 
-    applyPantoneTritone(scale, secondaryScale, roles);
+    var modeOverridesForTritone =
+      resolvedMode === "dark"
+        ? normalizeOverrides(entry.overrides_dark)
+        : normalizeOverrides(entry.overrides_light);
+    var baseOverridesForTritone = normalizeOverrides(entry.overrides);
+    var allOverridesForTritone = Object.assign(
+      {},
+      baseOverridesForTritone,
+      modeOverridesForTritone
+    );
+    function resolveStepColor(key) {
+      var raw = allOverridesForTritone[key];
+      if (!raw) return null;
+      var step = extractStepFromVarToken(String(raw), "coty");
+      if (!step) return null;
+      return getScaleColor(scale, "coty", step) || null;
+    }
+    applyPantoneTritone(scale, secondaryScale, roles, {
+      shadow: resolveStepColor("tritone_shadow_step"),
+      mid: resolveStepColor("tritone_mid_step"),
+      highlight: resolveStepColor("tritone_highlight_step"),
+    });
 
     if (secondaryScale) {
       document.documentElement.style.setProperty(

--- a/assets/js/coty-scale.js
+++ b/assets/js/coty-scale.js
@@ -1939,6 +1939,10 @@
     function resolveStepColor(key) {
       var raw = allOverridesForTritone[key];
       if (!raw) return null;
+      var secondaryStep = extractStepFromVarToken(String(raw), "coty-secondary");
+      if (secondaryStep && secondaryScale) {
+        return getScaleColor(secondaryScale, "coty-secondary", secondaryStep) || null;
+      }
       var step = extractStepFromVarToken(String(raw), "coty");
       if (!step) return null;
       return getScaleColor(scale, "coty", step) || null;

--- a/assets/js/coty-scale.js
+++ b/assets/js/coty-scale.js
@@ -1918,7 +1918,8 @@
     var allOverridesForTritone = Object.assign(
       {},
       baseOverridesForTritone,
-      modeOverridesForTritone
+      modeOverridesForTritone,
+      readDraftTritoneSteps(entry.year, resolvedMode)
     );
     function resolveStepColor(key) {
       var raw = allOverridesForTritone[key];
@@ -1962,6 +1963,28 @@
     applyManualOverrides(entry);
 
     return entry;
+  }
+
+  function readDraftTritoneSteps(year, mode) {
+    try {
+      var raw = localStorage.getItem("pantone-lab::" + String(year || ""));
+      if (!raw) return {};
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") return {};
+      var bucket =
+        mode === "dark"
+          ? parsed.overrides_dark || {}
+          : parsed.overrides_light || {};
+      var out = {};
+      ["tritone_shadow_step", "tritone_mid_step", "tritone_highlight_step"].forEach(
+        function (k) {
+          if (bucket[k]) out[k] = bucket[k];
+        }
+      );
+      return out;
+    } catch {
+      return {};
+    }
   }
 
   function getStoredYear() {

--- a/assets/js/coty-scale.js
+++ b/assets/js/coty-scale.js
@@ -1910,16 +1910,31 @@
       );
     }
 
+    var draftOverrides = readFullDraft(entry.year, resolvedMode);
+    var entryWithDraft = Object.assign({}, entry);
+    if (resolvedMode === "dark") {
+      entryWithDraft.overrides_dark = Object.assign(
+        {},
+        entry.overrides_dark || {},
+        draftOverrides
+      );
+    } else {
+      entryWithDraft.overrides_light = Object.assign(
+        {},
+        entry.overrides_light || {},
+        draftOverrides
+      );
+    }
+
     var modeOverridesForTritone =
       resolvedMode === "dark"
-        ? normalizeOverrides(entry.overrides_dark)
-        : normalizeOverrides(entry.overrides_light);
-    var baseOverridesForTritone = normalizeOverrides(entry.overrides);
+        ? normalizeOverrides(entryWithDraft.overrides_dark)
+        : normalizeOverrides(entryWithDraft.overrides_light);
+    var baseOverridesForTritone = normalizeOverrides(entryWithDraft.overrides);
     var allOverridesForTritone = Object.assign(
       {},
       baseOverridesForTritone,
-      modeOverridesForTritone,
-      readDraftTritoneSteps(entry.year, resolvedMode)
+      modeOverridesForTritone
     );
     function resolveStepColor(key) {
       var raw = allOverridesForTritone[key];
@@ -1960,12 +1975,12 @@
       clearDuoOverrides();
     }
 
-    applyManualOverrides(entry);
+    applyManualOverrides(entryWithDraft);
 
     return entry;
   }
 
-  function readDraftTritoneSteps(year, mode) {
+  function readFullDraft(year, mode) {
     try {
       var raw = localStorage.getItem("pantone-lab::" + String(year || ""));
       if (!raw) return {};
@@ -1976,11 +1991,9 @@
           ? parsed.overrides_dark || {}
           : parsed.overrides_light || {};
       var out = {};
-      ["tritone_shadow_step", "tritone_mid_step", "tritone_highlight_step"].forEach(
-        function (k) {
-          if (bucket[k]) out[k] = bucket[k];
-        }
-      );
+      Object.keys(bucket).forEach(function (k) {
+        if (bucket[k]) out[k] = bucket[k];
+      });
       return out;
     } catch {
       return {};

--- a/assets/js/palette-generator.js
+++ b/assets/js/palette-generator.js
@@ -1980,8 +1980,12 @@
           select.id = id;
           select.setAttribute("data-js", "coty-override-" + field.key);
 
+          const wrap = document.createElement("div");
+          wrap.className = "select-wrap";
+          wrap.appendChild(select);
+
           row.appendChild(label);
-          row.appendChild(select);
+          row.appendChild(wrap);
           grid.appendChild(row);
 
           cotyOverrideSelects[field.key] = select;

--- a/assets/js/palette-generator.js
+++ b/assets/js/palette-generator.js
@@ -272,6 +272,15 @@
         ],
       },
       {
+        id: "tritone",
+        label: "Tritone",
+        fields: [
+          { key: "tritone_shadow_step", token: "--tritone-shadow-step" },
+          { key: "tritone_mid_step", token: "--tritone-mid-step" },
+          { key: "tritone_highlight_step", token: "--tritone-highlight-step" },
+        ],
+      },
+      {
         id: "components",
         label: "Components",
         fields: [
@@ -2012,20 +2021,25 @@
       const allowed = new Set(optionValues);
       const isDuo = isCotyEntryDuo(year);
 
+      const tritoneStepKeys = new Set(["tritone_shadow_step", "tritone_mid_step", "tritone_highlight_step"]);
       Object.keys(cotyOverrideSelects).forEach((key) => {
         const select = cotyOverrideSelects[key];
         if (!select) {
           return;
         }
+        const values = tritoneStepKeys.has(key)
+          ? COTY_OVERRIDE_OPTION_VALUES_BASE.slice()
+          : optionValues;
+        const valueSet = new Set(values);
         const currentValue = select.value || "";
         select.innerHTML = "";
-        optionValues.forEach((value) => {
+        values.forEach((value) => {
           const opt = document.createElement("option");
           opt.value = value;
           opt.textContent = value || "auto";
           select.appendChild(opt);
         });
-        select.value = allowed.has(currentValue) ? currentValue : "";
+        select.value = valueSet.has(currentValue) ? currentValue : "";
       });
 
       if (!cotyOverrideGroupsRoot) {

--- a/assets/js/palette-generator.js
+++ b/assets/js/palette-generator.js
@@ -2028,7 +2028,9 @@
           return;
         }
         const values = tritoneStepKeys.has(key)
-          ? COTY_OVERRIDE_OPTION_VALUES_BASE.slice()
+          ? (isDuo
+              ? COTY_OVERRIDE_OPTION_VALUES_BASE.concat(COTY_OVERRIDE_OPTION_VALUES_SECONDARY)
+              : COTY_OVERRIDE_OPTION_VALUES_BASE.slice())
           : optionValues;
         const valueSet = new Set(values);
         const currentValue = select.value || "";

--- a/layouts/palette-generator/single.html
+++ b/layouts/palette-generator/single.html
@@ -78,7 +78,7 @@
             Preset
           {{ end }}</label
         >
-        <select id="palette-preset" data-js="palette-preset"></select>
+        <div class="select-wrap"><select id="palette-preset" data-js="palette-preset"></select></div>
       </div>
       <div class="palette-generator__row">
         <label class="palette-generator__label"
@@ -177,31 +177,31 @@
       <div class="palette-generator__grid" data-js="roles-grid">
         <div class="palette-generator__row">
           <label for="role-text" class="palette-generator__label">Text</label>
-          <select id="role-text" data-role="text"></select>
+          <div class="select-wrap"><select id="role-text" data-role="text"></select></div>
         </div>
         <div class="palette-generator__row">
           <label for="role-surface" class="palette-generator__label"
             >Surface</label
           >
-          <select id="role-surface" data-role="surface"></select>
+          <div class="select-wrap"><select id="role-surface" data-role="surface"></select></div>
         </div>
         <div class="palette-generator__row">
           <label for="role-border" class="palette-generator__label"
             >Border</label
           >
-          <select id="role-border" data-role="border"></select>
+          <div class="select-wrap"><select id="role-border" data-role="border"></select></div>
         </div>
         <div class="palette-generator__row">
           <label for="role-primary" class="palette-generator__label"
             >Primary</label
           >
-          <select id="role-primary" data-role="primary"></select>
+          <div class="select-wrap"><select id="role-primary" data-role="primary"></select></div>
         </div>
         <div class="palette-generator__row">
           <label for="role-secondary" class="palette-generator__label"
             >Secondary</label
           >
-          <select id="role-secondary" data-role="secondary"></select>
+          <div class="select-wrap"><select id="role-secondary" data-role="secondary"></select></div>
         </div>
       </div>
     </section>
@@ -232,7 +232,7 @@
             <label for="palette-coty-year" class="palette-generator__label"
               >{{ i18n "coty_year" }}</label
             >
-            <select id="palette-coty-year" data-js="coty-year"></select>
+            <div class="select-wrap"><select id="palette-coty-year" data-js="coty-year"></select></div>
             <div
               class="palette-generator__actions palette-generator__actions--coty"
             >
@@ -320,7 +320,7 @@
                   COTY role mode
                 {{ end }}</label
               >
-              <select id="coty-role-mode" data-js="coty-role-mode">
+              <div class="select-wrap"><select id="coty-role-mode" data-js="coty-role-mode">
                 <option value="auto">
                   {{ if eq .Language.Lang "sv" }}
                     Auto
@@ -342,7 +342,7 @@
                     Surface
                   {{ end }}
                 </option>
-              </select>
+              </select></div>
             </div>
             <div class="palette-generator__row">
               <label for="coty-anchor-step" class="palette-generator__label"
@@ -352,7 +352,7 @@
                   COTY anchor step
                 {{ end }}</label
               >
-              <select id="coty-anchor-step" data-js="coty-anchor-step"></select>
+              <div class="select-wrap"><select id="coty-anchor-step" data-js="coty-anchor-step"></select></div>
             </div>
           </div>
         </details>
@@ -431,10 +431,10 @@
                       Token
                     {{ end }}
                   </label>
-                  <select
+                  <div class="select-wrap"><select
                     id="coty-token-usage-select"
                     data-js="coty-token-usage-select"
-                  ></select>
+                  ></select></div>
                 </div>
                 <div
                   class="palette-generator__usage-list"
@@ -488,7 +488,7 @@
                       Scope
                     {{ end }}
                   </label>
-                  <select
+                  <div class="select-wrap"><select
                     id="coty-control-color-scope"
                     data-js="coty-control-color-scope"
                   >
@@ -527,7 +527,7 @@
                         Selected token
                       {{ end }}
                     </option>
-                  </select>
+                  </select></div>
                 </div>
                 <div
                   class="palette-generator__row"
@@ -544,10 +544,10 @@
                       Token
                     {{ end }}
                   </label>
-                  <select
+                  <div class="select-wrap"><select
                     id="coty-control-color-token"
                     data-js="coty-control-color-token"
-                  ></select>
+                  ></select></div>
                 </div>
                 <div
                   class="palette-generator__actions palette-generator__actions--coty"

--- a/layouts/palette-generator/single.html
+++ b/layouts/palette-generator/single.html
@@ -57,6 +57,20 @@
       role="tabpanel"
     >
       <div class="palette-generator__row">
+        <label class="palette-generator__label">{{ i18n "mode" }}</label>
+        <div class="theme-options theme-options--segmented" role="group" aria-label="{{ i18n "mode" }}">
+          <button class="theme-option" data-mode="light" data-js="mode-option" aria-label="{{ i18n "light_mode" }}">
+            <span>{{ i18n "light_mode" }}</span>
+          </button>
+          <button class="theme-option" data-mode="dark" data-js="mode-option" aria-label="{{ i18n "dark_mode" }}">
+            <span>{{ i18n "dark_mode" }}</span>
+          </button>
+          <button class="theme-option" data-mode="system" data-js="mode-option" aria-label="{{ i18n "system_mode" }}">
+            <span>{{ i18n "system_mode" }}</span>
+          </button>
+        </div>
+      </div>
+      <div class="palette-generator__row">
         <label for="palette-preset" class="palette-generator__label"
           >{{ if eq .Language.Lang "sv" }}
             Preset
@@ -199,6 +213,20 @@
       role="tabpanel"
     >
       <div class="palette-generator__coty" data-js="coty-controls">
+        <div class="palette-generator__row">
+          <label class="palette-generator__label">{{ i18n "mode" }}</label>
+          <div class="theme-options theme-options--segmented" role="group" aria-label="{{ i18n "mode" }}">
+            <button class="theme-option" data-mode="light" data-js="mode-option" aria-label="{{ i18n "light_mode" }}">
+              <span>{{ i18n "light_mode" }}</span>
+            </button>
+            <button class="theme-option" data-mode="dark" data-js="mode-option" aria-label="{{ i18n "dark_mode" }}">
+              <span>{{ i18n "dark_mode" }}</span>
+            </button>
+            <button class="theme-option" data-mode="system" data-js="mode-option" aria-label="{{ i18n "system_mode" }}">
+              <span>{{ i18n "system_mode" }}</span>
+            </button>
+          </div>
+        </div>
         <div class="palette-generator__coty-year-block">
           <div class="palette-generator__row">
             <label for="palette-coty-year" class="palette-generator__label"

--- a/layouts/ui-library/single.html
+++ b/layouts/ui-library/single.html
@@ -5004,7 +5004,7 @@
                         Select country
                       {{ end }}</label
                     >
-                    <select id="select-1">
+                    <div class="select-wrap"><select id="select-1">
                       <option value="">
                         {{ if eq .Language.Lang "sv" }}
                           -- Välj ett alternativ --
@@ -5040,7 +5040,7 @@
                           Finland
                         {{ end }}
                       </option>
-                    </select>
+                    </select></div>
                   </div>
                   <div class="form-group">
                     <label class="form-label" for="select-disabled"
@@ -5050,7 +5050,7 @@
                         Disabled select
                       {{ end }}</label
                     >
-                    <select id="select-disabled" disabled>
+                    <div class="select-wrap"><select id="select-disabled" disabled>
                       <option>
                         {{ if eq .Language.Lang "sv" }}
                           Kan inte ändras
@@ -5058,7 +5058,7 @@
                           Cannot be changed
                         {{ end }}
                       </option>
-                    </select>
+                    </select></div>
                   </div>
                 </div>
 


### PR DESCRIPTION
Palette Lab now has a Tritone group with shadow/mid/highlight
step selects (--coty-1..12) per light/dark mode, stored in
overrides_light/overrides_dark and included in TOML export.

When switching theme (light↔dark) while Pantone is active, the
SVG filter tableValues now interpolate via requestAnimationFrame
using an ease-out-cubic approximation of the theme easing curve,
instead of snapping immediately.

https://claude.ai/code/session_014CW4TnJnFoef3SdBYGQ4Y7