### PR TITLE
Add Cloudflare Web Analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -143,7 +143,7 @@ DefaultContentLanguage = "en"
   # Get it from the Cloudflare dashboard → Analytics & Logs → Web Analytics →
   # Add a site. The beacon loads in production builds only (see partials/head.html).
   # Leave empty to disable.
-  cloudflare_analytics_token = ""
+  cloudflare_analytics_token = "c6c51a6ea4c246019358361804383602"
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]

--- a/config.toml
+++ b/config.toml
@@ -139,6 +139,11 @@ DefaultContentLanguage = "en"
   newsletter_email_field = "EMAIL"
   dateFormat = "02 Jan 2006, 15:04"
   mainSections = ['writing', 'texter', 'newsletter', 'works']
+  # Cloudflare Web Analytics site token (cookieless, privacy-friendly).
+  # Get it from the Cloudflare dashboard → Analytics & Logs → Web Analytics →
+  # Add a site. The beacon loads in production builds only (see partials/head.html).
+  # Leave empty to disable.
+  cloudflare_analytics_token = ""
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]

--- a/config.toml
+++ b/config.toml
@@ -141,9 +141,13 @@ DefaultContentLanguage = "en"
   mainSections = ['writing', 'texter', 'newsletter', 'works']
   # Cloudflare Web Analytics site token (cookieless, privacy-friendly).
   # Get it from the Cloudflare dashboard → Analytics & Logs → Web Analytics →
-  # Add a site. The beacon loads in production builds only (see partials/head.html).
-  # Leave empty to disable.
+  # Add a site. The beacon loads only when the build's baseURL host matches
+  # cloudflare_analytics_host below, so deploy previews (Netlify, GitHub Pages)
+  # never emit it and pollute production stats. Leave the token empty to disable.
   cloudflare_analytics_token = "c6c51a6ea4c246019358361804383602"
+  # Canonical production host the beacon is allowed to run on. Must match the
+  # host of the baseURL used for the production build.
+  cloudflare_analytics_host = "www.tor-bjorn.com"
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]

--- a/content/english/privacy/index.md
+++ b/content/english/privacy/index.md
@@ -12,7 +12,7 @@ In line with GDPR and to be transparent, this page explains what data I collect 
 - Newsletter sign‑ups: email address submitted via the form in the footer.
 - Contact form: name, email address, subject, and message.
 
-This site does not use first‑party analytics or tracking cookies. However, some third‑party services may set cookies, such as Google reCAPTCHA (used on the contact form).
+For aggregate visitor statistics I use Cloudflare Web Analytics. It is privacy‑first: it sets no cookies, does not fingerprint you, and does not collect any personal data — it only records anonymous, aggregated metrics such as page views and referrers. This site uses no tracking cookies of its own. However, some third‑party services may set cookies, such as Google reCAPTCHA (used on the contact form).
 
 I also use Google Search Console to understand how visitors find the site via Google Search. This does not give me access to personal data about you.
 

--- a/content/swedish/privacy/index.md
+++ b/content/swedish/privacy/index.md
@@ -13,7 +13,7 @@ I enlighet med GDPR och för att vara transparent beskriver jag här vilken data
 - Nyhetsbrev: e‑postadress som skickas via formuläret i sidfoten.
 - Kontaktformulär: namn, e‑postadress, ämne och meddelande.
 
-Sajten använder inga egna analysverktyg eller förstapartscookies. Däremot kan vissa tredjepartstjänster sätta cookies, till exempel Google reCAPTCHA (används i kontaktformuläret).
+För övergripande besöksstatistik använder jag Cloudflare Web Analytics. Det är integritetsvänligt: det sätter inga cookies, fingeravtryckar dig inte och samlar inte in några personuppgifter — det registrerar endast anonym, aggregerad statistik som sidvisningar och hänvisande källor. Sajten använder inga egna spårningscookies. Däremot kan vissa tredjepartstjänster sätta cookies, till exempel Google reCAPTCHA (används i kontaktformuläret).
 
 Jag använder även Google Search Console för att förstå hur besökare hittar hit via Google. Det ger mig inte tillgång till personuppgifter om dig.
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -738,6 +738,18 @@
   {{ end }}
 
 
+  <!-- Cloudflare Web Analytics (cookieless, production only) -->
+  {{ with .Site.Params.cloudflare_analytics_token }}
+    {{ if not $isDevBuild }}
+      <script
+        defer
+        src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "{{ . }}"}'
+      ></script>
+    {{ end }}
+  {{ end }}
+
+
   <!-- Custom JS -->
   {{ range .Site.Params.custom_js }}
     {{ if findRE "https?://" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -738,9 +738,18 @@
   {{ end }}
 
 
-  <!-- Cloudflare Web Analytics (cookieless, production only) -->
+  <!-- Cloudflare Web Analytics (cookieless, production host only) -->
+  {{/* Gate on the canonical production host, not just $isDevBuild: deploy
+       previews (Netlify deploy-preview/branch-deploy, GitHub Pages) build with
+       `hugo --minify` and no HUGO_ENV, so Hugo defaults to the production
+       environment and would otherwise emit the beacon under a preview URL,
+       polluting production analytics. Comparing the build's baseURL host to the
+       configured production host suppresses the beacon everywhere except the
+       real production build. */}}
   {{ with .Site.Params.cloudflare_analytics_token }}
-    {{ if not $isDevBuild }}
+    {{ $prodHost := $.Site.Params.cloudflare_analytics_host }}
+    {{ $buildHost := (urls.Parse $.Site.BaseURL).Hostname }}
+    {{ if and (not $isDevBuild) $prodHost (eq $buildHost $prodHost) }}
       <script
         defer
         src="https://static.cloudflareinsights.com/beacon.min.js"


### PR DESCRIPTION
## Summary

Adds [Cloudflare Web Analytics](https://developers.cloudflare.com/web-analytics/) — a cookieless, privacy-first beacon that requires no DNS/proxy changes (works alongside the existing Netlify hosting).

## Changes

- **`config.toml`** — new `params.cloudflare_analytics_token`, populated with the site token from the Cloudflare dashboard.
- **`layouts/partials/head.html`** — renders the beacon (`static.cloudflareinsights.com/beacon.min.js`) only in **production** builds and only when a token is configured. No tracking in `hugo server`/dev.
- **`content/{english,swedish}/privacy/index.md`** — updated the privacy pages, which previously stated the site used no first-party analytics. New copy describes Cloudflare Web Analytics as cookieless and free of personal data.

## Notes

- Cookieless → no consent banner required.
- The token is public by design (it ships in the client-side beacon), so it's safe to commit.
- After merge and the production deploy, verify under **Web Analytics → tor-bjorn.com** in the Cloudflare dashboard that the snippet is detected; stats begin appearing within minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve5R1y8i3Lepo91rQEgBus

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve5R1y8i3Lepo91rQEgBus)_