### PR TITLE
ci: serialize preview cleanup with deploy (fix close-during-deploy race)

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -19,9 +19,14 @@ permissions:
   contents: write
 
 concurrency:
-  # Serialize with itself so two cleanups never race a push to gh-pages.
-  group: gh-pages-cleanup
-  cancel-in-progress: false
+  # Share the per-branch lane with the preview deploy (gh-pages.yml) so a
+  # cleanup and an in-flight deploy for the SAME branch are serialized: the
+  # cleanup (newer, fired on PR close) cancels a still-running deploy before it
+  # can push the preview folder back. Cleanups of *different* branches may run
+  # in parallel; the rebase-and-retry push below keeps those from clobbering
+  # each other.
+  group: preview-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   cleanup:


### PR DESCRIPTION
## Why

Follow-up to **#215** (already merged) — a race condition Codex flagged in review.

The `preview-cleanup` workflow used its own concurrency group (`gh-pages-cleanup`), independent of the deploy's per-branch group in `gh-pages.yml`. So if a PR was closed while its preview **deploy was still in flight**, the cleanup could delete `preview/<branch>` and the in-flight deploy would then push the folder **back** (or conflict on the gh-pages push) — leaving a stale preview and defeating the whole point.

## Fix

Use the **same per-branch concurrency group** as the deploy:

```yaml
concurrency:
  group: preview-${{ github.head_ref || github.ref_name }}
  cancel-in-progress: true
```

Now a cleanup and an in-flight deploy for the **same branch** share one lane: the cleanup (newer, fired on PR close) cancels the still-running deploy before removing the folder. Cleanups of *different* branches may still run in parallel — the existing rebase-and-retry push handles those.

CI-only; no site/Netlify impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRX3wZwCmEWnDJro94b4Qs)_