### PR TITLE
Mobile grain/nav fixes: grain over sticky nav, staging SVG paths, sticky-header reload lag

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -45,6 +45,13 @@ html[data-grid-overlay] .top-menu {
   z-index: 800;
 }
 
+/* Header-carried grain — reuses .grain-overlay styling but is clipped to the
+   header so it stays fixed with the sticky header on mobile. Hidden by default;
+   only shown at the mobile breakpoint where the header sticks (see below). */
+.grain-overlay--nav {
+  display: none;
+}
+
 /* ==========================================================================
    Navigation Lists
    ========================================================================== */
@@ -259,6 +266,17 @@ html[data-grid-overlay] .top-menu {
 
   :root {
     --size-header-height-neg: -4.5rem;
+  }
+
+  /* Lift the sticky header above the page grain (z 850) so its opaque surface
+     hides the scrolling grain, then show the header's own grain — which moves
+     with the header — so the effect stays put while the header is fixed. */
+  .top-menu {
+    z-index: 851;
+  }
+
+  .grain-overlay--nav {
+    display: block;
   }
 
   .top-menu.relative {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -557,7 +557,7 @@ video {
 }
 
 .grain-overlay::before {
-  background-image: url("../img/svg/grain-black.svg");
+  background-image: url("img/svg/grain-black.svg");
   background-size: 720px 720px;
   background-position: 0 0;
   mix-blend-mode: multiply;
@@ -565,7 +565,7 @@ video {
 }
 
 .grain-overlay::after {
-  background-image: url("../img/svg/grain-white.svg");
+  background-image: url("img/svg/grain-white.svg");
   background-size: 940px 940px;
   background-position: 18px 12px;
   mix-blend-mode: screen;

--- a/assets/js/header-hide.js
+++ b/assets/js/header-hide.js
@@ -101,6 +101,16 @@
           curDirection = 0;
           prevDirection = 0;
           lastY = prevScroll;
+          // Start in-flow when at the top so the very first downward scroll moves
+          // the header with the page immediately. Otherwise the header only gets
+          // '.relative' if a scroll event happens to fire while curScroll < 10,
+          // which a fast flick after reload can skip — leaving it stuck (sticky)
+          // until the hide threshold (300px) is crossed.
+          if (prevScroll < 10) {
+            header.classList.add('relative');
+          } else {
+            header.classList.remove('relative');
+          }
           w.addEventListener('scroll', checkScroll);
       };
 

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -1,4 +1,5 @@
 <header id="topmenu" class="top-menu" data-js="top-menu">
+  <div class="grain-overlay grain-overlay--nav" aria-hidden="true"></div>
   <div class="top-menu__container">
     {{ partial "brand.html" . }}
     <nav class="top-menu__nav" aria-label="{{ i18n "menu_title" }}">


### PR DESCRIPTION
Three related mobile fixes around the grain effect and the sticky header.

## 1. Grain stays fixed with the sticky nav on mobile
The page grain (`.grain-overlay`, `position: absolute`) scrolls with the document while the header is sticky, so the grain appeared to swim behind the stationary header and the effect broke over it.

Give the header its own grain layer that **reuses** the existing `.grain-overlay` styling but is clipped to the header, so it moves with the header. At the mobile breakpoint, lift the header above the page grain (`z-index: 851`) so its opaque surface hides the scrolling grain and the header's own (fixed) grain shows instead. Desktop is unchanged (header grain hidden).

Files: `layouts/partials/topmenu.html`, `assets/css/components/navigation.css`

## 2. Grain SVGs 404'd on staging / GitHub Pages sub-path
The grain used `url("../img/svg/...")`, but the bundled CSS is emitted at the site root, so the leading `../` traversed out of the GitHub Pages sub-path and the SVGs 404'd on staging (worked locally only because the dev server resolves relative paths more leniently).

Drop the `../` to match the proven icon fix (see `accordion.css`): a path without a leading slash resolves correctly on both the production root domain and the preview sub-path.

Files: `assets/css/style.css`

## 3. Sticky header stuck right after page reload
The header only became in-flow (`.relative`, so it scrolls away with the page) when a scroll event happened to fire while `scrollY < 10`. After a reload a fast flick often skips that window, so the header stayed pinned until the 300px hide threshold was crossed — the "works after a while / not always" lag.

Initialize `.relative` when the scroll handler is enabled at the top of the page so the first downward scroll moves the header immediately.

Files: `assets/js/header-hide.js`

## Testing
- Mobile (iOS): grain on → scroll → grain over the header stays put with the header; no swim.
- Staging/preview sub-path: grain SVGs load (no 404).
- Reload at top → first scroll down moves header with the page immediately; scroll up reveals it as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HL6Kt8g2bQ6YPhMJk5oTCn)_