### PR TITLE
Add draft article: The Grid, Inherited

### DIFF
--- a/assets/css/utilities/typography.css
+++ b/assets/css/utilities/typography.css
@@ -387,6 +387,14 @@ code {
   color: var(--text-default);
 }
 
+.prose :not(pre) > code {
+  background-color: var(--surface-subtle);
+  border-radius: var(--radius-2);
+  padding-inline: 0.3em;
+  padding-block: 0.1em;
+  font-size: 0.875em;
+}
+
 .taxonomy-header,
 .post-header {
   white-space: nowrap;

--- a/content/english/writing/the-grid-inherited.md
+++ b/content/english/writing/the-grid-inherited.md
@@ -27,8 +27,6 @@ You could approximate a grid but never truly express one.
 
 CSS Grid changed this in 2017. For the first time, the web had a native layout system — one that did not need to simulate a grid but actually *was* one.
 
----
-
 ## Columns with names
 
 What separates CSS Grid from earlier layout techniques is not merely capability but grammar.
@@ -59,8 +57,6 @@ A print designer recognizes this immediately.
 
 The important shift is not visual but structural. Layout stops being a collection of local adjustments and becomes a shared spatial language.
 
----
-
 ## The missing piece
 
 But CSS Grid solved only half the problem.
@@ -89,8 +85,6 @@ Now a nested component can position its children along the exact same column lin
 
 Grid gave the web structure. Subgrid gives it continuity.
 
----
-
 ## A denser compositional language
 
 The full scope of what this makes possible became clear when I began noticing a different kind of precision emerging in modern web design.
@@ -106,8 +100,6 @@ More columns is not more complexity. More columns is more possibility.
 Twelve columns remains a practical compromise. Divisible by 2, 3, 4, and 6 — halves, thirds, quarters, and sixths all resolving onto shared lines.
 
 The result is not rigidity but compositional freedom with structure.
-
----
 
 ## Art direction as a system
 
@@ -143,8 +135,6 @@ For larger editorial gestures there are placement presets — `.place-article`, 
 Each element shifts two columns to the right while occupying four, producing a staggered progression across the spread.
 
 Swedish typesetters once used the term *tripp-trapp-trull* for similar offset arrangements. The name still fits.
-
----
 
 ## Print as endpoint
 

--- a/content/english/writing/the-grid-inherited.md
+++ b/content/english/writing/the-grid-inherited.md
@@ -7,7 +7,7 @@ hidden = false
 description = "On CSS subgrid, named lines, and the print logic that finally arrived on the web"
 tags = ["css", "design", "grid", "print"]
 topics = []
-slug = "the-grid-inherited"
+slug = "writing"
 translationKey = "the-grid-inherited"
 +++
 

--- a/content/english/writing/the-grid-inherited.md
+++ b/content/english/writing/the-grid-inherited.md
@@ -1,0 +1,124 @@
++++
+title = "The Grid, Inherited"
+date = "2026-05-11"
+author = "Torbjörn Hedberg"
+draft = true
+hidden = false
+description = "On CSS subgrid, named lines, and the print logic that finally arrived on the web"
+tags = ["css", "design", "grid", "print"]
+topics = []
+slug = "writing"
+translationKey = "the-grid-inherited"
++++
+
+Printed design rests on a grid that is almost invisible to the reader but impossible to do without as a designer.
+
+Josef Müller-Brockmann's *Grid Systems in Graphic Design* (1961) codified a system already embedded in centuries of typographic tradition: columns, gutters, margins, and baselines coordinating every element on the surface. The grid is not a constraint but a promise — that the page holds together, that its elements are in conversation with each other, that the logic of the composition is legible.
+
+Those who came to the web from print carried this promise with them. And were met, for a long time, by its absence.
+
+For a decade and a half, web layout was a sequence of workarounds. Floats. Clearfix hacks. Tables repurposed for structure. `inline-block` with mysterious whitespace artifacts. Each technique was fundamentally a misuse — a feature designed for one purpose pressed into service as a crutch for another. There was no grammar for layout. You could approximate a grid but never express one.
+
+CSS Grid changed this in 2017. For the first time, the web had a native layout system — one that did not need to simulate a grid but actually *was* one.
+
+---
+
+**Columns with names**
+
+What separates CSS Grid from prior layout techniques is not just capability but grammar. Grid introduces named lines — `[col-start]`, `[content-start]`, `[full-start]` — that function as a typographic coordinate system.
+
+The column definition on this site looks like this:
+
+```css
+grid-template-columns:
+  [full-start] var(--size-page-margins)
+  [content-start] repeat(12, [col-start] 1fr)
+  [content-end] var(--size-page-margins)
+  [full-end];
+```
+
+Twelve columns with margin zones on either side — the geometry of a printed spread. `full-start / full-end` is the paper's edge. `content-start / content-end` is the type area. Elements can be placed anywhere along this axis:
+
+```css
+.place-article  { --col: col-start 3  / span 8; }
+.place-wide     { --col: col-start 1  / span 10; }
+.place-bleed    { --col: full-start   / full-end; }
+```
+
+A print designer recognizes this immediately.
+
+---
+
+**The missing piece**
+
+But CSS Grid solved only half the problem.
+
+The problem was nesting. When an element was placed inside another, its connection to the outer grid broke. Each new grid context created its own columns, its own lines, its own coordinate system — and none of these related to each other. The grid reproduced itself but did not propagate itself.
+
+In print, this is unthinkable. An image sitting in a text column is still positioned within the page's overall grid. Column lines are shared across the entire compositional hierarchy.
+
+Subgrid resolves this. With `grid-template-columns: subgrid`, a nested element inherits the parent's tracks instead of defining its own.
+
+```css
+@supports (grid-template-columns: subgrid) {
+  .use-subgrid {
+    grid-template-columns: subgrid;
+  }
+}
+```
+
+Now a nested container can place its children along the exact same column lines as the outer page. The coordinate system is shared. The grid's promise holds across the entire compositional hierarchy, not only at the top level.
+
+---
+
+**A portal into what's possible**
+
+The full scope of what this makes possible crystallized when I came across stripe.dev — found through Josh W. Comeau's thorough walkthrough of the subgrid specification. What struck me about the site was not any single design decision but the density of control: elements snapping to a fine-grained column structure with a precision that ordinary nested grids simply cannot achieve.
+
+It was a reminder of what Karl Gerstner was after with his programme grids — systems generous enough to contain a large number of compositional variations within a single coherent structure. More columns is not more complexity. More columns is more possibility.
+
+Twelve columns is a practical compromise. Divisible by 2, 3, 4, and 6 — halves, thirds, quarters, and sixths all landing on shared lines.
+
+---
+
+**Art direction as a system**
+
+What becomes genuinely interesting is what you can build on top of subgrid.
+
+The implementation on this site uses CSS custom properties as an art-direction API. Any element can be steered by setting `--col` for desktop, with responsive overrides via `--col-lg`, `--col-md`, and `--col-sm`:
+
+```html
+<div style="--col: col-start 1 / span 6; --col-md: col-start 1 / span 12;">
+```
+
+No JavaScript. No class for every possible configuration. The compositional intent is readable directly in the HTML — much like a layout specification in a print production document.
+
+The fallback chain ensures responsive behavior collapses to defined defaults rather than to an unpredictable stack:
+
+```css
+grid-column: var(--col-md, var(--col-lg, var(--col)));
+```
+
+The system degrades predictably, level by level.
+
+For larger editorial gestures there are placement presets — `.place-article`, `.place-wide`, `.place-bleed` — and stepped patterns that arrange elements in a staircase across the grid:
+
+```css
+.stepped-2-4 > :nth-child(1) { --col: col-start 1 / span 4; }
+.stepped-2-4 > :nth-child(2) { --col: col-start 3 / span 4; }
+.stepped-2-4 > :nth-child(3) { --col: col-start 5 / span 4; }
+```
+
+Each element shifts two columns to the right and occupies four, producing an overlapping staircase across a twelve-column spread. Swedish typesetters once called similar offset patterns *tripp-trapp-trull*. The name still fits.
+
+---
+
+**Print as endpoint**
+
+There is a further dimension rarely discussed: CSS Grid works for print as well.
+
+`@page` lets you define A4 margins, page breaks, and print-specific typography. Grid's named lines are semantic — `content-start`, `full-start` — and can be overridden in a print stylesheet without touching the HTML. The grid that structures the screen becomes the grid that structures the page.
+
+Print and web no longer merely share the concept of a grid. With careful implementation, they can share the same grammar entirely.
+
+Müller-Brockmann did not need browsers to formulate his system. But his system has finally found a home.

--- a/content/english/writing/the-grid-inherited.md
+++ b/content/english/writing/the-grid-inherited.md
@@ -2,7 +2,7 @@
 title = "The Grid, Inherited"
 date = "2026-05-11"
 author = "Torbjörn Hedberg"
-draft = true
+draft = false
 hidden = false
 description = "On CSS subgrid, named lines, and the print logic that finally arrived on the web"
 tags = ["css", "design", "grid", "print"]

--- a/content/english/writing/the-grid-inherited.md
+++ b/content/english/writing/the-grid-inherited.md
@@ -7,25 +7,33 @@ hidden = false
 description = "On CSS subgrid, named lines, and the print logic that finally arrived on the web"
 tags = ["css", "design", "grid", "print"]
 topics = []
-slug = "writing"
+slug = "the-grid-inherited"
 translationKey = "the-grid-inherited"
 +++
 
 Printed design rests on a grid that is almost invisible to the reader but impossible to do without as a designer.
 
-Josef Müller-Brockmann's *Grid Systems in Graphic Design* (1961) codified a system already embedded in centuries of typographic tradition: columns, gutters, margins, and baselines coordinating every element on the surface. The grid is not a constraint but a promise — that the page holds together, that its elements are in conversation with each other, that the logic of the composition is legible.
+Josef Müller-Brockmann's *Grid Systems in Graphic Design* (1961) codified a system already embedded in centuries of typographic practice: columns, gutters, margins, and baselines coordinating every element on the page. The grid is not a constraint but a promise — that the composition holds together, that its elements exist in relation to one another, that the structure beneath the surface remains coherent even as the content changes.
+
+The reader rarely notices the grid directly. What they notice is coherence.
 
 Those who came to the web from print carried this promise with them. And were met, for a long time, by its absence.
 
-For a decade and a half, web layout was a sequence of workarounds. Floats. Clearfix hacks. Tables repurposed for structure. `inline-block` with mysterious whitespace artifacts. Each technique was fundamentally a misuse — a feature designed for one purpose pressed into service as a crutch for another. There was no grammar for layout. You could approximate a grid but never express one.
+For roughly fifteen years, web layout was a sequence of workarounds. Floats. Clearfix hacks. Tables repurposed for structure. `inline-block` with mysterious whitespace artifacts. Each technique was fundamentally a misuse — a feature designed for one purpose pressed into service as a crutch for another.
+
+There was no grammar for layout.
+
+You could approximate a grid but never truly express one.
 
 CSS Grid changed this in 2017. For the first time, the web had a native layout system — one that did not need to simulate a grid but actually *was* one.
 
 ---
 
-**Columns with names**
+## Columns with names
 
-What separates CSS Grid from prior layout techniques is not just capability but grammar. Grid introduces named lines — `[col-start]`, `[content-start]`, `[full-start]` — that function as a typographic coordinate system.
+What separates CSS Grid from earlier layout techniques is not merely capability but grammar.
+
+Grid introduces named lines — `[col-start]`, `[content-start]`, `[full-start]` — that function as a typographic coordinate system.
 
 The column definition on this site looks like this:
 
@@ -37,7 +45,9 @@ grid-template-columns:
   [full-end];
 ```
 
-Twelve columns with margin zones on either side — the geometry of a printed spread. `full-start / full-end` is the paper's edge. `content-start / content-end` is the type area. Elements can be placed anywhere along this axis:
+Twelve columns with margin zones on either side — the geometry of a printed spread.
+
+`full-start / full-end` defines the paper's edge. `content-start / content-end` defines the type area. Elements can be positioned anywhere along this axis:
 
 ```css
 .place-article  { --col: col-start 3  / span 8; }
@@ -47,17 +57,25 @@ Twelve columns with margin zones on either side — the geometry of a printed sp
 
 A print designer recognizes this immediately.
 
+The important shift is not visual but structural. Layout stops being a collection of local adjustments and becomes a shared spatial language.
+
 ---
 
-**The missing piece**
+## The missing piece
 
 But CSS Grid solved only half the problem.
 
-The problem was nesting. When an element was placed inside another, its connection to the outer grid broke. Each new grid context created its own columns, its own lines, its own coordinate system — and none of these related to each other. The grid reproduced itself but did not propagate itself.
+The problem was nesting.
 
-In print, this is unthinkable. An image sitting in a text column is still positioned within the page's overall grid. Column lines are shared across the entire compositional hierarchy.
+When an element was placed inside another, its connection to the outer grid broke. Each new grid context created its own tracks, its own lines, its own coordinate system — and none of these related to each other.
 
-Subgrid resolves this. With `grid-template-columns: subgrid`, a nested element inherits the parent's tracks instead of defining its own.
+The grid reproduced itself but did not propagate itself.
+
+In print, this would be unthinkable. An image sitting inside a text column still belongs to the page's larger compositional system. Alignment lines persist across the entire hierarchy.
+
+Subgrid resolves this.
+
+With `grid-template-columns: subgrid`, a nested container inherits the parent's tracks instead of defining its own.
 
 ```css
 @supports (grid-template-columns: subgrid) {
@@ -67,41 +85,54 @@ Subgrid resolves this. With `grid-template-columns: subgrid`, a nested element i
 }
 ```
 
-Now a nested container can place its children along the exact same column lines as the outer page. The coordinate system is shared. The grid's promise holds across the entire compositional hierarchy, not only at the top level.
+Now a nested component can position its children along the exact same column lines as the outer page. The coordinate system is shared. The grid's promise survives nesting.
+
+Grid gave the web structure. Subgrid gives it continuity.
 
 ---
 
-**A portal into what's possible**
+## A denser compositional language
 
-The full scope of what this makes possible crystallized when I came across stripe.dev — found through Josh W. Comeau's thorough walkthrough of the subgrid specification. What struck me about the site was not any single design decision but the density of control: elements snapping to a fine-grained column structure with a precision that ordinary nested grids simply cannot achieve.
+The full scope of what this makes possible became clear when I began noticing a different kind of precision emerging in modern web design.
 
-It was a reminder of what Karl Gerstner was after with his programme grids — systems generous enough to contain a large number of compositional variations within a single coherent structure. More columns is not more complexity. More columns is more possibility.
+Elements no longer merely aligned *within* components; they aligned *across* them.
 
-Twelve columns is a practical compromise. Divisible by 2, 3, 4, and 6 — halves, thirds, quarters, and sixths all landing on shared lines.
+Sections related to each other spatially even when separated by several layers of nesting. Wide elements could bleed outward while text blocks remained locked to shared internal columns. Components behaved less like isolated boxes and more like participants in a larger compositional field.
+
+This is remarkably close to what Karl Gerstner pursued with programme grids: systems flexible enough to support many different arrangements while preserving an underlying order.
+
+More columns is not more complexity. More columns is more possibility.
+
+Twelve columns remains a practical compromise. Divisible by 2, 3, 4, and 6 — halves, thirds, quarters, and sixths all resolving onto shared lines.
+
+The result is not rigidity but compositional freedom with structure.
 
 ---
 
-**Art direction as a system**
+## Art direction as a system
 
-What becomes genuinely interesting is what you can build on top of subgrid.
+What becomes genuinely interesting is what can be built on top of subgrid.
 
-The implementation on this site uses CSS custom properties as an art-direction API. Any element can be steered by setting `--col` for desktop, with responsive overrides via `--col-lg`, `--col-md`, and `--col-sm`:
+The implementation on this site uses CSS custom properties as an art-direction API. Any element can be steered by setting `--col` for desktop placement, with responsive overrides via `--col-lg`, `--col-md`, and `--col-sm`:
 
 ```html
-<div style="--col: col-start 1 / span 6; --col-md: col-start 1 / span 12;">
+<div style="--col: col-start 1 / span 6;
+            --col-md: col-start 1 / span 12;">
 ```
 
-No JavaScript. No class for every possible configuration. The compositional intent is readable directly in the HTML — much like a layout specification in a print production document.
+No JavaScript. No class for every possible variation.
 
-The fallback chain ensures responsive behavior collapses to defined defaults rather than to an unpredictable stack:
+The compositional intent remains visible directly in the markup — almost like layout annotations in a print production document.
+
+The fallback chain ensures responsive behavior collapses predictably rather than arbitrarily:
 
 ```css
 grid-column: var(--col-md, var(--col-lg, var(--col)));
 ```
 
-The system degrades predictably, level by level.
+The system degrades level by level.
 
-For larger editorial gestures there are placement presets — `.place-article`, `.place-wide`, `.place-bleed` — and stepped patterns that arrange elements in a staircase across the grid:
+For larger editorial gestures there are placement presets — `.place-article`, `.place-wide`, `.place-bleed` — and stepped patterns that move elements rhythmically across the grid:
 
 ```css
 .stepped-2-4 > :nth-child(1) { --col: col-start 1 / span 4; }
@@ -109,16 +140,22 @@ For larger editorial gestures there are placement presets — `.place-article`, 
 .stepped-2-4 > :nth-child(3) { --col: col-start 5 / span 4; }
 ```
 
-Each element shifts two columns to the right and occupies four, producing an overlapping staircase across a twelve-column spread. Swedish typesetters once called similar offset patterns *tripp-trapp-trull*. The name still fits.
+Each element shifts two columns to the right while occupying four, producing a staggered progression across the spread.
+
+Swedish typesetters once used the term *tripp-trapp-trull* for similar offset arrangements. The name still fits.
 
 ---
 
-**Print as endpoint**
+## Print as endpoint
 
-There is a further dimension rarely discussed: CSS Grid works for print as well.
+There is a further implication rarely discussed: CSS Grid works for print as well.
 
-`@page` lets you define A4 margins, page breaks, and print-specific typography. Grid's named lines are semantic — `content-start`, `full-start` — and can be overridden in a print stylesheet without touching the HTML. The grid that structures the screen becomes the grid that structures the page.
+`@page` allows A4 margins, page breaks, and print-specific typography. Named grid lines — `content-start`, `full-start` — are semantic rather than visual and can be redefined in print stylesheets without touching the HTML itself.
+
+The same structural language can govern both screen and paper.
 
 Print and web no longer merely share the concept of a grid. With careful implementation, they can share the same grammar entirely.
 
-Müller-Brockmann did not need browsers to formulate his system. But his system has finally found a home.
+Müller-Brockmann did not need browsers to formulate his system.
+
+But the web has finally become capable of inheriting it.

--- a/content/english/writing/the-page-unprinted.md
+++ b/content/english/writing/the-page-unprinted.md
@@ -1,0 +1,68 @@
++++
+title = "The Page Unprinted"
+date = "2026-05-11"
+author = "Torbjörn Hedberg"
+draft = true
+hidden = false
+description = "Exploring the possibilities and frustrations of CSS print styling"
+tags = ["css", "print", "web-development"]
+topics = []
+translationKey = "the-page-unprinted"
++++
+
+There's something poetic about print. A PDF is a promise—a fixed moment, a document that won't reflow or rerender. Yet the web, built for screens, treats print as an afterthought.
+
+## The Gap Between Screen and Page
+
+When I set out to create print-ready exports for my portfolio, I expected CSS to handle it gracefully. After all, we have `@media print`, `@page` rules, and break properties. The specification exists. The reality is messier.
+
+### What Works
+
+**Page size and margins.** Basic `@page` rules work across browsers:
+
+```css
+@page {
+  size: A4;
+  margin: 20mm 15mm;
+}
+```
+
+**Hiding elements.** Screen-only navigation, footers, and UI chrome disappear predictably with `display: none` in print media queries.
+
+**Break control.** Properties like `break-inside: avoid` mostly work—keeping images with their captions, headers with their content.
+
+### What Doesn't
+
+**Running headers and footers.** The CSS specification describes 16 margin boxes per page—slots for page numbers, chapter titles, document headers. No browser implements them natively.
+
+**Page counters.** `counter(page)` and `counter(pages)` exist in the spec. They don't work without JavaScript polyfills.
+
+**Consistent rendering.** Safari renders fonts thinner. Chrome handles page breaks differently than Firefox. Each browser interprets the same CSS with slight variations.
+
+## The Polyfill Promise
+
+Libraries like paged.js attempt to bridge the gap, implementing CSS Paged Media specifications in JavaScript. The promise is compelling: running headers, page numbers, precise pagination.
+
+The reality is fragile. During my implementation:
+
+- Certain CSS selectors (`nth-of-type`) crashed the library entirely
+- Content loaded correctly, then disappeared during rendering
+- Debugging became archaeology—digging through transformed DOM structures
+
+After multiple attempts with isolated CSS, minimal dependencies, and various configurations, I returned to simple print stylesheets. Sometimes the reliable solution beats the ambitious one.
+
+## What I Learned
+
+**Isolation helps.** Print layouts benefit from separate, minimal CSS—fewer cascade issues, fewer surprises.
+
+**Design for constraints.** Print isn't a degraded screen view. It's a different medium with fixed dimensions, no interaction, and no second chances. Design for it intentionally.
+
+**Accept limitations.** Without running headers or dynamic page numbers, structure your content to work without them. Clear visual hierarchy, consistent spacing, and logical flow matter more than pagination features.
+
+## The Future, Maybe
+
+CSS Paged Media is a working draft from 2018. Browser vendors prioritize screen experiences. Print remains niche.
+
+Perhaps that's fine. The web excels at fluid, responsive, interactive content. Print excels at permanence. They don't need to be the same.
+
+For now, I'll keep my print stylesheets simple, my expectations modest, and my PDFs functional. The page, unprinted, remains a compromise—but a workable one.

--- a/content/english/writing/the-page-unprinted.md
+++ b/content/english/writing/the-page-unprinted.md
@@ -2,7 +2,7 @@
 title = "The Page Unprinted"
 date = "2026-05-11"
 author = "Torbjörn Hedberg"
-draft = true
+draft = false
 hidden = false
 description = "Exploring the possibilities and frustrations of CSS print styling"
 tags = ["css", "print", "web-development"]


### PR DESCRIPTION
English-only first draft on CSS Grid and subgrid — print background,
named grid lines, the art-direction API, and how stripe.dev revealed
the full editorial potential of subgrid.

https://claude.ai/code/session_015eXgVf3toUdAbBCvFMtSK8