### PR TITLE
chore: remove dead theme-color-cache reader from head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -523,20 +523,6 @@
       var storedPalette = localStorage.getItem("theme-palette") || "standard";
       document.documentElement.setAttribute("data-palette", storedPalette);
 
-      // Restore cached theme-color to prevent flash on reload
-      var cachedThemeColor = localStorage.getItem("theme-color-cache");
-      if (cachedThemeColor) {
-        var tcMetas = document.querySelectorAll('meta[name="theme-color"]');
-        for (var i = 0; i < tcMetas.length; i++) {
-          tcMetas[i].setAttribute("content", cachedThemeColor);
-        }
-        // For Pantone, --coty-role-surface drives --surface-page which nav uses.
-        // Set it from cache so nav/header don't flash before CotyScale runs.
-        // CotyScale will overwrite this with the proper oklch value on init.
-        if (storedPalette === "pantone") {
-          document.documentElement.style.setProperty("--coty-role-surface", cachedThemeColor);
-        }
-      }
       var storedCotyYear = localStorage.getItem("theme-coty-year") || "2026";
       document.documentElement.setAttribute("data-coty-year", storedCotyYear);
 


### PR DESCRIPTION
## Summary

The inline `<head>` bootstrap read `localStorage["theme-color-cache"]` before paint to pre-seed `<meta theme-color>` and, for Pantone, `--coty-role-surface` (to avoid a flash before CotyScale runs). But **nothing ever wrote that key** — its only writer, `darkmode.js` `updateThemeColorMeta()`, was never called — so the cache was always empty and the entire block was dead.

## Change
Remove the dead reader block from `head.html`. **No behavior change** — the `if (cachedThemeColor)` branch never executed.

## Why remove rather than wire it up
- **The flash is already prevented.** #199 injects CotyScale from the inline `<head>` (earlier than the old deferred bundle) and `theme-loading` suppresses transitions until init — confirmed flash-free on iOS.
- **Wiring it up could regress.** The cache stores a single color, but the correct color depends on **mode (light/dark) + COTY year**. A returning user whose cached color was for the other mode would get a *wrong-color* pre-seed before paint — worse than none. Doing it safely means keying by mode+year, i.e. real complexity for a niche case (returning Pantone user on a slow connection) that's already covered.
- `animateThemeColorMeta()` (which *is* called) still updates the `theme-color` meta at runtime on mode/palette changes, so browser chrome still gets the right color.

## Relationship to other PRs
Pairs with **#202**, which removes the dead *writer* (`updateThemeColorMeta`). The two are complementary and order-independent (the cache was dead with or without either) — different files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_