### PR TITLE
Fix coty-transport trigger disappearing after grid toggle on mobile

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -45,6 +45,13 @@ html[data-grid-overlay] .top-menu {
   z-index: 800;
 }
 
+/* Header-carried grain — reuses .grain-overlay styling but is clipped to the
+   header so it stays fixed with the sticky header on mobile. Hidden by default;
+   only shown at the mobile breakpoint where the header sticks (see below). */
+.grain-overlay--nav {
+  display: none;
+}
+
 /* ==========================================================================
    Navigation Lists
    ========================================================================== */
@@ -259,6 +266,17 @@ html[data-grid-overlay] .top-menu {
 
   :root {
     --size-header-height-neg: -4.5rem;
+  }
+
+  /* Lift the sticky header above the page grain (z 850) so its opaque surface
+     hides the scrolling grain, then show the header's own grain — which moves
+     with the header — so the effect stays put while the header is fixed. */
+  .top-menu {
+    z-index: 851;
+  }
+
+  .grain-overlay--nav {
+    display: block;
   }
 
   .top-menu.relative {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -557,7 +557,7 @@ video {
 }
 
 .grain-overlay::before {
-  background-image: url("../img/svg/grain-black.svg");
+  background-image: url("img/svg/grain-black.svg");
   background-size: 720px 720px;
   background-position: 0 0;
   mix-blend-mode: multiply;
@@ -565,7 +565,7 @@ video {
 }
 
 .grain-overlay::after {
-  background-image: url("../img/svg/grain-white.svg");
+  background-image: url("img/svg/grain-white.svg");
   background-size: 940px 940px;
   background-position: 18px 12px;
   mix-blend-mode: screen;

--- a/assets/js/grid-overlay.js
+++ b/assets/js/grid-overlay.js
@@ -106,6 +106,14 @@
     if (settingsToggle) {
       settingsToggle.setAttribute("aria-expanded", "false");
     }
+
+    // Clear the open-state attribute so CSS-driven UI (e.g. the coty-transport
+    // trigger) is restored. Without this the three dots stay hidden on mobile
+    // until another close path removes the attribute.
+    if (document.documentElement.hasAttribute("data-settings-panel-open")) {
+      document.documentElement.removeAttribute("data-settings-panel-open");
+      window.dispatchEvent(new window.CustomEvent("theme:sheet-closed"));
+    }
   }
 
   function updateUI(on) {

--- a/assets/js/header-hide.js
+++ b/assets/js/header-hide.js
@@ -101,6 +101,16 @@
           curDirection = 0;
           prevDirection = 0;
           lastY = prevScroll;
+          // Start in-flow when at the top so the very first downward scroll moves
+          // the header with the page immediately. Otherwise the header only gets
+          // '.relative' if a scroll event happens to fire while curScroll < 10,
+          // which a fast flick after reload can skip — leaving it stuck (sticky)
+          // until the hide threshold (300px) is crossed.
+          if (prevScroll < 10) {
+            header.classList.add('relative');
+          } else {
+            header.classList.remove('relative');
+          }
           w.addEventListener('scroll', checkScroll);
       };
 

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -1,4 +1,5 @@
 <header id="topmenu" class="top-menu" data-js="top-menu">
+  <div class="grain-overlay grain-overlay--nav" aria-hidden="true"></div>
   <div class="top-menu__container">
     {{ partial "brand.html" . }}
     <nav class="top-menu__nav" aria-label="{{ i18n "menu_title" }}">


### PR DESCRIPTION
Closed in favour of splitting the work into two PRs:

- #206 — Fix coty-transport trigger disappearing after grid toggle on mobile
- #207 — Mobile grain/nav fixes (grain over sticky nav, staging SVG paths, sticky-header reload lag)

The branch for this PR (`claude/pantone-grid-toggle-mobile-rj2ey4`) has been deleted.