### PR TITLE
quality: exclude uses-text-compression from CI backlog candidates

### DIFF
--- a/quality-policy.yml
+++ b/quality-policy.yml
@@ -43,3 +43,11 @@ policy:
   backlog:
     axeImpacts:
       - minor
+
+    # Lighthouse opportunity audits to exclude from "Backlog candidates".
+    # CI serves the build with `python3 -m http.server`, which never gzips
+    # and sends no cache headers. These audits therefore report huge (false)
+    # savings and drown out real items. Production (Netlify) brotli/gzip-
+    # compresses all text, so this audit does not apply there.
+    ignoreLighthouseAudits:
+      - uses-text-compression

--- a/scripts/quality/evaluate.mjs
+++ b/scripts/quality/evaluate.mjs
@@ -96,10 +96,11 @@ function scoreToPoints(score) {
   return Number.isFinite(points) ? points : null;
 }
 
-function pickTopOpportunities(lhr, maxItems = 5) {
+function pickTopOpportunities(lhr, maxItems = 5, ignoreAudits = new Set()) {
   const items = [];
   const audits = lhr?.audits ?? {};
   for (const [auditId, audit] of Object.entries(audits)) {
+    if (ignoreAudits.has(auditId)) continue;
     const details = audit?.details;
     if (!details || details.type !== "opportunity") continue;
     const savingsMs = asInt(details.overallSavingsMs, 0);
@@ -168,7 +169,7 @@ function aggregateLighthouseRuns(lighthouseRuns) {
   return aggregated;
 }
 
-async function parseLighthouse(lighthouseDir) {
+async function parseLighthouse(lighthouseDir, ignoreAudits = new Set()) {
   const files = await listFilesRecursive(lighthouseDir);
   const lhrFiles = files.filter((f) => path.basename(f).startsWith("lhr-") && f.endsWith(".json"));
   const results = [];
@@ -186,7 +187,7 @@ async function parseLighthouse(lighthouseDir) {
         bestPractices: scoreToPoints(lhr?.categories?.["best-practices"]?.score),
         seo: scoreToPoints(lhr?.categories?.seo?.score),
       },
-      opportunities: pickTopOpportunities(lhr),
+      opportunities: pickTopOpportunities(lhr, 5, ignoreAudits),
     });
   }
 
@@ -421,9 +422,11 @@ async function main() {
   let lighthouseRunsAggregated = null;
   let axeRuns = null;
 
+  const ignoreLighthouseAudits = new Set(policy?.policy?.backlog?.ignoreLighthouseAudits ?? []);
+
   if (lighthouseDir) {
     try {
-      lighthouseRuns = await parseLighthouse(lighthouseDir);
+      lighthouseRuns = await parseLighthouse(lighthouseDir, ignoreLighthouseAudits);
       lighthouseRunsAggregated = aggregateLighthouseRuns(lighthouseRuns);
     } catch (err) {
       lighthouseRuns = null;


### PR DESCRIPTION
## Summary

CI serves the build with `python3 -m http.server`, which never gzips and sends no cache headers. As a result, Lighthouse's `uses-text-compression` audit ("Enable text compression") reports huge, false byte savings and **dominates the "Backlog candidates" list** in the CI Quality Report — pushing real, actionable items out of view.

Production runs on **Netlify**, which brotli/gzip-compresses all text responses, so this audit does not apply there. It is purely a test-harness artifact.

## Change

- Add a policy-driven ignore list `policy.backlog.ignoreLighthouseAudits` in `quality-policy.yml`, seeded with `uses-text-compression`, documented with the rationale.
- Honor it in `scripts/quality/evaluate.mjs`: `pickTopOpportunities()` now skips ignored audit IDs, threaded through `parseLighthouse()` from the loaded policy.

Keeps the mechanism configurable (future artefact audits can be silenced in one place) rather than hardcoding the audit id.

## Scope / impact

- **CI tooling only** — no change to site output; nothing visitors see changes.
- Does not affect blockers/scoring; only what appears under "Backlog candidates (top)".

## Verification

- `node --check scripts/quality/evaluate.mjs` ✅
- YAML parses; `policy.backlog.ignoreLighthouseAudits == ["uses-text-compression"]` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_