### PR TITLE
chore: attribute commits to repo owner via SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git config --local user.name \"tor2dbear\" && git config --local user.email \"tb.hedberg@gmail.com\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add a committed .claude/settings.json SessionStart hook that sets the
local git identity to tor2dbear <tb.hedberg@gmail.com> at the start of
every session, so cloud/web sessions no longer commit as the default
container identity.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S3Xmn1bhEdHoHqeLVaU8UF