### PR TITLE
Fix coty-transport trigger disappearing after grid toggle on mobile

### DIFF
--- a/assets/js/grid-overlay.js
+++ b/assets/js/grid-overlay.js
@@ -106,6 +106,14 @@
     if (settingsToggle) {
       settingsToggle.setAttribute("aria-expanded", "false");
     }
+
+    // Clear the open-state attribute so CSS-driven UI (e.g. the coty-transport
+    // trigger) is restored. Without this the three dots stay hidden on mobile
+    // until another close path removes the attribute.
+    if (document.documentElement.hasAttribute("data-settings-panel-open")) {
+      document.documentElement.removeAttribute("data-settings-panel-open");
+      window.dispatchEvent(new window.CustomEvent("theme:sheet-closed"));
+    }
   }
 
   function updateUI(on) {


### PR DESCRIPTION
## Problem
With Pantone active, opening the transport controls (the three dots) and toggling **grid** on/off caused the three dots to disappear once the bottom sheet auto-closed on mobile. They only reappeared after toggling something else (e.g. grain).

## Root cause
On mobile, the grid toggle closes the settings bottom sheet via `closeSettingsPanelOnMobile()` in `assets/js/grid-overlay.js`. That function hid the panel/overlay but never removed the `data-settings-panel-open` attribute on `<html>`. Since CSS hides the `.coty-transport` trigger while that attribute is present, the trigger stayed hidden until another close path (e.g. the grain toggle's `closePanel()`) cleared it.

## Fix
Clear `data-settings-panel-open` and dispatch the `theme:sheet-closed` event in `closeSettingsPanelOnMobile()`, matching the regular close path so the three dots are restored as soon as the sheet closes.

## Testing
- Verify on mobile (iOS): Pantone active → open three dots → toggle grid → sheet closes → three dots return immediately.
- Desktop behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HL6Kt8g2bQ6YPhMJk5oTCn)_