### PR TITLE
Polish lang-notice and EN tag badge styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,56 @@ This triggers a full Netlify deploy preview with all Netlify features (redirects
 
 ## Content Guidelines
 
+### Writing Articles (`/writing/` and `/texter/`)
+
+**Required front matter for every English writing article** (`content/english/writing/*.md`):
+```toml
++++
+title = "Article Title"
+date = "2026-01-01"
+author = "Torbjörn Hedberg"
+draft = false
+hidden = false
+description = "Subtitle / preamble shown below the title"
+tags = ["design", "tools", "process"]
+topics = []
+slug = "writing"
+translationKey = "article-slug-used-as-key"
++++
+```
+
+**Required front matter for every Swedish writing article** (`content/swedish/texter/*.md`):
+```toml
++++
+title = "Artikelns titel"
+date = "2026-01-01"
+author = "Torbjörn Hedberg"
+draft = false
+hidden = false
+description = "Underrubrik / ingress"
+tags = ["design", "verktyg", "process"]
+topics = []
+slug = "texter"
+translationKey = "article-slug-used-as-key"
++++
+```
+
+**Critical rules**:
+- `slug = "writing"` is **required** on all English writing articles — without it Hugo generates a wrong URL (e.g. `/writing/article-slug/article-slug/` instead of `/writing/article-slug/`). Every file in the directory must set this explicitly.
+- `slug = "texter"` is the equivalent requirement for Swedish articles.
+- `translationKey` must match exactly between the EN and SV versions — this is how Hugo and the templates link them as translations of each other.
+
+**Untranslated articles (English-only)**:
+When a Swedish translation is not ready, set `hidden = true` on the Swedish file. Effects:
+- The English article appears on `/sv/texter/` with an "English" badge and topic tags translated via `data/tag_translations.toml`
+- A Swedish lang-notice ("Denna text finns inte på svenska.") is shown when the user arrives from the Swedish list via `?from=sv`
+- The language switcher is hidden on the English article (no misleading fallback link)
+- The Swedish file is preserved in the repo for future editing — change to `hidden = false` when ready to publish
+
+**Tag translations** (`data/tag_translations.toml`): Maps English tag names to Swedish equivalents for display on the Swedish list. Update this file when new English tags are introduced.
+
+---
+
 ### Portfolio Projects (`/works/`)
 Front matter structure:
 ```yaml
@@ -697,6 +747,7 @@ npm run test:coverage       # Generate coverage report
 7. **Git Conventions**: Follow the branch format defined in this document
 8. **Taxonomy System**: Employers/clients use Hugo taxonomies - projects need taxonomy tags to appear on company pages
 9. **Hidden Projects**: Respect `hidden: true` parameter - must be filtered in main portfolio templates
+10. **Writing slug**: Every English writing article needs `slug = "writing"` and every Swedish texter article needs `slug = "texter"` in front matter — Hugo will generate wrong URLs without it
 10. **Request Handling**: Follow the "Request Handling Guidelines" section below - propose plans for analysis requests, implement directly only for clear action requests
 11. **Keep AGENTS.md Current**: If you change structure, workflows, or conventions, update this file accordingly
 
@@ -985,4 +1036,4 @@ if (path.startsWith('/sv/') && !path.endsWith('/404.html')) {
 
 ---
 
-Last updated: 2026-02-04
+Last updated: 2026-05-09

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -71,14 +71,10 @@
   background-color: transparent;
   border: 1px solid var(--border-default);
   color: var(--text-muted);
-}
-
-.article-card__header--en {
-  display: flex;
-  align-items: baseline;
-  column-gap: var(--spacing-8);
-}
-
-.article-card__header--en > h2 {
-  min-width: 0;
+  vertical-align: middle;
+  margin-left: 0.5em;
+  padding-top: 0.1rem;
+  padding-bottom: 0.1rem;
+  font-size: var(--text-xs);
+  line-height: 1;
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -75,7 +75,10 @@
 
 .article-card__header--en {
   display: flex;
-  flex-wrap: wrap;
   align-items: baseline;
   column-gap: var(--spacing-8);
+}
+
+.article-card__header--en > h2 {
+  min-width: 0;
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -75,6 +75,6 @@
   margin-left: 0.5em;
   padding-top: 0.1rem;
   padding-bottom: 0.1rem;
-  font-size: var(--text-xs);
+  font-size: 0.6em;
   line-height: 1;
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -75,6 +75,6 @@
   margin-left: 0.5em;
   padding-top: 0.1rem;
   padding-bottom: 0.1rem;
-  font-size: 0.6em;
+  font-size: var(--text-xs);
   line-height: 1;
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -75,4 +75,5 @@
   margin-left: 0.5em;
   padding-top: 0.1rem;
   padding-bottom: 0.1rem;
+  font-size: var(--text-xs);
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -71,10 +71,11 @@
   background-color: transparent;
   border: 1px solid var(--border-default);
   color: var(--text-muted);
-  vertical-align: middle;
-  margin-left: 0.5em;
-  padding-top: 0.1rem;
-  padding-bottom: 0.1rem;
-  font-size: var(--text-xs);
-  line-height: 1;
+}
+
+.article-card__header--en {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: var(--spacing-8);
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -75,5 +75,4 @@
   margin-left: 0.5em;
   padding-top: 0.1rem;
   padding-bottom: 0.1rem;
-  font-size: 0.6em;
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -76,4 +76,5 @@
   padding-top: 0.1rem;
   padding-bottom: 0.1rem;
   font-size: var(--text-xs);
+  line-height: 1;
 }

--- a/assets/css/components/tags.css
+++ b/assets/css/components/tags.css
@@ -72,4 +72,8 @@
   border: 1px solid var(--border-default);
   color: var(--text-muted);
   vertical-align: middle;
+  margin-left: 0.5em;
+  padding-top: 0.1rem;
+  padding-bottom: 0.1rem;
+  font-size: 0.6em;
 }

--- a/assets/css/utilities/typography.css
+++ b/assets/css/utilities/typography.css
@@ -589,6 +589,7 @@ figcaption {
   margin-bottom: var(--spacing-24);
   padding: var(--spacing-12) var(--spacing-16);
   background-color: var(--surface-subtle);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
 }
 

--- a/config.toml
+++ b/config.toml
@@ -69,13 +69,18 @@ DefaultContentLanguage = "en"
       identifier = "works"
       url = "/works/tags/"
     [[languages.en.menu.top]]
-      name = "About me"
+      name = "Writing"
       weight = 3
+      identifier = "writing"
+      url = "/writing/"
+    [[languages.en.menu.top]]
+      name = "About me"
+      weight = 4
       identifier = "about"
       url = "/about"
     [[languages.en.menu.top]]
       name = "contact"
-      weight = 4
+      weight = 5
       identifier = "contact"
       url = "/contact"
 
@@ -103,13 +108,18 @@ DefaultContentLanguage = "en"
       identifier = "works"
       url = "/sv/arbeten/tags/"
     [[languages.sv.menu.top]]
-      name = "Om mig"
+      name = "Texter"
       weight = 3
+      identifier = "writing"
+      url = "/sv/texter/"
+    [[languages.sv.menu.top]]
+      name = "Om mig"
+      weight = 4
       identifier = "about"
       url = "/sv/om"
     [[languages.sv.menu.top]]
       name = "kontakt"
-      weight = 4
+      weight = 5
       identifier = "contact"
       url = "/sv/kontakt"
 

--- a/layouts/texter/list.html
+++ b/layouts/texter/list.html
@@ -36,10 +36,11 @@
       <div class="place-article">
         {{ if eq .Language.Lang "en" }}
           <article class="article-card" data-tags="{{ delimit .Params.tags "," | lower }}">
-            <header>
+            <header class="article-card__header--en">
               <h2 class="article-card__title type-headline-3">
-                <a href="{{ .RelPermalink }}?from=sv">{{ .Title }} <span class="tag tag--lang">English</span></a>
+                <a href="{{ .RelPermalink }}?from=sv">{{ .Title }}</a>
               </h2>
+              <span class="tag tag--lang">English</span>
               {{ if .Description }}
               <p class="article-card__description type-body">{{ .Description }}</p>
               {{ end }}

--- a/layouts/texter/list.html
+++ b/layouts/texter/list.html
@@ -36,11 +36,10 @@
       <div class="place-article">
         {{ if eq .Language.Lang "en" }}
           <article class="article-card" data-tags="{{ delimit .Params.tags "," | lower }}">
-            <header class="article-card__header--en">
+            <header>
               <h2 class="article-card__title type-headline-3">
-                <a href="{{ .RelPermalink }}?from=sv">{{ .Title }}</a>
+                <a href="{{ .RelPermalink }}?from=sv">{{ .Title }} <span class="tag tag--lang">English</span></a>
               </h2>
-              <span class="tag tag--lang">English</span>
               {{ if .Description }}
               <p class="article-card__description type-body">{{ .Description }}</p>
               {{ end }}

--- a/layouts/writing/single.html
+++ b/layouts/writing/single.html
@@ -14,7 +14,7 @@
   {{ $svURL := "" }}
   {{ with .Parent }}{{ range .Translations }}{{ if eq .Language.Lang "sv" }}{{ $svURL = .RelPermalink }}{{ end }}{{ end }}{{ end }}
   <aside class="lang-notice place-article" style="display:none">
-    {{ i18n "lang_only_english" }}{{ if $svURL }} <a href="{{ $svURL }}">{{ i18n "lang_browse_swedish" }}</a>{{ end }}
+    Denna text finns inte på svenska.{{ if $svURL }} <a href="{{ $svURL }}">Tillbaka till svenska texter.</a>{{ end }}
   </aside>
   <script>if (location.search.includes('from=sv')) document.currentScript.previousElementSibling.style.display = '';</script>
   {{ end }}


### PR DESCRIPTION
- lang-notice: add border to make info box more visible against subtle bg
- lang-notice: hardcode Swedish text directly in template
  ("Denna text finns inte på svenska. Tillbaka till svenska texter.")
- tag--lang: add margin-left for breathing room from title text,
  reduce vertical padding and font-size to better fit large headlines

https://claude.ai/code/session_01CoGauTkuyUu98Zk7qL9N1P