### PR TITLE
fix: restore vertical spacing on plain list pages (writing/texter/etc.)

### DIFF
--- a/assets/css/components/article-card.css
+++ b/assets/css/components/article-card.css
@@ -38,9 +38,11 @@ article {
 .summary-card:hover .header-image {
   -webkit-filter: contrast(1.2);
   filter: contrast(1.2);
-  transition: -webkit-filter var(--motion-duration-xslow) var(--motion-ease-standard);
+  transition: -webkit-filter var(--motion-duration-xslow)
+    var(--motion-ease-standard);
   transition: filter var(--motion-duration-xslow) var(--motion-ease-standard);
-  transition: filter var(--motion-duration-xslow) var(--motion-ease-standard), -webkit-filter var(--motion-duration-xslow) var(--motion-ease-standard);
+  transition: filter var(--motion-duration-xslow) var(--motion-ease-standard),
+    -webkit-filter var(--motion-duration-xslow) var(--motion-ease-standard);
 }
 
 .related-items__image {
@@ -50,6 +52,15 @@ article {
 /* ==========================================================================
    List Page Grid Layout
    ========================================================================== */
+
+/* Base vertical rhythm for every list page. A `.use-subgrid` container
+   inherits the parent grid's columns + column-gap but NOT its row-gap, and
+   the article items carry `margin-bottom: 0`, so each list must set its own
+   row-gap. Without this, plain `.content.list` pages (writing, texter,
+   newsletter, post, taxonomy) collapse with no spacing between items. */
+.content.list {
+  row-gap: var(--spacing-32);
+}
 
 .content.list.tag-page {
   row-gap: var(--spacing-32);


### PR DESCRIPTION
## Summary

The writing/texter list pages (and other plain list pages) had **zero vertical spacing between items** — titles butted directly against the previous item's tags.

## Root cause (pre-existing, from 2026-06-03)
List pages render `<div class="content list use-subgrid">` with each item as a grid row, and `.content.list article` carries `margin-bottom: 0` — so the spacing between items must come from the grid's **`row-gap`**. But a CSS `subgrid` container inherits the parent grid's columns and *column*-gap, **not** its row-gap, so each list must set its own.

The subgrid migration in `5a3dab1` ("Migrate all list and client layouts to use page subgrid") added `row-gap: var(--spacing-32)` to `.content.list.tag-page` and `.content.list.works-list`, **but not to the plain `.content.list`**. So writing, texter, newsletter, post and taxonomy list pages collapsed to no spacing. (Not related to any recent change — confirmed none of the recent PRs touched `article-card.css`, `grid.css`, or the list templates.)

## Fix
Add `row-gap: var(--spacing-32)` to the base `.content.list`, so every list page gets the standard rhythm.

## Scope / safety
- **Affected (fixed):** writing, texter, newsletter, nyhetsbrev, post, taxonomy/terms lists — they all share the `margin-bottom: 0` rule and were equally cramped.
- **Unaffected:** the **ui-library** does not use `.content.list` at all (verified: 0 occurrences), and `works`/`tag` lists already had the same row-gap (the specific rules are now redundant duplicates of the same value — left in place, can be cleaned up later).

## Verification
Production Hugo build (v0.154.2): the rule `.content.list{row-gap:var(--spacing-32)}` is in the CSS bundle, and the ui-library output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_