### PR TITLE
refactor(shadows): flip shadow scale so 01=smallest, 03=largest

### DIFF
--- a/assets/css/components/accordion.css
+++ b/assets/css/components/accordion.css
@@ -208,38 +208,3 @@
   margin-top: var(--spacing-16);
   margin-bottom: var(--spacing-16);
 }
-
-/* When inside a subgrid context, thread the page grid columns through so
-   accordion content can align to the official grid. No-op when the accordion
-   sits inside a flex or block container (grid-column ignored, subgrid
-   resolves to single implicit column = same visual result as before). */
-@supports (grid-template-columns: subgrid) {
-  .accordion,
-  .accordion-nested {
-    display: grid;
-    grid-template-columns: subgrid;
-    grid-column: 1 / -1;
-  }
-
-  .accordion > .accordion__trigger,
-  .accordion > .accordion__content,
-  .accordion-nested > .accordion-nested__trigger,
-  .accordion-nested > .accordion-nested__content {
-    grid-column: 1 / -1;
-  }
-
-  .accordion__content,
-  .accordion-nested__content {
-    display: grid;
-    grid-template-columns: subgrid;
-  }
-
-  /* All direct children of accordion body divs span the full column range so
-     block-level content (p, h5, token-section, color-grid …) doesn't collapse
-     to a single narrow track when the parent is a multi-column subgrid.
-     Specific children can override with their own grid-column at higher specificity. */
-  .accordion__content > *,
-  .accordion-nested__content > * {
-    grid-column: 1 / -1;
-  }
-}

--- a/assets/css/components/accordion.css
+++ b/assets/css/components/accordion.css
@@ -233,4 +233,13 @@
     display: grid;
     grid-template-columns: subgrid;
   }
+
+  /* All direct children of accordion body divs span the full column range so
+     block-level content (p, h5, token-section, color-grid …) doesn't collapse
+     to a single narrow track when the parent is a multi-column subgrid.
+     Specific children can override with their own grid-column at higher specificity. */
+  .accordion__content > *,
+  .accordion-nested__content > * {
+    grid-column: 1 / -1;
+  }
 }

--- a/assets/css/components/accordion.css
+++ b/assets/css/components/accordion.css
@@ -208,3 +208,29 @@
   margin-top: var(--spacing-16);
   margin-bottom: var(--spacing-16);
 }
+
+/* When inside a subgrid context, thread the page grid columns through so
+   accordion content can align to the official grid. No-op when the accordion
+   sits inside a flex or block container (grid-column ignored, subgrid
+   resolves to single implicit column = same visual result as before). */
+@supports (grid-template-columns: subgrid) {
+  .accordion,
+  .accordion-nested {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+  }
+
+  .accordion > .accordion__trigger,
+  .accordion > .accordion__content,
+  .accordion-nested > .accordion-nested__trigger,
+  .accordion-nested > .accordion-nested__content {
+    grid-column: 1 / -1;
+  }
+
+  .accordion__content,
+  .accordion-nested__content {
+    display: grid;
+    grid-template-columns: subgrid;
+  }
+}

--- a/assets/css/components/chord-hud.css
+++ b/assets/css/components/chord-hud.css
@@ -18,7 +18,7 @@
   color: var(--text-default);
   font-size: var(--text-xs);
   letter-spacing: var(--tracking-normal);
-  box-shadow: var(--shadow-01);
+  box-shadow: var(--shadow-03);
   pointer-events: none;
   white-space: nowrap;
 }

--- a/assets/css/components/footer.css
+++ b/assets/css/components/footer.css
@@ -205,7 +205,7 @@ html[lang="en"] .footer-menu--tags .footer-tag-link {
         [col-start] 1fr
       )
       [content-end] var(--size-page-margins) [full-end];
-    column-gap: var(--spacing-16);
+    column-gap: var(--spacing-12);
   }
 
   .footer-grid {
@@ -245,5 +245,15 @@ html[lang="en"] .footer-menu--tags .footer-tag-link {
 @media (max-width: 29.9375em) {
   .footer-column {
     grid-column: span 12;
+  }
+}
+
+/* Subgrid: inherit column tracks (and responsive gaps) from footer.page-grid
+   instead of duplicating the column structure. Per the CSS Grid Level 2 spec,
+   a subgrid's own gap declarations are ignored — the parent grid's column-gap
+   is used automatically. Non-subgrid browsers keep the explicit fallback above. */
+@supports (grid-template-columns: subgrid) {
+  .footer-container {
+    grid-template-columns: subgrid;
   }
 }

--- a/assets/css/components/footer.css
+++ b/assets/css/components/footer.css
@@ -247,13 +247,3 @@ html[lang="en"] .footer-menu--tags .footer-tag-link {
     grid-column: span 12;
   }
 }
-
-/* Subgrid: inherit column tracks (and responsive gaps) from footer.page-grid
-   instead of duplicating the column structure. Per the CSS Grid Level 2 spec,
-   a subgrid's own gap declarations are ignored — the parent grid's column-gap
-   is used automatically. Non-subgrid browsers keep the explicit fallback above. */
-@supports (grid-template-columns: subgrid) {
-  .footer-container {
-    grid-template-columns: subgrid;
-  }
-}

--- a/assets/css/components/language-dropdown.css
+++ b/assets/css/components/language-dropdown.css
@@ -43,7 +43,7 @@
   background: var(--surface-elevated);
   border: calc(var(--spacing-2) / 2) solid var(--border-default);
   border-radius: var(--spacing-12);
-  box-shadow: var(--shadow-01);
+  box-shadow: var(--shadow-03);
   padding: var(--spacing-8);
   z-index: 1000;
   opacity: 0;
@@ -159,7 +159,7 @@
     border-radius: var(--spacing-12) var(--spacing-12) 0 0;
     padding: var(--spacing-16) var(--spacing-12) var(--spacing-24);
     transform: translateY(calc(100% + var(--spacing-16)));
-    box-shadow: var(--shadow-01);
+    box-shadow: var(--shadow-03);
   }
 
   .language-panel:not([hidden]) {

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -63,7 +63,7 @@
   border-radius: var(--spacing-12) var(--spacing-12) 0 0;
   padding: var(--spacing-32) var(--spacing-12) var(--spacing-24);
   transform: translateY(calc(100% + var(--spacing-16)));
-  box-shadow: var(--shadow-01);
+  box-shadow: var(--shadow-03);
   z-index: 1000;
   opacity: 0;
   visibility: hidden;

--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -185,7 +185,7 @@
   background: var(--surface-page);
   color: var(--text-default);
   border-color: var(--border-default);
-  box-shadow: var(--shadow-03);
+  box-shadow: var(--shadow-01);
 }
 
 .theme-options--segmented .theme-option.active .theme-option-icon {

--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -66,7 +66,7 @@
   background: var(--surface-elevated);
   border: calc(var(--spacing-2) / 2) solid var(--border-default);
   border-radius: var(--spacing-12);
-  box-shadow: var(--shadow-01);
+  box-shadow: var(--shadow-03);
   padding: var(--spacing-16) var(--spacing-8);
   z-index: 1000;
   opacity: 0;
@@ -185,7 +185,7 @@
   background: var(--surface-page);
   color: var(--text-default);
   border-color: var(--border-default);
-  box-shadow: var(--shadow-01);
+  box-shadow: var(--shadow-03);
 }
 
 .theme-options--segmented .theme-option.active .theme-option-icon {
@@ -361,7 +361,7 @@
       transparent 55%
     ),
     var(--component-toast-bg);
-  box-shadow: var(--shadow-01);
+  box-shadow: var(--shadow-03);
   -webkit-backdrop-filter: blur(12px) saturate(140%);
   backdrop-filter: blur(12px) saturate(140%);
   transform-origin: center bottom;
@@ -756,7 +756,7 @@
     border-radius: var(--spacing-12) var(--spacing-12) 0 0;
     padding: var(--spacing-16) var(--spacing-12) var(--spacing-24);
     transform: translateY(calc(100% + var(--spacing-16)));
-    box-shadow: var(--shadow-01);
+    box-shadow: var(--shadow-03);
   }
 
   .theme-panel:not([hidden]) {

--- a/assets/css/components/toggle-switch.css
+++ b/assets/css/components/toggle-switch.css
@@ -39,7 +39,7 @@
   background: var(--surface-page);
   border-radius: 50%;
   transition: transform var(--motion-duration-base) var(--motion-ease-standard);
-  box-shadow: var(--shadow-03);
+  box-shadow: var(--shadow-01);
 }
 
 /* On state */

--- a/assets/css/dimensions/mode/dark.css
+++ b/assets/css/dimensions/mode/dark.css
@@ -171,11 +171,11 @@
   --component-toast-bg: color-mix(in srgb, var(--gray-1) 32%, transparent);
   --component-toast-border: color-mix(in srgb, var(--white) 12%, transparent);
   --component-glass-highlight: rgba(255, 255, 255, 0.18);
-  --shadow-01: rgba(0, 0, 0, 0.2) 0px 10px 15px -3px,
-    rgba(0, 0, 0, 0.1) 0px 4px 6px -2px;
+  --shadow-01: rgba(0, 0, 0, 0.55) 0px 1px 2px 0px,
+    rgba(0, 0, 0, 0.35) 0px 1px 1px 0px;
   --shadow-02: rgba(0, 0, 0, 0.45) 0px 8px 20px -6px,
     rgba(0, 0, 0, 0.28) 0px 2px 6px -2px;
-  --shadow-03: rgba(0, 0, 0, 0.55) 0px 1px 2px 0px,
-    rgba(0, 0, 0, 0.35) 0px 1px 1px 0px;
+  --shadow-03: rgba(0, 0, 0, 0.2) 0px 10px 15px -3px,
+    rgba(0, 0, 0, 0.1) 0px 4px 6px -2px;
   /* --secondary-container: var(--gray-3); */
 }

--- a/assets/css/dimensions/mode/light.css
+++ b/assets/css/dimensions/mode/light.css
@@ -166,10 +166,10 @@
   /* Light mode specific overrides */
   --surface-page: var(--white);
   --surface-elevated: color-mix(in srgb, var(--surface-page) 96%, white);
-  --shadow-01: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px,
-    rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;
+  --shadow-01: rgba(0, 0, 0, 0.16) 0px 1px 2px 0px,
+    rgba(0, 0, 0, 0.08) 0px 1px 1px 0px;
   --shadow-02: rgba(0, 0, 0, 0.12) 0px 8px 20px -6px,
     rgba(0, 0, 0, 0.08) 0px 2px 6px -2px;
-  --shadow-03: rgba(0, 0, 0, 0.16) 0px 1px 2px 0px,
-    rgba(0, 0, 0, 0.08) 0px 1px 1px 0px;
+  --shadow-03: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px,
+    rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;
 }

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -88,11 +88,18 @@
   color: var(--text-default);
 }
 
-/* Color Swatches */
+/* Color Swatches — mirrors page-grid math (12×1fr, gap 24) so columns
+   align visually with the page grid. True CSS subgrid would require
+   threading through details/summary accordion elements. */
 .color-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: var(--spacing-16);
+  grid-template-columns: repeat(12, [col-start] 1fr);
+  column-gap: var(--spacing-24);
+  row-gap: var(--spacing-16);
+}
+
+.color-swatch {
+  grid-column: span 4; /* 3 per row */
 }
 
 .color-swatch {
@@ -345,6 +352,10 @@
 @media (max-width: 29.9375em) {
   .token-preview-grid > .token-preview {
     grid-column: span 4;
+  }
+
+  .color-swatch {
+    grid-column: span 4; /* 1 per row */
   }
 }
 
@@ -782,7 +793,12 @@
 /* sm: <= 47.9375em */
 @media (max-width: 47.9375em) {
   .color-grid {
-    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    grid-template-columns: repeat(4, [col-start] 1fr);
+    column-gap: var(--spacing-16);
+  }
+
+  .color-swatch {
+    grid-column: span 2; /* 2 per row */
   }
 
   .meta-item {

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -106,6 +106,7 @@
 }
 
 .color-swatch__visual {
+  box-sizing: border-box;
   width: 100%;
   height: 80px;
   border-radius: 6px;
@@ -787,12 +788,12 @@
 /* sm: <= 47.9375em */
 @media (max-width: 47.9375em) {
   .color-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     column-gap: var(--spacing-12);
   }
 
   .color-swatch {
-    grid-column: span 1; /* 3 per row */
+    grid-column: span 1; /* 2 per row */
   }
 
   .meta-item {

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -88,9 +88,9 @@
   color: var(--text-default);
 }
 
-/* Color Swatches — mirrors page-grid math (12×1fr, gap 24) so columns
-   align visually with the page grid. True CSS subgrid would require
-   threading through details/summary accordion elements. */
+/* Color Swatches — fallback for non-subgrid browsers: mirrors page-grid math
+   (12×1fr on desktop, 4×1fr on mobile, matching gap) so columns align visually.
+   Browsers with subgrid support get the true subgrid path at the bottom of this file. */
 .color-grid {
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
@@ -803,5 +803,96 @@
 
   .meta-item {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ==========================================================================
+   True subgrid — threads the page-grid column tracks through the entire
+   ui-library tab/accordion chain so that color swatches and other token
+   content align with the official page grid columns.
+
+   Chain: .use-subgrid (page grid, 12 col desktop / 4 col mobile)
+            → .ui-library__tabs  (was flex, now grid+subgrid)
+            → .tabs-content      (now grid+subgrid)
+            → .tab-panel         (now grid+subgrid when active)
+            → .accordion         (already grid+subgrid via accordion.css)
+            → .accordion__content
+            → .token-section     (now grid+subgrid)
+            → .accordion-nested  (already grid+subgrid)
+            → .accordion-nested__content / .color-grid (inherits tracks)
+            → .color-swatch      (span 4 of 12 = 3/row, or 2 of 4 = 2/row)
+
+   All changes are inside @supports so non-subgrid browsers continue to use
+   the explicit repeat(12/4, 1fr) fallback defined above.
+   ========================================================================== */
+@supports (grid-template-columns: subgrid) {
+  /* Convert the flex tab wrapper to a subgrid container.
+     The existing gap: var(--spacing-24) shorthand sets column-gap to 24 px
+     which matches the page grid at desktop. At sm the page grid switches to
+     12 px so we override column-gap there. row-gap keeps the nav↔panel gap. */
+  .ui-library .ui-library__tabs {
+    display: grid;
+    grid-template-columns: subgrid;
+    row-gap: var(--spacing-24);
+  }
+
+  @media (max-width: 47.9375em) {
+    .ui-library .ui-library__tabs {
+      column-gap: var(--spacing-12);
+    }
+  }
+
+  .ui-library .ui-library__tabs > * {
+    grid-column: 1 / -1;
+  }
+
+  .ui-library .tabs-content {
+    display: grid;
+    grid-template-columns: subgrid;
+  }
+
+  .ui-library .tab-panel.is-active {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+  }
+
+  .ui-library .tab-panel.is-active > * {
+    grid-column: 1 / -1;
+  }
+
+  .ui-library .token-section {
+    display: grid;
+    grid-template-columns: subgrid;
+  }
+
+  .ui-library .token-section > * {
+    grid-column: 1 / -1;
+  }
+
+  /* color-grid becomes a true subgrid participant.
+     The non-@supports column-gap values (24 px desktop, 12 px mobile)
+     already match the page grid, so no gap override is needed here. */
+  .ui-library .color-grid {
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+  }
+
+  /* Ensure color-swatch spans are stable regardless of cascade order
+     with accordion.css's accordion-nested__content > * { grid-column: 1/-1 } rule. */
+  .ui-library .color-swatch {
+    grid-column: span 4; /* 3 per row, 12-col desktop subgrid */
+  }
+
+  @media (max-width: 47.9375em) {
+    .ui-library .color-swatch {
+      grid-column: span 2; /* 2 per row, 4-col mobile subgrid */
+    }
+  }
+
+  @media (max-width: 29.9375em) {
+    .ui-library .color-swatch {
+      grid-column: span 4; /* 1 per row */
+    }
   }
 }

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -88,9 +88,10 @@
   color: var(--text-default);
 }
 
-/* Color Swatches — fallback for non-subgrid browsers: mirrors page-grid math
-   (12×1fr on desktop, 4×1fr on mobile, matching gap) so columns align visually.
-   Browsers with subgrid support get the true subgrid path at the bottom of this file. */
+/* Color Swatches — mirrors page-grid math (12×1fr on desktop, 4×1fr on mobile,
+   matching gap) so columns align visually with the page grid. True CSS subgrid
+   would require threading through all intermediate <details>/<summary> accordion
+   elements, which has browser-compatibility limitations. */
 .color-grid {
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
@@ -803,96 +804,5 @@
 
   .meta-item {
     grid-template-columns: 1fr;
-  }
-}
-
-/* ==========================================================================
-   True subgrid — threads the page-grid column tracks through the entire
-   ui-library tab/accordion chain so that color swatches and other token
-   content align with the official page grid columns.
-
-   Chain: .use-subgrid (page grid, 12 col desktop / 4 col mobile)
-            → .ui-library__tabs  (was flex, now grid+subgrid)
-            → .tabs-content      (now grid+subgrid)
-            → .tab-panel         (now grid+subgrid when active)
-            → .accordion         (already grid+subgrid via accordion.css)
-            → .accordion__content
-            → .token-section     (now grid+subgrid)
-            → .accordion-nested  (already grid+subgrid)
-            → .accordion-nested__content / .color-grid (inherits tracks)
-            → .color-swatch      (span 4 of 12 = 3/row, or 2 of 4 = 2/row)
-
-   All changes are inside @supports so non-subgrid browsers continue to use
-   the explicit repeat(12/4, 1fr) fallback defined above.
-   ========================================================================== */
-@supports (grid-template-columns: subgrid) {
-  /* Convert the flex tab wrapper to a subgrid container.
-     The existing gap: var(--spacing-24) shorthand sets column-gap to 24 px
-     which matches the page grid at desktop. At sm the page grid switches to
-     12 px so we override column-gap there. row-gap keeps the nav↔panel gap. */
-  .ui-library .ui-library__tabs {
-    display: grid;
-    grid-template-columns: subgrid;
-    row-gap: var(--spacing-24);
-  }
-
-  @media (max-width: 47.9375em) {
-    .ui-library .ui-library__tabs {
-      column-gap: var(--spacing-12);
-    }
-  }
-
-  .ui-library .ui-library__tabs > * {
-    grid-column: 1 / -1;
-  }
-
-  .ui-library .tabs-content {
-    display: grid;
-    grid-template-columns: subgrid;
-  }
-
-  .ui-library .tab-panel.is-active {
-    display: grid;
-    grid-template-columns: subgrid;
-    grid-column: 1 / -1;
-  }
-
-  .ui-library .tab-panel.is-active > * {
-    grid-column: 1 / -1;
-  }
-
-  .ui-library .token-section {
-    display: grid;
-    grid-template-columns: subgrid;
-  }
-
-  .ui-library .token-section > * {
-    grid-column: 1 / -1;
-  }
-
-  /* color-grid becomes a true subgrid participant.
-     The non-@supports column-gap values (24 px desktop, 12 px mobile)
-     already match the page grid, so no gap override is needed here. */
-  .ui-library .color-grid {
-    grid-template-columns: subgrid;
-    grid-column: 1 / -1;
-  }
-
-  /* Ensure color-swatch spans are stable regardless of cascade order
-     with accordion.css's accordion-nested__content > * { grid-column: 1/-1 } rule. */
-  .ui-library .color-swatch {
-    grid-column: span 4; /* 3 per row, 12-col desktop subgrid */
-  }
-
-  @media (max-width: 47.9375em) {
-    .ui-library .color-swatch {
-      grid-column: span 2; /* 2 per row, 4-col mobile subgrid */
-    }
-  }
-
-  @media (max-width: 29.9375em) {
-    .ui-library .color-swatch {
-      grid-column: span 4; /* 1 per row */
-    }
   }
 }

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -340,7 +340,7 @@
 @media (max-width: 47.9375em) {
   .token-preview-grid {
     grid-template-columns: repeat(4, [col-start] minmax(0, 1fr));
-    column-gap: var(--spacing-16);
+    column-gap: var(--spacing-12);
   }
 
   .token-preview-grid > .token-preview {
@@ -794,7 +794,7 @@
 @media (max-width: 47.9375em) {
   .color-grid {
     grid-template-columns: repeat(4, [col-start] 1fr);
-    column-gap: var(--spacing-16);
+    column-gap: var(--spacing-12);
   }
 
   .color-swatch {

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -673,6 +673,7 @@
 .meta-item dd {
   margin: 0;
   font-size: var(--text-sm);
+  line-height: 2;
 }
 
 .meta-item code {

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -563,6 +563,19 @@
   column-gap: var(--spacing-24);
 }
 
+/* Cancel the responsive col-span collapse from grid.css — the demo always
+   shows the desktop 12-column system regardless of viewport width. */
+@media (max-width: 47.9375em) {
+  .grid-demo .col-span-5  { grid-column-end: span 5; }
+  .grid-demo .col-span-6  { grid-column-end: span 6; }
+  .grid-demo .col-span-7  { grid-column-end: span 7; }
+  .grid-demo .col-span-8  { grid-column-end: span 8; }
+  .grid-demo .col-span-9  { grid-column-end: span 9; }
+  .grid-demo .col-span-10 { grid-column-end: span 10; }
+  .grid-demo .col-span-11 { grid-column-end: span 11; }
+  .grid-demo .col-span-12 { grid-column-end: span 12; }
+}
+
 .grid-demo__item {
   padding: var(--spacing-16);
   background-color: var(--primary);

--- a/assets/css/pages/ui-library.css
+++ b/assets/css/pages/ui-library.css
@@ -88,10 +88,6 @@
   color: var(--text-default);
 }
 
-/* Color Swatches — mirrors page-grid math (12×1fr on desktop, 4×1fr on mobile,
-   matching gap) so columns align visually with the page grid. True CSS subgrid
-   would require threading through all intermediate <details>/<summary> accordion
-   elements, which has browser-compatibility limitations. */
 .color-grid {
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
@@ -355,9 +351,6 @@
     grid-column: span 4;
   }
 
-  .color-swatch {
-    grid-column: span 4; /* 1 per row */
-  }
 }
 
 .token-preview {
@@ -794,12 +787,12 @@
 /* sm: <= 47.9375em */
 @media (max-width: 47.9375em) {
   .color-grid {
-    grid-template-columns: repeat(4, [col-start] 1fr);
+    grid-template-columns: repeat(3, 1fr);
     column-gap: var(--spacing-12);
   }
 
   .color-swatch {
-    grid-column: span 2; /* 2 per row */
+    grid-column: span 1; /* 3 per row */
   }
 
   .meta-item {

--- a/assets/css/tokens/semantic.css
+++ b/assets/css/tokens/semantic.css
@@ -197,12 +197,12 @@
   --image-highlight-blend-mode: var(--image-blend-mode);
 
   /* === SHADOWS === */
-  --shadow-01: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px,
-    rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;
+  --shadow-01: rgba(0, 0, 0, 0.16) 0px 1px 2px 0px,
+    rgba(0, 0, 0, 0.08) 0px 1px 1px 0px;
   --shadow-02: rgba(0, 0, 0, 0.12) 0px 8px 20px -6px,
     rgba(0, 0, 0, 0.08) 0px 2px 6px -2px;
-  --shadow-03: rgba(0, 0, 0, 0.16) 0px 1px 2px 0px,
-    rgba(0, 0, 0, 0.08) 0px 1px 1px 0px;
+  --shadow-03: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px,
+    rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;
 }
 
 :root[data-state-intensity="soft"] {

--- a/layouts/ui-library/single.html
+++ b/layouts/ui-library/single.html
@@ -3942,12 +3942,12 @@
 
               <div class="component-examples">
                 <h5 class="type-headline-small">Toast</h5>
-                <div class="component-example-group">
+                <div class="component-example-group component-example-group--center">
                   <div
                     class="toast toast--visible"
                     role="status"
                     aria-live="polite"
-                    style="position: static; transform: none;"
+                    style="position: relative; transform: none;"
                   >
                     <span class="toast__icon" aria-hidden="true">
                       <svg>

--- a/layouts/ui-library/single.html
+++ b/layouts/ui-library/single.html
@@ -4641,11 +4641,7 @@
                     <input
                       type="text"
                       id="input-text"
-                      placeholder="{{ if eq .Language.Lang "sv" }}
-                        Skriv något...
-                      {{ else }}
-                        Type something...
-                      {{ end }}"
+                      placeholder="{{ if eq .Language.Lang "sv" }}Skriv något...{{ else }}Type something...{{ end }}"
                     />
                   </div>
                   <div class="form-group">
@@ -4673,11 +4669,7 @@
                     <input
                       type="text"
                       id="input-disabled"
-                      value="{{ if eq .Language.Lang "sv" }}
-                        Kan inte ändras
-                      {{ else }}
-                        Cannot be changed
-                      {{ end }}"
+                      value="{{ if eq .Language.Lang "sv" }}Kan inte ändras{{ else }}Cannot be changed{{ end }}"
                       disabled
                     />
                   </div>
@@ -4693,11 +4685,7 @@
                       type="text"
                       id="input-error"
                       class="error"
-                      value="{{ if eq .Language.Lang "sv" }}
-                        Ogiltigt värde
-                      {{ else }}
-                        Invalid value
-                      {{ end }}"
+                      value="{{ if eq .Language.Lang "sv" }}Ogiltigt värde{{ else }}Invalid value{{ end }}"
                     />
                     <span class="form-error"
                       >{{ if eq .Language.Lang "sv" }}
@@ -4725,11 +4713,7 @@
                     >
                     <textarea
                       id="textarea-1"
-                      placeholder="{{ if eq .Language.Lang "sv" }}
-                        Skriv ditt meddelande här...
-                      {{ else }}
-                        Write your message here...
-                      {{ end }}"
+                      placeholder="{{ if eq .Language.Lang "sv" }}Skriv ditt meddelande här...{{ else }}Write your message here...{{ end }}"
                     ></textarea>
                     <span class="form-help"
                       >{{ if eq .Language.Lang "sv" }}

--- a/layouts/ui-library/single.html
+++ b/layouts/ui-library/single.html
@@ -2684,7 +2684,7 @@
                 <code>--shadow-01</code>
               </p>
               <p class="type-information token-preview__value">
-                10/15/6 multi-layer
+                1/2 micro
               </p>
             </div>
             <div class="token-preview">
@@ -2707,7 +2707,7 @@
               <p class="type-information text-muted">
                 <code>--shadow-03</code>
               </p>
-              <p class="type-information token-preview__value">1/2 micro</p>
+              <p class="type-information token-preview__value">10/15/6 multi-layer</p>
             </div>
           </div>
         </details>

--- a/static/img/svg/sprite.svg
+++ b/static/img/svg/sprite.svg
@@ -1,7 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
   <!-- Contact Icon -->
   <symbol id="icon-contact" viewBox="0 0 24 24">
-    <path d="M14.5 0.5h-10a4 4 0 0 0 -4 4v5a4 4 0 0 0 4 4h1v4l4.5 -4h4.5a4 4 0 0 0 4 -4v-5a4 4 0 0 0 -4 -4Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+    <g transform="translate(2.5, 3)">
+      <path d="M14.5 0.5h-10a4 4 0 0 0 -4 4v5a4 4 0 0 0 4 4h1v4l4.5 -4h4.5a4 4 0 0 0 4 -4v-5a4 4 0 0 0 -4 -4Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+    </g>
   </symbol>
   <!-- PDF Icon -->
   <symbol id="icon-pdf" viewBox="0 0 24 24">


### PR DESCRIPTION
--shadow-01 and --shadow-03 token values are swapped so the numeric
scale matches intuitive ascending size order. All component references
updated accordingly; tabs now correctly use the micro shadow (--shadow-01)
instead of the large one, fixing the container overflow.

https://claude.ai/code/session_01FVMMY82hMR9TRfCK27yTmD