### PR TITLE
perf: cache fingerprinted CSS/JS immutably for one year

### DIFF
--- a/layouts/portfolio-print/single.html
+++ b/layouts/portfolio-print/single.html
@@ -1,146 +1,177 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Portfolio – {{ .Params.company_name | title }} | {{ .Site.Title }}</title>
-  <meta name="robots" content="noindex, nofollow">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Portfolio – {{ .Params.company_name | title }} | {{ .Site.Title }}
+    </title>
+    <meta name="robots" content="noindex, nofollow" />
 
-  <!-- Typekit fonts -->
-  <link rel="preconnect" href="https://use.typekit.net" crossorigin>
-  <link rel="preconnect" href="https://p.typekit.net" crossorigin>
-  <link rel="stylesheet" href="https://use.typekit.net/diz3sha.css">
+    <!-- Typekit fonts -->
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
+    <link rel="preconnect" href="https://p.typekit.net" crossorigin />
+    <link rel="stylesheet" href="https://use.typekit.net/diz3sha.css" />
 
-  <!-- CSS -->
-  {{ $reset := resources.Get "css/base/reset.css" }}
-  {{ $primitives := resources.Get "css/tokens/primitives.css" }}
-  {{ $semantic := resources.Get "css/tokens/semantic.css" }}
-  {{ $light := resources.Get "css/dimensions/mode/light.css" }}
-  {{ $typography := resources.Get "css/utilities/typography.css" }}
-  {{ $style := resources.Get "css/style.css" }}
-  {{ $print := resources.Get "css/print.css" }}
-  {{ $css := slice $reset $primitives $semantic $light $typography $style $print | resources.Concat "portfolio-print-bundle.css" }}
-  <link rel="stylesheet" type="text/css" href="{{ $css.Permalink }}" media="all" />
+    <!-- CSS -->
+    {{ $reset := resources.Get "css/base/reset.css" }}
+    {{ $primitives := resources.Get "css/tokens/primitives.css" }}
+    {{ $semantic := resources.Get "css/tokens/semantic.css" }}
+    {{ $light := resources.Get "css/dimensions/mode/light.css" }}
+    {{ $typography := resources.Get "css/utilities/typography.css" }}
+    {{ $style := resources.Get "css/style.css" }}
+    {{ $print := resources.Get "css/print.css" }}
+    {{ $css := slice $reset $primitives $semantic $light $typography $style $print | resources.Concat "portfolio-print-bundle.css" | minify | fingerprint }}
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ $css.Permalink }}"
+      media="all"
+    />
 
-  <style>
-    /* Portfolio print specific overrides */
-    .portfolio-print__images {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 1rem;
-      margin: 1.5rem 0;
-    }
-    .portfolio-print__images img {
-      width: 100%;
-      height: auto;
-      max-height: 300px;
-      object-fit: contain;
-      background: #f5f5f5;
-    }
-    .portfolio-print__project {
-      margin-bottom: 3rem;
-      padding-bottom: 2rem;
-      border-bottom: 1px solid var(--border-default, #ddd);
-    }
-    .portfolio-print__project:last-child {
-      border-bottom: none;
-    }
-    .portfolio-print__content {
-      margin-top: 1.5rem;
-    }
-    .portfolio-print__content img {
-      max-width: 100%;
-      height: auto;
-      max-height: 400px;
-      object-fit: contain;
-    }
-    @media print {
-      .portfolio-print__images img {
-        max-height: 200px;
+    <style>
+      /* Portfolio print specific overrides */
+      .portfolio-print__images {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+        margin: 1.5rem 0;
       }
-      .portfolio-print__content img {
+      .portfolio-print__images img {
+        width: 100%;
+        height: auto;
         max-height: 300px;
+        object-fit: contain;
+        background: #f5f5f5;
       }
       .portfolio-print__project {
-        page-break-inside: avoid;
-        break-inside: avoid;
+        margin-bottom: 3rem;
+        padding-bottom: 2rem;
+        border-bottom: 1px solid var(--border-default, #ddd);
       }
-    }
-  </style>
-</head>
-<body>
-  <main class="portfolio-print">
-    <nav class="portfolio-print__nav">
-      <a href="{{ .Params.back_url | default (print "/" .Params.taxonomy "/" .Params.company_name "/") }}">&larr; {{ if eq .Language.Lang "sv" }}Tillbaka till ansökan{{ else }}Back to application{{ end }}</a>
-    </nav>
+      .portfolio-print__project:last-child {
+        border-bottom: none;
+      }
+      .portfolio-print__content {
+        margin-top: 1.5rem;
+      }
+      .portfolio-print__content img {
+        max-width: 100%;
+        height: auto;
+        max-height: 400px;
+        object-fit: contain;
+      }
+      @media print {
+        .portfolio-print__images img {
+          max-height: 200px;
+        }
+        .portfolio-print__content img {
+          max-height: 300px;
+        }
+        .portfolio-print__project {
+          page-break-inside: avoid;
+          break-inside: avoid;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="portfolio-print">
+      <nav class="portfolio-print__nav">
+        <a
+          href="{{ .Params.back_url | default (print "/" .Params.taxonomy "/" .Params.company_name "/") }}"
+          >&larr;
+          {{ if eq .Language.Lang "sv" }}
+            Tillbaka till ansökan
+          {{ else }}
+            Back to application
+          {{ end }}</a
+        >
+      </nav>
 
-    <header class="portfolio-print__header">
-      <h1 class="type-headline-2">Portfolio</h1>
-      <p class="portfolio-print__subtitle type-preamble">{{ .Params.subtitle | default (print (i18n "selected_works_for" | default "Selected works for") " " (.Params.company_name | title)) }}</p>
-    </header>
-
-    {{ $companyName := .Params.company_name }}
-    {{ $taxonomy := .Params.taxonomy | default "employers" }}
-    {{ $projects := slice }}
-
-    {{/* Get projects based on taxonomy type */}}
-    {{ range where .Site.RegularPages "Type" "works" }}
-      {{ if eq $taxonomy "employers" }}
-        {{ if in .Params.employers $companyName }}
-          {{ $projects = $projects | append . }}
-        {{ end }}
-      {{ else if eq $taxonomy "clients" }}
-        {{ if in .Params.clients $companyName }}
-          {{ $projects = $projects | append . }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-
-    {{ range $projects }}
-    <article class="portfolio-print__project">
-      <header class="portfolio-print__project-header">
-        <h2 class="type-headline-3">{{ .Title }}</h2>
-        {{ with .Params.subtitle }}
-        <p class="type-preamble">{{ . }}</p>
-        {{ end }}
+      <header class="portfolio-print__header">
+        <h1 class="type-headline-2">Portfolio</h1>
+        <p class="portfolio-print__subtitle type-preamble">
+          {{ .Params.subtitle | default (print (i18n "selected_works_for" | default "Selected works for") " " (.Params.company_name | title)) }}
+        </p>
       </header>
 
-      {{ with .Description }}
-      <p class="type-body">{{ . }}</p>
-      {{ end }}
+      {{ $companyName := .Params.company_name }}
+      {{ $taxonomy := .Params.taxonomy | default "employers" }}
+      {{ $projects := slice }}
 
-      {{/* Use the project-info partial for consistent display */}}
-      {{ partial "project-info.html" . }}
-
-      {{/* Display first 4 images from project */}}
-      {{ $images := .Resources.ByType "image" }}
-      {{ if $images }}
-      <div class="portfolio-print__images">
-        {{ range first 4 $images }}
-        <figure>
-          <img src="{{ .Permalink }}" alt="{{ $.Title }}" loading="lazy">
-        </figure>
+      {{/* Get projects based on taxonomy type */}}
+      {{ range where .Site.RegularPages "Type" "works" }}
+        {{ if eq $taxonomy "employers" }}
+          {{ if in .Params.employers $companyName }}
+            {{ $projects = $projects | append . }}
+          {{ end }}
+        {{ else if eq $taxonomy "clients" }}
+          {{ if in .Params.clients $companyName }}
+            {{ $projects = $projects | append . }}
+          {{ end }}
         {{ end }}
-      </div>
       {{ end }}
 
-      {{ with .Content }}
-      <div class="portfolio-print__content type-body">
-        {{ . }}
-      </div>
+      {{ range $projects }}
+        <article class="portfolio-print__project">
+          <header class="portfolio-print__project-header">
+            <h2 class="type-headline-3">{{ .Title }}</h2>
+            {{ with .Params.subtitle }}
+              <p class="type-preamble">{{ . }}</p>
+            {{ end }}
+          </header>
+
+          {{ with .Description }}
+            <p class="type-body">{{ . }}</p>
+          {{ end }}
+
+          {{/* Use the project-info partial for consistent display */}}
+          {{ partial "project-info.html" . }}
+
+          {{/* Display first 4 images from project */}}
+          {{ $images := .Resources.ByType "image" }}
+          {{ if $images }}
+            <div class="portfolio-print__images">
+              {{ range first 4 $images }}
+                <figure>
+                  <img
+                    src="{{ .Permalink }}"
+                    alt="{{ $.Title }}"
+                    loading="lazy"
+                  />
+                </figure>
+              {{ end }}
+            </div>
+          {{ end }}
+
+          {{ with .Content }}
+            <div class="portfolio-print__content type-body">
+              {{ . }}
+            </div>
+          {{ end }}
+        </article>
       {{ end }}
-    </article>
-    {{ end }}
 
-    <footer class="portfolio-print__footer">
-      <p>{{ if eq $.Language.Lang "sv" }}Se fullständig ansökan online{{ else }}View full application online{{ end }}: <strong>{{ .Params.back_url | default (print .Site.BaseURL .Params.taxonomy "/" .Params.company_name "/") }}</strong></p>
-    </footer>
-  </main>
 
-  <!-- Print footer -->
-  <div class="print-footer">
-    <span class="print-footer__label">Portfolio:</span>
-    <span class="print-footer__url">{{ .Permalink }}</span>
-  </div>
-</body>
+      <footer class="portfolio-print__footer">
+        <p>
+          {{ if eq $.Language.Lang "sv" }}
+            Se fullständig ansökan online
+          {{ else }}
+            View full application online
+          {{ end }}:
+          <strong
+            >{{ .Params.back_url | default (print .Site.BaseURL .Params.taxonomy "/" .Params.company_name "/") }}</strong
+          >
+        </p>
+      </footer>
+    </main>
+
+    <!-- Print footer -->
+    <div class="print-footer">
+      <span class="print-footer__label">Portfolio:</span>
+      <span class="print-footer__url">{{ .Permalink }}</span>
+    </div>
+  </body>
 </html>

--- a/layouts/taxonomy/client.html
+++ b/layouts/taxonomy/client.html
@@ -1,7 +1,7 @@
 {{ partial "header-client.html" . }}
 
 {{ $style := resources.Get "css/clientpage.css" }}
-{{ $css := slice $style | resources.Concat "client.css" }}
+{{ $css := slice $style | resources.Concat "client.css" | minify | fingerprint }}
 
 
 <link
@@ -19,21 +19,32 @@
 <div class="content application-page use-subgrid">
   <nav class="application-breadcrumb show-on-client reveal">
     <ul>
-      <li class="application-breadcrumb__item application-breadcrumb__item--caps">
-        <a class="application-breadcrumb__link" href="{{ .Site.BaseURL | relLangURL }}">
+      <li
+        class="application-breadcrumb__item application-breadcrumb__item--caps"
+      >
+        <a
+          class="application-breadcrumb__link"
+          href="{{ .Site.BaseURL | relLangURL }}"
+        >
           <svg class="icon icon--sm" aria-hidden="true">
-            <use href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-home"></use>
+            <use
+              href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-home"
+            ></use>
           </svg>
           <span>Start</span>
         </a>
       </li>
       <li class="application-breadcrumb__separator" aria-hidden="true">
         <svg class="icon icon--xs">
-          <use href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-arrow-right-micro"></use>
+          <use
+            href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-arrow-right-micro"
+          ></use>
         </svg>
       </li>
       <!-- company_name for localstorage -->
-      <li class="application-breadcrumb__item application-page__company application-breadcrumb__item--muted application-breadcrumb__item--caps">
+      <li
+        class="application-breadcrumb__item application-page__company application-breadcrumb__item--muted application-breadcrumb__item--caps"
+      >
         {{ .Params.company_name }}
       </li>
     </ul>
@@ -43,7 +54,9 @@
 
   <!-- Main column -->
   <div class="application-page__main" style="--col: col-start 1 / span 8">
-    <div class="application-page__section application-page__section--letter reveal">
+    <div
+      class="application-page__section application-page__section--letter reveal"
+    >
       <!-- put this just above the section you wanna go to -->
       <a id="letter" data-toc-section="letter"></a>
       <h3 class="type-headline-small section-headline">Letter</h3>
@@ -58,7 +71,9 @@
       <div class="type-information is-muted application-page__meta">
         {{ partial "date.html" . }}
       </div>
-      <p class="type-body">{{ with .Params.body }}{{ . | safeHTML }}{{ end }}</p>
+      <p class="type-body">
+        {{ with .Params.body }}{{ . | safeHTML }}{{ end }}
+      </p>
       <!-- Mobile downloads: all downloads after Letter section -->
       <div class="download-inline">
         <h3 class="type-headline-small section-headline">Download</h3>
@@ -87,7 +102,9 @@
     </div>
 
     <!-- Contact section moved to main column -->
-    <div class="application-page__section application-page__section--contact reveal">
+    <div
+      class="application-page__section application-page__section--contact reveal"
+    >
       <a id="contact" class="anchor-offset" data-toc-section="contact"></a>
       <h3 class="type-headline-small section-headline">Contact</h3>
       {{ partial "contact_info.html" . }}
@@ -100,7 +117,9 @@
     <div class="application-page__sidebar-sticky reveal reveal--delay">
       <!-- Table of Contents -->
       <ul class="toc">
-        <li class="toc__header"><h3 class="type-headline-small">Table of content</h3></li>
+        <li class="toc__header">
+          <h3 class="type-headline-small">Table of content</h3>
+        </li>
         <li class="toc__item">
           <a href="#letter" data-toc-link="letter">Letter</a>
         </li>
@@ -118,9 +137,7 @@
       <!-- Downloads -->
       <div class="download-list">
         <a id="download"></a>
-        <h3 class="type-headline-small section-headline">
-          Download
-        </h3>
+        <h3 class="type-headline-small section-headline">Download</h3>
         {{/* Supports both absolute paths (/images/file.pdf) and page bundle resources (file.pdf) */}}
         {{ partial "download-card.html" (dict "page" . "path" .Params.attach_letter "label" "Letter + CV") }}
         {{ partial "download-card.html" (dict "page" . "path" .Params.attach_portfolio "label" "Portfolio") }}

--- a/layouts/taxonomy/employer.html
+++ b/layouts/taxonomy/employer.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
 {{ $style := resources.Get "css/clientpage.css" }}
-{{ $css := slice $style | resources.Concat "employer.css" }}
+{{ $css := slice $style | resources.Concat "employer.css" | minify | fingerprint }}
 
 
 <link
@@ -19,20 +19,31 @@
 <div class="content application-page use-subgrid">
   <nav class="application-breadcrumb show-on-employer reveal">
     <ul>
-      <li class="application-breadcrumb__item application-breadcrumb__item--caps">
-        <a class="application-breadcrumb__link" href="{{ .Site.BaseURL | relLangURL }}">
+      <li
+        class="application-breadcrumb__item application-breadcrumb__item--caps"
+      >
+        <a
+          class="application-breadcrumb__link"
+          href="{{ .Site.BaseURL | relLangURL }}"
+        >
           <svg class="icon icon--sm" aria-hidden="true">
-            <use href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-home"></use>
+            <use
+              href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-home"
+            ></use>
           </svg>
           <span>Start</span>
         </a>
       </li>
       <li class="application-breadcrumb__separator" aria-hidden="true">
         <svg class="icon icon--xs">
-          <use href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-arrow-right-micro"></use>
+          <use
+            href="{{ "img/svg/sprite.svg?v=20260211b" | absURL }}#icon-arrow-right-micro"
+          ></use>
         </svg>
       </li>
-      <li class="application-breadcrumb__item application-page__company application-breadcrumb__item--muted application-breadcrumb__item--caps">
+      <li
+        class="application-breadcrumb__item application-page__company application-breadcrumb__item--muted application-breadcrumb__item--caps"
+      >
         {{ .Params.company_name }}
       </li>
     </ul>
@@ -41,7 +52,9 @@
 
   <!-- Main column -->
   <div class="application-page__main" style="--col: col-start 1 / span 8">
-    <div class="application-page__section application-page__section--letter reveal">
+    <div
+      class="application-page__section application-page__section--letter reveal"
+    >
       <!-- put this just above the section you wanna go to -->
       <a id="letter" data-toc-section="letter"></a>
       <h3 class="type-headline-small section-headline">Letter</h3>
@@ -56,7 +69,9 @@
       <div class="type-information is-muted application-page__meta">
         {{ partial "date.html" . }}
       </div>
-      <p class="type-body">{{ with .Params.body }}{{ . | safeHTML }}{{ end }}</p>
+      <p class="type-body">
+        {{ with .Params.body }}{{ . | safeHTML }}{{ end }}
+      </p>
       <!-- Mobile downloads: all downloads after Letter section -->
       <div class="download-inline">
         <h3 class="type-headline-small section-headline">Download</h3>
@@ -88,7 +103,9 @@
     </div>
 
     <!-- Contact section moved to main column -->
-    <div class="application-page__section application-page__section--contact reveal">
+    <div
+      class="application-page__section application-page__section--contact reveal"
+    >
       <a id="contact" class="anchor-offset" data-toc-section="contact"></a>
       <h3 class="type-headline-small section-headline">Contact</h3>
       {{ partial "contact_info.html" . }}
@@ -101,7 +118,9 @@
     <div class="application-page__sidebar-sticky reveal reveal--delay">
       <!-- Table of Contents -->
       <ul class="toc">
-        <li class="toc__header"><h3 class="type-headline-small">Table of content</h3></li>
+        <li class="toc__header">
+          <h3 class="type-headline-small">Table of content</h3>
+        </li>
         <li class="toc__item">
           <a href="#letter" data-toc-link="letter">Letter</a>
         </li>
@@ -119,9 +138,7 @@
       <!-- Downloads -->
       <div class="download-list">
         <a id="download"></a>
-        <h3 class="type-headline-small section-headline">
-          Download
-        </h3>
+        <h3 class="type-headline-small section-headline">Download</h3>
         {{/* Supports both absolute paths (/images/file.pdf) and page bundle resources (file.pdf) */}}
         {{ partial "download-card.html" (dict "page" . "path" .Params.attach_letter "label" "Letter + CV") }}
         {{ partial "download-card.html" (dict "page" . "path" .Params.attach_portfolio "label" "Portfolio") }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -92,3 +92,17 @@
   for = "/images/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+
+# Hugo fingerprints all CSS/JS (content hash in the filename), so they can be
+# cached forever — a content change produces a new URL. Every referenced .css
+# and .js bundle is fingerprinted (the page-bundles, the main bundle, the
+# lazy/standalone scripts, and the client/employer/print bundles).
+[[headers]]
+  for = "/*.css"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*.js"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
## Summary

`netlify.toml` only cached `/fonts` and `/images` long-term. Every CSS/JS bundle was served with Netlify's short default TTL, so repeat visitors re-downloaded the (unchanged) stylesheets and script bundles. Lighthouse flagged this as **"Serve static assets with an efficient cache policy" / "Use efficient cache lifetimes"** — and unlike the text-compression noise, this one is a real production gap.

## Change

Hugo fingerprints all CSS/JS (content hash in the filename), so they are safe to cache forever — any content change produces a new URL. Added immutable 1-year `Cache-Control` for `/*.css` and `/*.js`.

To make that blanket rule **safe**, the three remaining non-fingerprinted CSS bundles are now fingerprinted too (they were built with `resources.Concat` but never `| fingerprint`):

| Template | Bundle |
|----------|--------|
| `layouts/taxonomy/client.html` | `client.css` |
| `layouts/taxonomy/employer.html` | `employer.css` |
| `layouts/portfolio-print/single.html` | `portfolio-print-bundle.css` |

## Verification (production Hugo build, v0.154.2)

Built the full site and enumerated every `.css`/`.js` in `public/`:
- **Every referenced** asset is now fingerprinted (page bundles, main bundle, standalone scripts, and the three client/employer/print bundles).
- The only non-fingerprinted file left is `js/darkmode-initial.js` — an unreferenced orphan (its `<script>` is commented out in `head.html`), so caching it immutably is harmless.
- Build clean (only the pre-existing, unrelated goldmark raw-HTML warnings).

So the immutable rule never applies to a file that can change under a stable URL.

## Notes
- `darkmode-initial.js` looks like dead output worth removing in a separate cleanup.
- Netlify applies `Cache-Control` per the `for` globs; worth a quick check of response headers on the deploy to confirm the bundles come back with `immutable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_