### PR TITLE
quality: dedupe backlog candidates so one finding can't fill the list

### DIFF
--- a/scripts/quality/evaluate.mjs
+++ b/scripts/quality/evaluate.mjs
@@ -391,11 +391,34 @@ function formatMarkdown({ policy, mode, lighthouseRuns, axeRuns, blockers, runUr
     }
   }
 
-  backlogItems.sort((a, b) => b.weight - a.weight);
-  const topBacklog = backlogItems.slice(0, 10);
+  // Collapse duplicates: the same Lighthouse audit (or axe violation) is
+  // reported on every run and every route, so one recurring finding would
+  // otherwise fill the entire list and bury everything else. Group by
+  // kind+title, keep the highest weight, and track the distinct routes hit.
+  const byFinding = new Map();
+  for (const item of backlogItems) {
+    const key = `${item.kind}:${item.title}`;
+    const existing = byFinding.get(key);
+    if (existing) {
+      existing.weight = Math.max(existing.weight, item.weight);
+      existing.routes.add(item.route);
+    } else {
+      byFinding.set(key, {
+        kind: item.kind,
+        title: item.title,
+        weight: item.weight,
+        routes: new Set([item.route]),
+      });
+    }
+  }
+
+  const dedupedBacklog = [...byFinding.values()].sort((a, b) => b.weight - a.weight);
+  const topBacklog = dedupedBacklog.slice(0, 10);
   if (topBacklog.length === 0) lines.push("- None");
   for (const item of topBacklog) {
-    lines.push(`- ${item.kind} on \`${item.route}\`: ${safeMarkdown(item.title)}`);
+    const routes = [...item.routes].sort();
+    const scope = routes.length === 1 ? `\`${routes[0]}\`` : `${routes.length} routes`;
+    lines.push(`- ${item.kind} (${scope}): ${safeMarkdown(item.title)}`);
   }
 
   lines.push("");


### PR DESCRIPTION
## Summary

After `uses-text-compression` was silenced (#197), the CI Quality Report's **"Backlog candidates"** filled all 10 slots with **"Reduce unused CSS"** — making it look like 10 problems when it's really **one** finding, repeated.

## Root cause
The backlog builder pushed every Lighthouse opportunity from **every run × every route** with no dedup. Lighthouse-CI runs ~3× per route across 4 routes, so one recurring high-weight finding (`unused CSS`, weight ≈ bytes/1024) appeared ~10–12 times and crowded out genuinely actionable items — including the **2 axe moderate a11y violations** (weight 50) and image-delivery opportunities, which got pushed past the top-10 cutoff.

## Change
Collapse backlog entries by `kind + title`, keeping the highest weight and the set of distinct routes affected. Output now reads one line per distinct finding:

```
- lighthouse (4 routes): Reduce unused CSS
- axe (`/ui-library/`): moderate: <id>
- lighthouse (2 routes): Improve image delivery
```

## Why dedup rather than silence unused-CSS
Unlike text-compression (a false positive — production *does* gzip), unused-CSS is a **real** finding, just low-ROI to fix (all component CSS is ~16KB gzipped and cached immutably for a year via #200; Lighthouse's "unused" also overstates, counting interaction/JS-injected styles). So it stays in the backlog as one honest, deprioritized line — while the dedup lets the *other* real items surface.

## Verification
- `node --check scripts/quality/evaluate.mjs` ✅
- Simulated with report-like data: unused-CSS collapses to one `(4 routes)` entry; the axe moderates and image-delivery items now appear.
- CI-only — no effect on blockers, scoring, or site output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_