### PR TITLE
a11y: give the works list page a level-one heading

### DIFF
--- a/layouts/works/works.html
+++ b/layouts/works/works.html
@@ -1,11 +1,12 @@
 {{ partial "header.html" . }}
 
+
 <div class="content list works-list use-subgrid">
   <div class="post-header">
-    <h2 class="type-headline-small">{{ .Title }}</h2>
+    <h1 class="type-headline-small">{{ .Title }}</h1>
   </div>
   {{ range where .Data.Pages ".Params.hidden" "!=" true }}
-    {{ .Render "summary"}}
+    {{ .Render "summary" }}
   {{ end }}
 </div>
 


### PR DESCRIPTION
## Summary

Fixes one of the two axe **moderate** violations from the Quality Report: `page-has-heading-one` on `/works/`.

The works list page set its title as `<h2 class="type-headline-small">`, so the page had **no `<h1>` at all**. The writing list already uses `<h1>` with the same styling class — this makes works consistent.

`h2 → h1` keeps the styling identical (same class) and the heading order valid: `h1` (page title) → `h2` (work-card titles).

## Verification
Local axe run (Playwright + @axe-core/playwright, same versions as CI): `/works/` goes from **1 moderate → 0**.

## The other moderate (`heading-order` on `/ui-library/`) is intentionally NOT in this PR
On inspection it's much bigger than a quick tweak: the ui-library has **no `<h2>` at all** — `1× h1`, then `28× h3` (accordion sections), `25× h4`, `33× h5`, with the accordions skipping h2 (h1→h3) and frequent h3→h5 skips throughout. Fixing it properly is a page-wide re-level of ~85 headings (paired open/close tags) in a 6000-line internal showcase template (A11y already 98). That deserves its own focused pass rather than riding along here. Tracked for a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_