### PR TITLE
ci: stop preview deploys from failing + auto-clean gh-pages previews

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -75,6 +75,10 @@ jobs:
           keep_files: true
 
       - name: Wait for GitHub Pages deployment
+        # Non-fatal: GitHub Pages serving lags behind the (successful) deploy,
+        # so a timeout here must not fail the whole job. The preview link is
+        # still posted below and goes live a little later.
+        continue-on-error: true
         run: |
           URL="https://tor2dbear.github.io/portfolio/preview/${{ env.PREVIEW_BRANCH }}/"
           echo "Waiting for $URL to be available..."

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,75 @@
+name: Preview cleanup
+
+# Keeps the gh-pages branch small so GitHub Pages stays fast:
+#   - on PR close (merge or abandon): delete that branch's preview folder
+#   - manual run (workflow_dispatch): delete ALL preview folders, a one-time
+#     reset of the existing backlog. Open PRs simply re-deploy on their next push.
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "all" to delete every preview folder (one-time reset).'
+        required: true
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  # Serialize with itself so two cleanups never race a push to gh-pages.
+  group: gh-pages-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove preview(s)
+        env:
+          EVENT: ${{ github.event_name }}
+          BRANCH: ${{ github.head_ref }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ "$CONFIRM" != "all" ]; then
+              echo "Confirmation was '$CONFIRM' (expected 'all'); nothing done."
+              exit 0
+            fi
+            TARGET="preview"
+          else
+            TARGET="preview/${BRANCH}"
+          fi
+
+          if [ ! -e "$TARGET" ]; then
+            echo "Nothing to remove at '$TARGET'."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm -r --quiet "$TARGET"
+          git commit -m "chore(preview): clean up '$TARGET'"
+
+          # gh-pages may move under us if a deploy lands concurrently; rebase & retry.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed on attempt $attempt."
+              exit 0
+            fi
+            echo "Push rejected; rebasing onto latest gh-pages and retrying..."
+            git pull --rebase origin gh-pages
+          done
+
+          echo "Failed to push after 5 attempts." >&2
+          exit 1


### PR DESCRIPTION
## Why

The **CI & Preview** job kept failing on **"Wait for GitHub Pages deployment"** (hence the "must re-run"). Root cause: GitHub Pages *serving* lags behind the (successful) deploy, and the `gh-pages` branch has been growing without bound — `keep_files: true` keeps **every** preview folder forever. As it bloated, Pages builds got slow enough to exceed the 5-minute poll → 404 the whole time → `exit 1` → fail. Re-running sometimes catches a faster build, which is why it's intermittent.

## Changes (CI-only — no site/Netlify impact)

**1. The wait step no longer fails the job** — `continue-on-error: true`. The build + deploy still happen and the preview link is still posted; a slow Pages publish just doesn't fail everything.

**2. New `preview-cleanup.yml` keeps `gh-pages` small:**
- **On PR close** (merge or abandon) → delete that branch's `preview/<branch>/` folder.
- **Manual `workflow_dispatch`** (type `all` to confirm) → delete **every** preview folder — a one-time reset of the accumulated backlog. Open PRs simply re-deploy on their next push.
- Pushes `rebase-and-retry` so a cleanup never races a concurrent deploy.

## How to use
After merge: run the **Preview cleanup** workflow once (Actions → Preview cleanup → Run workflow → input `all`) to clear the existing backlog. From then on it self-prunes on every PR close.

## Note (separate, recommended)
Enable **Settings → General → "Automatically delete head branches"** so merged branches disappear too — that's also what triggers this cleanup. (Repo setting, can't be done from a PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_