### PR TITLE
Tokenise page spacing into the layout dimension, tune hero line-breaks, add shareable-look links

### DIFF
--- a/assets/css/__tests__/layout-spacing-guard.test.js
+++ b/assets/css/__tests__/layout-spacing-guard.test.js
@@ -1,0 +1,93 @@
+/**
+ * Layout spacing guard
+ *
+ * Locks in the "composition spacing goes through the --layout-* contract" rule so
+ * it can't silently regress: section/hero padding and the article inter-card
+ * margin must read layout tokens (not raw --spacing), the fluid clamps must use
+ * the shared range, and the block-rhythm family must scale via --layout-block-scale.
+ * See docs/layout-dimension-plan.md ("layout-tied vs constant").
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const CSS_ROOT = path.resolve(__dirname, "../");
+const read = (rel) => fs.readFileSync(path.join(CSS_ROOT, rel), "utf8");
+
+// Grab the body of the first FLAT rule (no nested braces) whose selector matches.
+function flatRuleBody(css, selectorRegexSrc) {
+  const m = css.match(new RegExp(selectorRegexSrc + "\\s*\\{([^{}]*)\\}"));
+  return m ? m[1] : null;
+}
+const declaration = (body, prop) => {
+  const m =
+    body &&
+    body.match(new RegExp("(?:^|[;{\\s])" + prop + "\\s*:\\s*([^;]+);"));
+  return m ? m[1].trim() : null;
+};
+
+describe("layout spacing contract", () => {
+  test("fluid range + block-scale knob are defined once in semantic.css", () => {
+    const semantic = read("tokens/semantic.css");
+    expect(semantic).toMatch(/--fluid-floor:/);
+    expect(semantic).toMatch(/--fluid-span:/);
+    // Composition density is its own knob, defaulting to prose rhythm.
+    expect(semantic).toMatch(
+      /--layout-block-scale:\s*var\(--layout-prose-rhythm\)/
+    );
+  });
+
+  test("block-rhythm tokens scale via --layout-block-scale (not raw / not prose)", () => {
+    const semantic = read("tokens/semantic.css");
+    for (const token of [
+      "--layout-block-gap",
+      "--layout-title-gap",
+      "--layout-label-gap",
+      "--layout-card-gap",
+    ]) {
+      const def = declaration(semantic, token);
+      expect(def).toBeTruthy();
+      expect(def).toContain("--layout-block-scale");
+    }
+  });
+
+  test("every layout's section/hero rhythm is a fluid clamp on the shared range", () => {
+    const files = [
+      "tokens/semantic.css", // column default
+      "dimensions/layout/editorial.css",
+      "dimensions/layout/index.css",
+      "dimensions/layout/terminal.css",
+    ];
+    for (const file of files) {
+      const css = read(file);
+      for (const token of ["--layout-section-rhythm", "--layout-hero-rhythm"]) {
+        const def = declaration(css, token);
+        expect(`${file} ${token} → ${def}`).toMatch(/clamp\(/);
+        // endpoints must ride the --spacing-* scale, interpolation the shared range
+        expect(def).toContain("var(--spacing-");
+        expect(def).toContain("var(--fluid-floor)");
+        expect(def).toContain("var(--fluid-span)");
+      }
+    }
+  });
+
+  test("home section/hero padding reads the layout tokens, never raw --spacing", () => {
+    const home = read("pages/home.css");
+    expect(
+      declaration(flatRuleBody(home, "\\.home-section"), "padding")
+    ).toContain("--layout-section-rhythm");
+    expect(
+      declaration(flatRuleBody(home, "\\.hero-section"), "padding")
+    ).toContain("--layout-hero-rhythm");
+    // The removed anti-pattern: a raw spacing padding override on the section/hero
+    // (e.g. `padding: var(--spacing-48) 0`) bypassing the layout token.
+    expect(home).not.toMatch(/padding:\s*var\(--spacing-\d+\)\s+0\s*;/);
+  });
+
+  test("global article inter-card margin reads --layout-card-gap", () => {
+    const card = read("components/article-card.css");
+    expect(
+      declaration(flatRuleBody(card, "\\barticle"), "margin-bottom")
+    ).toContain("--layout-card-gap");
+  });
+});

--- a/assets/css/components/article-card.css
+++ b/assets/css/components/article-card.css
@@ -8,7 +8,9 @@
    ========================================================================== */
 
 article {
-  margin-bottom: 3rem;
+  /* Inter-card rhythm, scaled to the layout (column ×1 = 3rem as before,
+     editorial airier). index + terminal zero this for their flush list/rows. */
+  margin-bottom: var(--layout-card-gap);
 }
 
 /* ==========================================================================
@@ -230,8 +232,7 @@ article {
 /* >= 48em: single-line row — thumb | title | date | tags. */
 @media (min-width: 48em) {
   :root[data-layout="index"] .related-items__item {
-    grid-template-columns:
-      var(--place-card-thumb) minmax(0, 1fr) auto auto;
+    grid-template-columns: var(--place-card-thumb) minmax(0, 1fr) auto auto;
     align-items: center;
     column-gap: var(--layout-col-gap);
     row-gap: 0;

--- a/assets/css/components/summary-card.css
+++ b/assets/css/components/summary-card.css
@@ -88,8 +88,8 @@
 :root[data-layout="index"] article:has(> .summary-card) {
   /* --place-card-thumb (thumbnail column width) is defined on the index layout
      in dimensions/layout/index.css and inherited here. */
-  /* Zero the global `article { margin-bottom: 3rem }` (which gives column/
-     editorial their inter-card rhythm) — index rows are a flush divided list. */
+  /* Zero the global `article` inter-card rhythm (--layout-card-gap, which gives
+     column/editorial their card spacing) — index rows are a flush divided list. */
   margin: 0;
   position: relative;
   display: grid;

--- a/assets/css/components/theme-dropdown.css
+++ b/assets/css/components/theme-dropdown.css
@@ -828,3 +828,62 @@
     z-index: 1000;
   }
 }
+
+/* ============================================================================
+   Share-this-look button (settings panel)
+
+   A full-width labelled action that copies a URL encoding the current layout /
+   typography / mode / palette / Pantone year / blend / grain, so a specific
+   composition can be shared by link. Styled to sit with the effect controls.
+   ============================================================================ */
+.settings-share {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--spacing-8) var(--spacing-12);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-4);
+  background: transparent;
+  color: var(--text-default);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--sans-weight-medium);
+  line-height: var(--line-height-normal);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--motion-duration-base) var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    color var(--motion-duration-base) var(--motion-ease-standard);
+}
+
+.settings-share__icon {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: color var(--motion-duration-base) var(--motion-ease-standard);
+}
+
+.settings-share:hover {
+  background-image: linear-gradient(
+    var(--state-surface-hover),
+    var(--state-surface-hover)
+  );
+  border-color: var(--border-default);
+}
+
+.settings-share:hover .settings-share__icon {
+  color: var(--text-default);
+}
+
+.settings-share:active {
+  background-image: linear-gradient(
+    var(--state-surface-active),
+    var(--state-surface-active)
+  );
+}
+
+.settings-share:focus-visible {
+  outline: none;
+  box-shadow: var(--ring-focus);
+}

--- a/assets/css/dimensions/layout/editorial.css
+++ b/assets/css/dimensions/layout/editorial.css
@@ -8,8 +8,8 @@
    ============================================================================ */
 
 :root[data-layout="editorial"] {
-  --layout-section-rhythm: var(--spacing-96);
-  --layout-hero-rhythm: var(--spacing-160);
+  --layout-section-rhythm: clamp(2.5rem, 0.6rem + 8.43vw, 6rem); /* 40 → 96 */
+  --layout-hero-rhythm: clamp(4rem, 0.75rem + 14.46vw, 10rem); /* 64 → 160 */
   --layout-heading-gap: var(--spacing-48);
   --layout-col-gap: var(--spacing-32);
   /* Body reading measure is set by grid columns (see body placement below),
@@ -37,12 +37,11 @@
 
 /* sm: keep the editorial type bump but a touch gentler than desktop — a long
    single-word title at full 1.15 can nudge the edge on the narrowest phones.
-   Hero rhythm stays tamed (spacing-160 is excessive hero padding on a phone).
-   The earlier overflow was the footer grid gaps, not the type (now fixed). */
+   (Hero rhythm no longer needs a step here — the fluid clamp above already tames
+   it toward the phone floor.) */
 @media (max-width: 47.9375em) {
   :root[data-layout="editorial"] {
     --layout-scale-ratio: 1.1;
-    --layout-hero-rhythm: var(--spacing-96);
   }
 }
 

--- a/assets/css/dimensions/layout/editorial.css
+++ b/assets/css/dimensions/layout/editorial.css
@@ -17,6 +17,15 @@
   --layout-scale-ratio: 1.15;
   --layout-prose-rhythm: 1.25;
 
+  /* Airy page rhythm. The hero section already carries a generous
+     --layout-hero-rhythm (spacing-160), so the heading's own top pad is trimmed
+     to avoid an excessive double gap; inner-page and about/contact gaps open up
+     to match the magazine spacing. */
+  --layout-hero-heading-top: var(--spacing-24);
+  --layout-content-top: var(--spacing-96);
+  --layout-about-cv-gap: var(--spacing-96);
+  --layout-contact-info-gap: var(--spacing-96);
+
   /* Drop cap (anfang) — tune here in one place. Leading/offsets are relative to
      the cap's own font-size so they scale together; watch the mono typeface,
      which is widest. */

--- a/assets/css/dimensions/layout/editorial.css
+++ b/assets/css/dimensions/layout/editorial.css
@@ -8,8 +8,20 @@
    ============================================================================ */
 
 :root[data-layout="editorial"] {
-  --layout-section-rhythm: clamp(2.5rem, 0.6rem + 8.43vw, 6rem); /* 40 → 96 */
-  --layout-hero-rhythm: clamp(4rem, 0.75rem + 14.46vw, 10rem); /* 64 → 160 */
+  --layout-section-rhythm: clamp(
+    var(--spacing-40),
+    calc(
+      var(--spacing-40) + 56 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-96)
+  ); /* 40 → 96 */
+  --layout-hero-rhythm: clamp(
+    var(--spacing-64),
+    calc(
+      var(--spacing-64) + 96 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-160)
+  ); /* 64 → 160 */
   --layout-heading-gap: var(--spacing-48);
   --layout-col-gap: var(--spacing-32);
   /* Body reading measure is set by grid columns (see body placement below),

--- a/assets/css/dimensions/layout/index.css
+++ b/assets/css/dimensions/layout/index.css
@@ -7,8 +7,12 @@
    ============================================================================ */
 
 :root[data-layout="index"] {
-  --layout-section-rhythm: var(--spacing-40);
-  --layout-hero-rhythm: var(--spacing-64);
+  --layout-section-rhythm: clamp(
+    1.5rem,
+    0.96rem + 2.41vw,
+    2.5rem
+  ); /* 24 → 40 */
+  --layout-hero-rhythm: clamp(2.5rem, 1.69rem + 3.61vw, 4rem); /* 40 → 64 */
   --layout-heading-gap: var(--spacing-16);
   --layout-col-gap: var(--spacing-16);
   --layout-row-gap: var(--spacing-16);

--- a/assets/css/dimensions/layout/index.css
+++ b/assets/css/dimensions/layout/index.css
@@ -15,6 +15,15 @@
   --layout-scale-ratio: 0.9;
   --layout-prose-rhythm: 0.8;
 
+  /* Dense: pull the page in tight. The hero heading's own top pad is nearly
+     removed (the hero section already supplies --layout-hero-rhythm), so the
+     lead sits close to the top instead of floating mid-screen; inner-page and
+     about/contact gaps tighten to match the packed rhythm. */
+  --layout-hero-heading-top: var(--spacing-8);
+  --layout-content-top: var(--spacing-40);
+  --layout-about-cv-gap: var(--spacing-40);
+  --layout-contact-info-gap: var(--spacing-40);
+
   /* Placement API: works/related card thumbnail column width. Defined once here
      so every consumer (summary rows + related rows) inherits it; overridable per
      context. Widens on desktop where the row goes single-line. */

--- a/assets/css/dimensions/layout/index.css
+++ b/assets/css/dimensions/layout/index.css
@@ -8,11 +8,19 @@
 
 :root[data-layout="index"] {
   --layout-section-rhythm: clamp(
-    1.5rem,
-    0.96rem + 2.41vw,
-    2.5rem
+    var(--spacing-24),
+    calc(
+      var(--spacing-24) + 16 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-40)
   ); /* 24 → 40 */
-  --layout-hero-rhythm: clamp(2.5rem, 1.69rem + 3.61vw, 4rem); /* 40 → 64 */
+  --layout-hero-rhythm: clamp(
+    var(--spacing-40),
+    calc(
+      var(--spacing-40) + 24 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-64)
+  ); /* 40 → 64 */
   --layout-heading-gap: var(--spacing-16);
   --layout-col-gap: var(--spacing-16);
   --layout-row-gap: var(--spacing-16);

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -38,11 +38,19 @@
 :root[data-layout="terminal"] {
   /* Composition tokens */
   --layout-section-rhythm: clamp(
-    1.5rem,
-    0.96rem + 2.41vw,
-    2.5rem
+    var(--spacing-24),
+    calc(
+      var(--spacing-24) + 16 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-40)
   ); /* 24 → 40 */
-  --layout-hero-rhythm: clamp(1rem, 0.73rem + 1.2vw, 1.5rem); /* 16 → 24 */
+  --layout-hero-rhythm: clamp(
+    var(--spacing-16),
+    calc(
+      var(--spacing-16) + 8 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-24)
+  ); /* 16 → 24 */
   --layout-heading-gap: var(--spacing-16);
   --layout-col-gap: var(--spacing-16);
   --layout-row-gap: var(--spacing-16);

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -45,6 +45,14 @@
   --layout-scale-ratio: 1;
   --layout-prose-rhythm: 0.9;
 
+  /* Page/section spacing knobs — the whole stream sits on one tight gap so the
+     buffer reads as a continuous terminal session (replaces the old direct
+     .content / .startpage-heading padding override below). */
+  --layout-content-top: var(--spacing-24);
+  --layout-hero-heading-top: var(--spacing-24);
+  --layout-about-cv-gap: var(--spacing-24);
+  --layout-contact-info-gap: var(--spacing-24);
+
   /* The terminal window: the 12-col grid's side tracks absorb everything
      beyond ~48rem, so header, main and footer (which share the grid template
      in style.css) all narrow to the same centred stream. */
@@ -104,12 +112,9 @@
   transition: none !important;
 }
 
-/* Page containers carry a generous top padding; the stream starts right
-   under the statusbar. */
-:root[data-layout="terminal"] .content,
-:root[data-layout="terminal"] .startpage-heading {
-  padding-top: var(--spacing-24);
-}
+/* Page-container top padding (.content / .startpage-heading) now rides the
+   --layout-content-top / --layout-hero-heading-top tokens set above, so the
+   stream still starts right under the statusbar. */
 
 /* ============================================================================
    One type size

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1478,6 +1478,42 @@
   font-family: var(--font-mono);
 }
 
+/* Share action: a plain command line, not a boxed button (the base .settings-share
+   carries a border/pill that reads as chrome the terminal doesn't use). Strip it
+   to text and drop the icon like every other panel control; hover underlines like
+   the terminal's links. */
+:root[data-layout="terminal"] .settings-panel .settings-share {
+  display: inline-flex;
+  align-items: baseline;
+  width: auto;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  font-size: var(--terminal-font-size);
+  font-weight: 400;
+  line-height: var(--terminal-line-height);
+  color: var(--text-default);
+}
+
+:root[data-layout="terminal"] .settings-panel .settings-share:hover,
+:root[data-layout="terminal"] .settings-panel .settings-share:focus-visible {
+  background: none;
+  box-shadow: none;
+  outline: none;
+  text-decoration: underline;
+}
+
+:root[data-layout="terminal"] .settings-panel .settings-share__icon {
+  display: none;
+}
+
+:root[data-layout="terminal"] .settings-panel .settings-share__label {
+  text-transform: lowercase;
+}
+
 /* ============================================================================
    Pantone player → background job
    The floating pill becomes job-control output pinned to the buffer's bottom

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -37,8 +37,12 @@
 
 :root[data-layout="terminal"] {
   /* Composition tokens */
-  --layout-section-rhythm: var(--spacing-40);
-  --layout-hero-rhythm: var(--spacing-24);
+  --layout-section-rhythm: clamp(
+    1.5rem,
+    0.96rem + 2.41vw,
+    2.5rem
+  ); /* 24 → 40 */
+  --layout-hero-rhythm: clamp(1rem, 0.73rem + 1.2vw, 1.5rem); /* 16 → 24 */
   --layout-heading-gap: var(--spacing-16);
   --layout-col-gap: var(--spacing-16);
   --layout-row-gap: var(--spacing-16);

--- a/assets/css/pages/home.css
+++ b/assets/css/pages/home.css
@@ -336,12 +336,12 @@
 }
 
 .contact-content {
-  row-gap: var(--spacing-32);
+  row-gap: var(--layout-block-gap);
   align-items: start;
 }
 
 .hero-title {
-  margin-bottom: var(--spacing-24);
+  margin-bottom: var(--layout-title-gap);
 }
 
 .home-page .contact-info {
@@ -428,22 +428,8 @@
   }
 }
 
-/* sm: <= 47.9375em */
-@media (max-width: 47.9375em) {
-  /* about-main placement now handled by stepped-6-6 sm collapse */
-
-  .home-section {
-    padding: var(--spacing-48) 0;
-  }
-
-  .hero-section {
-    padding: var(--spacing-64) 0;
-  }
-}
-
-/* xs: <= 29.9375em */
-@media (max-width: 29.9375em) {
-  .home-section {
-    padding: var(--spacing-32) 0;
-  }
-}
+/* Section + hero padding are no longer stepped down here: the rhythm rides the
+   fluid --layout-section-rhythm / --layout-hero-rhythm tokens (see the layout
+   dimension files), which compact themselves toward their phone floor. Overriding
+   the property here would have ignored the layout's own rhythm on small screens
+   (it did — index/terminal were being bumped larger than intended). */

--- a/assets/css/pages/home.css
+++ b/assets/css/pages/home.css
@@ -103,34 +103,109 @@
   font-weight: inherit;
 }
 
-/* Below ~680px the hero becomes viewport-constrained and the lead + role no
-   longer fit one line, so the growing/shrinking role would re-wrap the sentence
-   (the page jumps, the em dash hops between lines). Drop the role onto its own
-   line here: the lead above is then fixed text that wraps identically whatever
-   the role is, and only the role's own line changes. The break after the role
-   is hidden since the block already starts a new line for the following text. */
-@media (max-width: 42.5em) {
-  .role-swapper {
+/* Role line-break, tuned per layout + typeface.
+
+   When the hero is viewport-constrained the lead + the longest role stop fitting
+   on one line, so the growing/shrinking role would re-wrap the sentence (the page
+   jumps, the em dash hops between lines). Below each threshold we drop the role
+   onto its own line: the lead above is then fixed text that wraps identically
+   whatever the role is, and only the role's own line changes. The <br> after the
+   role is hidden since the block already starts a new line for what follows.
+
+   The threshold tracks the hero font size — set by the LAYOUT (index dials the
+   hero down to ~text-lg; terminal flattens it to ~text-base; editorial scales it
+   up 1.15×) — and the typeface WIDTH (mono/technical is widest, so it wraps
+   earliest). Values were verified against the longest role with Chrome
+   screenshots at the boundary widths. Each rule is scoped to its layout so the
+   ranges never fight; the mono bump is a wider, more-specific companion to each
+   layout's base break. */
+
+/* Column (default) — the generous ~30–36px hero. */
+@media (max-width: 38em) {
+  :root:not([data-layout="editorial"]):not([data-layout="index"]):not(
+      [data-layout="terminal"]
+    )
+    .role-swapper {
     display: block;
   }
 
-  .hero-role-br {
+  :root:not([data-layout="editorial"]):not([data-layout="index"]):not(
+      [data-layout="terminal"]
+    )
+    .hero-role-br {
     display: none;
   }
 }
 
-/* Per-typeface tuning: the mono typeface (technical) is much wider, so the lead
-   + role stop fitting on one line well before the default breakpoint. Break the
-   role onto its own line up to 800px for it (combine the typography dimension
-   with the media query). The same pattern extends to a typeface+layout combo,
-   e.g. :root[data-typography="technical"][data-layout="editorial"], since
-   editorial scales the type up (1.15×) and wraps a little sooner still. */
-@media (max-width: 50em) {
-  :root[data-typography="technical"] .role-swapper {
+@media (max-width: 42em) {
+  :root:not([data-layout="editorial"]):not([data-layout="index"]):not(
+      [data-layout="terminal"]
+    )[data-typography="technical"]
+    .role-swapper {
     display: block;
   }
 
-  :root[data-typography="technical"] .hero-role-br {
+  :root:not([data-layout="editorial"]):not([data-layout="index"]):not(
+      [data-layout="terminal"]
+    )[data-typography="technical"]
+    .hero-role-br {
+    display: none;
+  }
+}
+
+/* Editorial — the hero is scaled up 1.15×, so it wraps a step sooner. */
+@media (max-width: 42em) {
+  :root[data-layout="editorial"] .role-swapper {
+    display: block;
+  }
+
+  :root[data-layout="editorial"] .hero-role-br {
+    display: none;
+  }
+}
+
+@media (max-width: 46em) {
+  :root[data-layout="editorial"][data-typography="technical"] .role-swapper {
+    display: block;
+  }
+
+  :root[data-layout="editorial"][data-typography="technical"] .hero-role-br {
+    display: none;
+  }
+}
+
+/* Index — the hero is dialled down to ~text-lg, so the sentence keeps fitting far
+   narrower; only break on small phones. */
+@media (max-width: 26em) {
+  :root[data-layout="index"] .role-swapper {
+    display: block;
+  }
+
+  :root[data-layout="index"] .hero-role-br {
+    display: none;
+  }
+}
+
+@media (max-width: 30em) {
+  :root[data-layout="index"][data-typography="technical"] .role-swapper {
+    display: block;
+  }
+
+  :root[data-layout="index"][data-typography="technical"] .hero-role-br {
+    display: none;
+  }
+}
+
+/* Terminal — a flat ~text-base hero with a still (non-typewriter) role. One
+   breakpoint covers every typeface (incl. the wider mono); the frozen role means
+   a wrap can't jump, but keeping the whole role on its own line avoids splitting
+   it mid-word on narrow phones. */
+@media (max-width: 28em) {
+  :root[data-layout="terminal"] .role-swapper {
+    display: block;
+  }
+
+  :root[data-layout="terminal"] .hero-role-br {
     display: none;
   }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -206,7 +206,7 @@ body.darkmodeTransition
 }
 
 .startpage-heading h1 {
-  margin-bottom: var(--spacing-24);
+  margin-bottom: var(--layout-title-gap);
 }
 
 .content.thankyou h3,
@@ -797,15 +797,15 @@ p:empty {
 .content.post > .project-info {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  padding: 2rem 2rem;
-  margin-bottom: var(--spacing-32);
+  padding: var(--spacing-32);
+  margin-bottom: var(--layout-block-gap);
   background-color: var(--surface-default);
   /* Self-contained responsive placement (previously inherited from the
      .content.post AD-mapping fallback below): span 10 desktop, 12 tablet, 4
      mobile. Kept identical so column stays a no-op; layout overrides win above. */
   --col: col-start 1 / span 10;
   grid-column: var(--col);
-  grid-column-gap: 3rem;
+  grid-column-gap: var(--spacing-48);
   transition: background-color
       var(--theme-transition-duration, var(--motion-duration-xslow))
       var(--motion-ease-theme),
@@ -912,7 +912,7 @@ p:empty {
 @media (max-width: 63.9375em) {
   .content.post > .project-info {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-column-gap: 2rem;
+    grid-column-gap: var(--spacing-32);
   }
 
   .content.post > .project-info.project-info--cols-1 {
@@ -924,7 +924,7 @@ p:empty {
 @media (max-width: 47.9375em) {
   .content.post > .project-info {
     grid-template-columns: minmax(0, 1fr);
-    grid-column-gap: 1.5rem;
+    grid-column-gap: var(--spacing-24);
   }
 }
 
@@ -995,11 +995,11 @@ p:empty {
 }
 
 .about-cv__title {
-  margin-bottom: var(--spacing-32);
+  margin-bottom: var(--layout-block-gap);
 }
 
 .about-main__headline {
-  margin-bottom: var(--spacing-32);
+  margin-bottom: var(--layout-block-gap);
 }
 
 .about-cv__section {
@@ -1008,7 +1008,7 @@ p:empty {
      which staggered the column tops. A block-level BFC keeps each section
      intact (break-inside: avoid) while the columns start flush at the top. */
   display: flow-root;
-  margin-bottom: var(--spacing-32);
+  margin-bottom: var(--layout-block-gap);
   /* The fade itself (opacity/transform/transition + reduced-motion) comes from
      the shared .reveal rules — each section carries .reveal and is revealed
      individually on scroll (reveal-on-scroll.js), with a left→right stagger. */
@@ -1023,11 +1023,11 @@ p:empty {
 }
 
 .about-cv__heading {
-  margin-bottom: var(--spacing-16);
+  margin-bottom: var(--layout-label-gap);
 }
 
 .about-cv__text {
-  margin-bottom: var(--spacing-32);
+  margin-bottom: var(--layout-block-gap);
 }
 
 /* md: <= 63.9375em */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -195,14 +195,14 @@ body.darkmodeTransition
 }
 
 .content {
-  padding-top: var(--spacing-80);
+  padding-top: var(--layout-content-top);
   grid-column: content-start / content-end;
   grid-auto-rows: -webkit-max-content;
   grid-auto-rows: max-content;
 }
 
 .startpage-heading {
-  padding-top: var(--spacing-80);
+  padding-top: var(--layout-hero-heading-top);
 }
 
 .startpage-heading h1 {
@@ -298,7 +298,9 @@ footer > * {
     .place-prose
   ):not(.place-article):not(.place-narrow):not(.place-aside):not(
     .place-aside-left
-  ):not(.place-bleed):not(.related-items__title):not(.related-items__item):not(.project-info):not(.place-wide-center) {
+  ):not(.place-bleed):not(.related-items__title):not(.related-items__item):not(
+    .project-info
+  ):not(.place-wide-center) {
   --col: col-start 1 / span 10;
   grid-column: var(--col);
   grid-row: var(--row, auto);
@@ -311,7 +313,9 @@ footer > * {
       .place-prose
     ):not(.place-article):not(.place-narrow):not(.place-aside):not(
       .place-aside-left
-    ):not(.place-bleed):not(.related-items__title):not(.related-items__item):not(.project-info):not(.place-wide-center) {
+    ):not(.place-bleed):not(.related-items__title):not(
+      .related-items__item
+    ):not(.project-info):not(.place-wide-center) {
     --col: col-start 1 / span 12;
   }
 }
@@ -323,7 +327,9 @@ footer > * {
       .place-prose
     ):not(.place-article):not(.place-narrow):not(.place-aside):not(
       .place-aside-left
-    ):not(.place-bleed):not(.related-items__title):not(.related-items__item):not(.project-info):not(.place-wide-center) {
+    ):not(.place-bleed):not(.related-items__title):not(
+      .related-items__item
+    ):not(.project-info):not(.place-wide-center) {
     --col: col-start 1 / span 4;
   }
 }
@@ -970,7 +976,7 @@ p:empty {
 /* || ========== About page ------------------------------------- */
 .about-cv {
   grid-column: content-start / content-end;
-  margin-top: var(--spacing-64);
+  margin-top: var(--layout-about-cv-gap);
 }
 
 .about-cv__icon,
@@ -1063,7 +1069,7 @@ p:empty {
 }
 
 .contact-info {
-  margin-bottom: var(--spacing-64);
+  margin-bottom: var(--layout-contact-info-gap);
 }
 
 /* || ========== Client page ------------------------------------- */

--- a/assets/css/tokens/semantic.css
+++ b/assets/css/tokens/semantic.css
@@ -222,6 +222,18 @@
   --layout-scale-ratio: 1;
   /* Multiplier on prose vertical rhythm (paragraph/heading spacing). 1 = today. */
   --layout-prose-rhythm: 1;
+
+  /* Page/section spacing knobs. These were hardcoded margins/paddings; lifting
+     them into the layout layer lets each composition tune its own breathing room.
+     Defaults equal today's hardcoded values, so column is a visual no-op. */
+  /* .content top padding (inner pages) */
+  --layout-content-top: var(--spacing-80);
+  /* .startpage-heading top pad (home hero) */
+  --layout-hero-heading-top: var(--spacing-80);
+  /* .about-cv margin-top */
+  --layout-about-cv-gap: var(--spacing-64);
+  /* .contact-info margin-bottom */
+  --layout-contact-info-gap: var(--spacing-64);
 }
 
 :root[data-state-intensity="soft"] {

--- a/assets/css/tokens/semantic.css
+++ b/assets/css/tokens/semantic.css
@@ -210,8 +210,12 @@
      visual no-op. Overridden per document via
      html[data-layout="column|editorial|index"]. Same pattern as the
      --state-mix-* knobs above. */
-  --layout-section-rhythm: var(--spacing-64);
-  --layout-hero-rhythm: var(--spacing-96);
+  /* Section + hero rhythm are FLUID: the token itself scales with the viewport
+     (clamp min→max across ~360–1024px), so small screens compact automatically
+     with no per-breakpoint property overrides. Each layout re-clamps to its own
+     min/max; consumers only ever read the token. min = phone, max = desktop. */
+  --layout-section-rhythm: clamp(2rem, 0.92rem + 4.82vw, 4rem); /* 32 → 64 */
+  --layout-hero-rhythm: clamp(4rem, 2.92rem + 4.82vw, 6rem); /* 64 → 96 */
   --layout-heading-gap: var(--spacing-32);
   --layout-col-gap: var(--spacing-24);
   --layout-row-gap: var(--spacing-32);
@@ -234,6 +238,16 @@
   --layout-about-cv-gap: var(--spacing-64);
   /* .contact-info margin-bottom */
   --layout-contact-info-gap: var(--spacing-64);
+
+  /* Block rhythm — the vertical gaps between and under composition blocks
+     (masthead titles, section blocks, cards). Scaled by --layout-prose-rhythm so
+     a denser (index) or airier (editorial) layout carries this rhythm with it;
+     column is ×1 so these equal their raw spacing. Consumers read the token
+     instead of a bare --spacing-*, which is what ties block spacing to the layout
+     dimension. */
+  --layout-block-gap: calc(var(--spacing-32) * var(--layout-prose-rhythm));
+  --layout-title-gap: calc(var(--spacing-24) * var(--layout-prose-rhythm));
+  --layout-label-gap: calc(var(--spacing-16) * var(--layout-prose-rhythm));
 }
 
 :root[data-state-intensity="soft"] {

--- a/assets/css/tokens/semantic.css
+++ b/assets/css/tokens/semantic.css
@@ -211,11 +211,32 @@
      html[data-layout="column|editorial|index"]. Same pattern as the
      --state-mix-* knobs above. */
   /* Section + hero rhythm are FLUID: the token itself scales with the viewport
-     (clamp min→max across ~360–1024px), so small screens compact automatically
-     with no per-breakpoint property overrides. Each layout re-clamps to its own
-     min/max; consumers only ever read the token. min = phone, max = desktop. */
-  --layout-section-rhythm: clamp(2rem, 0.92rem + 4.82vw, 4rem); /* 32 → 64 */
-  --layout-hero-rhythm: clamp(4rem, 2.92rem + 4.82vw, 6rem); /* 64 → 96 */
+     (min on phones → max on desktop), so small screens compact automatically with
+     no per-breakpoint property overrides. Each layout re-clamps to its own min/max
+     (all on the --spacing-* scale); consumers only ever read the token.
+
+     The interpolation range is shared and defined ONCE (--fluid-floor/-span) so no
+     one hand-computes a slope. The pattern for a min→max token is:
+       clamp(MIN, calc(MIN + Δpx * (100vw - floor) / span), MAX)
+     where MIN/MAX are --spacing-* tokens, Δpx is (max − min) in px (the --spacing-N
+     scale is N px), floor = 360px, span = 664 (= 1024 − 360). At 360px it sits at
+     MIN, at 1024px at MAX, linear between. */
+  --fluid-floor: 360px; /* below this a fluid token sits at its MIN */
+  --fluid-span: 664; /* 1024px − 360px, unitless (px) — the divisor */
+  --layout-section-rhythm: clamp(
+    var(--spacing-32),
+    calc(
+      var(--spacing-32) + 32 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-64)
+  ); /* 32 → 64 */
+  --layout-hero-rhythm: clamp(
+    var(--spacing-64),
+    calc(
+      var(--spacing-64) + 32 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+    ),
+    var(--spacing-96)
+  ); /* 64 → 96 */
   --layout-heading-gap: var(--spacing-32);
   --layout-col-gap: var(--spacing-24);
   --layout-row-gap: var(--spacing-32);
@@ -224,8 +245,15 @@
      fixed cap). */
   --layout-measure: none;
   --layout-scale-ratio: 1;
-  /* Multiplier on prose vertical rhythm (paragraph/heading spacing). 1 = today. */
+  /* Two density multipliers, deliberately separate:
+     - --layout-prose-rhythm scales PROSE vertical rhythm (paragraph/heading
+       spacing inside body text).
+     - --layout-block-scale scales COMPOSITION block/card rhythm (the block-gap
+       family below). It defaults to prose-rhythm so it is a no-op today, but a
+       layout can override it alone to be, say, tight in text yet airy in cards.
+     1 = today. */
   --layout-prose-rhythm: 1;
+  --layout-block-scale: var(--layout-prose-rhythm);
 
   /* Page/section spacing knobs. These were hardcoded margins/paddings; lifting
      them into the layout layer lets each composition tune its own breathing room.
@@ -240,17 +268,17 @@
   --layout-contact-info-gap: var(--spacing-64);
 
   /* Block rhythm — the vertical gaps between and under composition blocks
-     (masthead titles, section blocks, cards). Scaled by --layout-prose-rhythm so
-     a denser (index) or airier (editorial) layout carries this rhythm with it;
+     (masthead titles, section blocks, cards). Scaled by --layout-block-scale so a
+     denser (index) or airier (editorial) layout carries this rhythm with it;
      column is ×1 so these equal their raw spacing. Consumers read the token
      instead of a bare --spacing-*, which is what ties block spacing to the layout
      dimension. */
-  --layout-block-gap: calc(var(--spacing-32) * var(--layout-prose-rhythm));
-  --layout-title-gap: calc(var(--spacing-24) * var(--layout-prose-rhythm));
-  --layout-label-gap: calc(var(--spacing-16) * var(--layout-prose-rhythm));
+  --layout-block-gap: calc(var(--spacing-32) * var(--layout-block-scale));
+  --layout-title-gap: calc(var(--spacing-24) * var(--layout-block-scale));
+  --layout-label-gap: calc(var(--spacing-16) * var(--layout-block-scale));
   /* Inter-card rhythm (the global `article` bottom margin). index + terminal
      override to a flush list/row, so this feeds column + editorial. */
-  --layout-card-gap: calc(var(--spacing-48) * var(--layout-prose-rhythm));
+  --layout-card-gap: calc(var(--spacing-48) * var(--layout-block-scale));
 }
 
 :root[data-state-intensity="soft"] {

--- a/assets/css/tokens/semantic.css
+++ b/assets/css/tokens/semantic.css
@@ -248,6 +248,9 @@
   --layout-block-gap: calc(var(--spacing-32) * var(--layout-prose-rhythm));
   --layout-title-gap: calc(var(--spacing-24) * var(--layout-prose-rhythm));
   --layout-label-gap: calc(var(--spacing-16) * var(--layout-prose-rhythm));
+  /* Inter-card rhythm (the global `article` bottom margin). index + terminal
+     override to a flush list/row, so this feeds column + editorial. */
+  --layout-card-gap: calc(var(--spacing-48) * var(--layout-prose-rhythm));
 }
 
 :root[data-state-intensity="soft"] {

--- a/assets/css/utilities/typography.css
+++ b/assets/css/utilities/typography.css
@@ -550,14 +550,18 @@ figcaption {
    CONTENT-SPECIFIC TYPOGRAPHY
    ========================================================================== */
 
-/* Heading-hugs-its-content: a heading sits close to the text right below it.
-   Intentionally a CONSTANT (raw --spacing-8), not layout-scaled — this is
-   typographic proximity/legibility, not compositional density. See the
-   "layout-tied vs constant" note in docs/layout-dimension-plan.md. */
+/* Heading-hugs-its-content: a generic content heading sits close to the text
+   below it (a CONSTANT — typographic proximity, not layout density). The class
+   exclusions are wrapped in :where() so they add NO specificity — otherwise this
+   catch-all (was (0,5,1)) out-specified the dedicated `.content.post .prose h2/h3`
+   rules (0,3,1) and silently forced their margin to 8px. At (0,1,1) it now only
+   governs headings that have no dedicated rule of their own. */
 .content
-  :is(h1, h2, h3, h4, h5, h6):not(.type-headline-1):not(.type-preamble):not(
-    .type-headline-4
-  ):not(.accordion__title) {
+  :is(h1, h2, h3, h4, h5, h6):where(
+    :not(.type-headline-1):not(.type-preamble):not(.type-headline-4):not(
+        .accordion__title
+      )
+  ) {
   margin-bottom: var(--spacing-8);
 }
 
@@ -589,19 +593,22 @@ figcaption {
   margin-bottom: var(--spacing-24);
 }
 
-/* Article prose hierarchy */
+/* Article prose hierarchy. Body headings sit a clear STEP below the preamble
+   (~clamp 3xl→5xl): h2 lands ~24px, h3 ~21px, so a section heading never reads as
+   the same tier as the lead. Margins ride --layout-prose-rhythm to match the body
+   paragraph rhythm (column ×1 = the old 32/16, 24/12). */
 .content.post .prose h2 {
-  font-size: clamp(var(--text-4xl), calc(1.2rem + 0.75vw), var(--text-6xl));
+  font-size: clamp(var(--text-2xl), calc(1.2rem + 0.4vw), var(--text-4xl));
   line-height: var(--line-height-tight);
-  margin-top: var(--spacing-32);
-  margin-bottom: var(--spacing-16);
+  margin-top: calc(var(--spacing-32) * var(--layout-prose-rhythm));
+  margin-bottom: calc(var(--spacing-16) * var(--layout-prose-rhythm));
 }
 
 .content.post .prose h3 {
-  font-size: clamp(var(--text-2xl), calc(1rem + 0.55vw), var(--text-4xl));
+  font-size: clamp(var(--text-xl), calc(1rem + 0.35vw), var(--text-3xl));
   line-height: var(--line-height-tight);
-  margin-top: var(--spacing-24);
-  margin-bottom: var(--spacing-12);
+  margin-top: calc(var(--spacing-24) * var(--layout-prose-rhythm));
+  margin-bottom: calc(var(--spacing-12) * var(--layout-prose-rhythm));
 }
 
 .content.post .prose :is(ul, ol) {

--- a/assets/css/utilities/typography.css
+++ b/assets/css/utilities/typography.css
@@ -550,6 +550,10 @@ figcaption {
    CONTENT-SPECIFIC TYPOGRAPHY
    ========================================================================== */
 
+/* Heading-hugs-its-content: a heading sits close to the text right below it.
+   Intentionally a CONSTANT (raw --spacing-8), not layout-scaled — this is
+   typographic proximity/legibility, not compositional density. See the
+   "layout-tied vs constant" note in docs/layout-dimension-plan.md. */
 .content
   :is(h1, h2, h3, h4, h5, h6):not(.type-headline-1):not(.type-preamble):not(
     .type-headline-4
@@ -557,6 +561,12 @@ figcaption {
   margin-bottom: var(--spacing-8);
 }
 
+/* NOTE (inconsistency to resolve): this raw 16px OVERRIDES the layout-tied
+   `.prose p` rhythm (calc(--spacing-24 * --layout-prose-rhythm)) above, so post
+   paragraphs alone don't scale with the layout. Leave as-is for now — flipping it
+   to `calc(var(--spacing-16) * var(--layout-prose-rhythm))` (a no-op for column)
+   is a deliberate visual change on editorial/index/terminal post pages and needs
+   sign-off. */
 .content.post .prose p {
   margin-bottom: var(--spacing-16);
   hyphens: auto;

--- a/assets/css/utilities/typography.css
+++ b/assets/css/utilities/typography.css
@@ -561,14 +561,11 @@ figcaption {
   margin-bottom: var(--spacing-8);
 }
 
-/* NOTE (inconsistency to resolve): this raw 16px OVERRIDES the layout-tied
-   `.prose p` rhythm (calc(--spacing-24 * --layout-prose-rhythm)) above, so post
-   paragraphs alone don't scale with the layout. Leave as-is for now — flipping it
-   to `calc(var(--spacing-16) * var(--layout-prose-rhythm))` (a no-op for column)
-   is a deliberate visual change on editorial/index/terminal post pages and needs
-   sign-off. */
+/* Post body paragraph rhythm, tied to the layout (column ×1 = 16px as before;
+   editorial airier, index/terminal tighter) so post prose scales like the rest
+   of the composition. */
 .content.post .prose p {
-  margin-bottom: var(--spacing-16);
+  margin-bottom: calc(var(--spacing-16) * var(--layout-prose-rhythm));
   hyphens: auto;
 }
 

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -803,6 +803,10 @@
         "theme-typography-previous",
         localStorage.getItem("theme-typography") || "editorial"
       );
+      // Snap to the top so the boot banner/animation plays in view — otherwise a
+      // visitor part-way down the page enters the terminal mid-stream and misses
+      // it. Instant (not smooth) so it lands before the layout reflows.
+      window.scrollTo(0, 0);
       playTerminalBoot();
     }
     localStorage.setItem("theme-layout", layout);

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -15,6 +15,23 @@
       return;
     }
 
+    // Keep the terminal collapsed marker ("… +N lines (click to expand)") honest:
+    // N is the number of settings the panel lists (mode, typography, layout,
+    // effects, share, language). Recomputed from the DOM so it can't drift when a
+    // section is added or removed. No-op off the terminal layout (the attribute is
+    // only rendered as text there); works for every locale by rewriting the digits.
+    (function syncTerminalExpandCount() {
+      const expandLabel = toggle.getAttribute("data-terminal-expand");
+      if (!expandLabel) {
+        return;
+      }
+      const count = panel.querySelectorAll(".theme-section").length;
+      toggle.setAttribute(
+        "data-terminal-expand",
+        expandLabel.replace(/\+\s*\d+/, "+" + count)
+      );
+    })();
+
     function setSettingsPanelOpenState(isOpen) {
       if (isOpen) {
         document.documentElement.setAttribute(

--- a/assets/js/theme-share.js
+++ b/assets/js/theme-share.js
@@ -69,9 +69,10 @@
   }
 
   function buildUrl() {
+    // Preserve any existing query + hash (e.g. focus-mode client/employer views
+    // like ?view=client&ref=…, or a section anchor) and only add/replace the
+    // theme param, so a shared link reproduces the same page, not just the look.
     var url = new URL(window.location.href);
-    url.hash = "";
-    url.search = "";
     url.searchParams.set("theme", buildPayload());
     return url.toString();
   }

--- a/assets/js/theme-share.js
+++ b/assets/js/theme-share.js
@@ -1,0 +1,155 @@
+/**
+ * Theme share
+ *
+ * Builds a shareable link that encodes the current composition — layout,
+ * typography, colour mode, palette, Pantone year, and the blend/grain effects —
+ * into a single `?theme=` query param, copies it to the clipboard, and toasts.
+ *
+ * The matching decoder runs in the inline head script (partials/head.html) so a
+ * shared link applies before first paint (no flash) and persists to
+ * localStorage. This module also strips a consumed `?theme=` from the address
+ * bar on load, leaving a clean URL while the choice lives on in localStorage.
+ */
+(function () {
+  "use strict";
+
+  var ALLOW = {
+    layout: ["column", "editorial", "index", "terminal"],
+    font: ["editorial", "refined", "expressive", "technical", "system"],
+    mode: ["light", "dark", "system"],
+    palette: ["standard", "pantone"],
+  };
+
+  function attr(name, fallback) {
+    return document.documentElement.getAttribute(name) || fallback;
+  }
+
+  // Read the live composition into an ordered key:value payload.
+  function buildPayload() {
+    var layout = attr("data-layout", "column");
+    var font = attr("data-typography", "editorial");
+    var mode = localStorage.getItem("theme-mode") || "system";
+    var palette = attr("data-palette", "standard");
+    var parts = [];
+
+    if (ALLOW.layout.indexOf(layout) > -1) {
+      parts.push("layout:" + layout);
+    }
+    if (ALLOW.font.indexOf(font) > -1) {
+      parts.push("font:" + font);
+    }
+    if (ALLOW.mode.indexOf(mode) > -1) {
+      parts.push("mode:" + mode);
+    }
+
+    // Only standard/pantone are portable; a custom palette is device-local, so a
+    // link that can't reproduce it simply omits the palette (recipient keeps
+    // their own).
+    if (palette === "pantone") {
+      parts.push("palette:pantone");
+      var year = attr(
+        "data-coty-year",
+        localStorage.getItem("theme-coty-year") || ""
+      );
+      if (/^\d{4}$/.test(year)) {
+        parts.push("year:" + year);
+      }
+    } else if (palette === "standard") {
+      parts.push("palette:standard");
+    }
+
+    parts.push(
+      "blend:" + (attr("data-effect-blend", "off") === "on" ? "1" : "0")
+    );
+    parts.push(
+      "grain:" + (attr("data-effect-grain", "off") === "on" ? "1" : "0")
+    );
+
+    return parts.join(",");
+  }
+
+  function buildUrl() {
+    var url = new URL(window.location.href);
+    url.hash = "";
+    url.search = "";
+    url.searchParams.set("theme", buildPayload());
+    return url.toString();
+  }
+
+  function copyText(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    // Fallback for insecure contexts / older engines.
+    return new Promise(function (resolve, reject) {
+      try {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "absolute";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        var ok = document.execCommand("copy");
+        document.body.removeChild(ta);
+        ok ? resolve() : reject(new Error("execCommand failed"));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  function toast(button, value) {
+    if (!window.Toast) {
+      return;
+    }
+    var title = button.getAttribute("data-toast-title") || "Share";
+    var icon = button.getAttribute("data-toast-icon") || "";
+    window.Toast.show(title, value, { icon: icon });
+  }
+
+  // Remove a consumed ?theme= from the address bar (the head script already
+  // applied + persisted it), keeping any unrelated query params intact.
+  function cleanUrl() {
+    try {
+      var url = new URL(window.location.href);
+      if (!url.searchParams.has("theme")) {
+        return;
+      }
+      url.searchParams.delete("theme");
+      var qs = url.searchParams.toString();
+      window.history.replaceState(
+        window.history.state,
+        "",
+        url.pathname + (qs ? "?" + qs : "") + url.hash
+      );
+    } catch (e) {}
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    cleanUrl();
+
+    var button = document.querySelector('[data-js="theme-share"]');
+    if (!button) {
+      return;
+    }
+
+    button.addEventListener("click", function () {
+      var link = buildUrl();
+      copyText(link).then(
+        function () {
+          toast(
+            button,
+            button.getAttribute("data-toast-copied") || "Link copied"
+          );
+        },
+        function () {
+          toast(
+            button,
+            button.getAttribute("data-toast-failed") || "Copy failed"
+          );
+        }
+      );
+    });
+  });
+})();

--- a/docs/layout-dimension-plan.md
+++ b/docs/layout-dimension-plan.md
@@ -18,19 +18,19 @@ Definieras i `:root` (defaults) i `tokens/semantic.css`, åsidosätts per `:root
 
 ### A. Sektionsrytm (vertikal)
 
-| Token                       | Default (kolumn)                              | Konsument                                                |
-| --------------------------- | --------------------------------------------- | -------------------------------------------------------- |
-| `--layout-section-rhythm`   | `clamp(2rem, 0.92rem + 4.82vw, 4rem)` (32→64) | `.home-section` padding                                  |
-| `--layout-hero-rhythm`      | `clamp(4rem, 2.92rem + 4.82vw, 6rem)` (64→96) | hero padding                                             |
-| `--layout-heading-gap`      | `var(--spacing-32)`                           | `.section-heading` margin-bottom                         |
-| `--layout-block-gap`        | `calc(var(--spacing-32) * prose-rhythm)`      | mellan/inuti kompositionsblock (titlar, sektioner, kort) |
-| `--layout-title-gap`        | `calc(var(--spacing-24) * prose-rhythm)`      | under masthead-/hero-titel                               |
-| `--layout-label-gap`        | `calc(var(--spacing-16) * prose-rhythm)`      | under liten etikett/underrubrik                          |
-| `--layout-card-gap`         | `calc(var(--spacing-48) * prose-rhythm)`      | `article` inter-kort-marginal (index/terminal nollar)    |
-| `--layout-content-top`      | `var(--spacing-80)`                           | `.content` padding-top (innersidor)                      |
-| `--layout-hero-heading-top` | `var(--spacing-80)`                           | `.startpage-heading` padding-top (hem-hero)              |
-| `--layout-about-cv-gap`     | `var(--spacing-64)`                           | `.about-cv` margin-top                                   |
-| `--layout-contact-info-gap` | `var(--spacing-64)`                           | `.contact-info` margin-bottom                            |
+| Token                       | Default (kolumn)                        | Konsument                                                |
+| --------------------------- | --------------------------------------- | -------------------------------------------------------- |
+| `--layout-section-rhythm`   | fluid `clamp` 32→64 (se mönster nedan)  | `.home-section` padding                                  |
+| `--layout-hero-rhythm`      | fluid `clamp` 64→96                     | hero padding                                             |
+| `--layout-heading-gap`      | `var(--spacing-32)`                     | `.section-heading` margin-bottom                         |
+| `--layout-block-gap`        | `calc(var(--spacing-32) * block-scale)` | mellan/inuti kompositionsblock (titlar, sektioner, kort) |
+| `--layout-title-gap`        | `calc(var(--spacing-24) * block-scale)` | under masthead-/hero-titel                               |
+| `--layout-label-gap`        | `calc(var(--spacing-16) * block-scale)` | under liten etikett/underrubrik                          |
+| `--layout-card-gap`         | `calc(var(--spacing-48) * block-scale)` | `article` inter-kort-marginal (index/terminal nollar)    |
+| `--layout-content-top`      | `var(--spacing-80)`                     | `.content` padding-top (innersidor)                      |
+| `--layout-hero-heading-top` | `var(--spacing-80)`                     | `.startpage-heading` padding-top (hem-hero)              |
+| `--layout-about-cv-gap`     | `var(--spacing-64)`                     | `.about-cv` margin-top                                   |
+| `--layout-contact-info-gap` | `var(--spacing-64)`                     | `.contact-info` margin-bottom                            |
 
 > **Fluid rytm:** `section-rhythm` och `hero-rhythm` är `clamp()` — tokenen skalar
 > själv med viewporten (min på telefon → max på desktop), så små skärmar komprimeras
@@ -38,13 +38,50 @@ Definieras i `:root` (defaults) i `tokens/semantic.css`, åsidosätts per `:root
 > sina egna min/max; `.home-section` / `.hero-section` (och kritisk CSS i `head.html`)
 > läser bara tokenen. Detta ersatte de gamla `.home-section`/`.hero-section`
 > padding-överskrivningarna som ignorerade layoutens rytm på små skärmar.
+>
+> **Clamp-mönstret** (så ingen räknar lutning för hand): ändpunkterna är `--spacing-*`
+> och interpolationen härleds ur en delad range som definieras **en gång**:
+>
+> ```css
+> --fluid-floor: 360px; /* under detta: MIN */
+> --fluid-span: 664; /* 1024 − 360, unitless (px) — divisorn */
+> --layout-section-rhythm: clamp(
+>   var(--spacing-32),
+>   calc(
+>     var(--spacing-32) + 32 * (100vw - var(--fluid-floor)) / var(--fluid-span)
+>   ),
+>   var(--spacing-64)
+> ); /* 32 → 64 */
+> ```
+>
+> `Δpx` (här 32) = `max − min` i px (`--spacing-N` = N px). Vid 360px = MIN, vid 1024px = MAX.
 
-> **Blockrytm:** `block-gap` / `title-gap` / `label-gap` skalas av
-> `--layout-prose-rhythm` (kolumn ×1 = no-op; editorial 1.25 = luftigare; index 0.8
+> **Två täthetsspakar (medvetet separata):**
+>
+> - `--layout-prose-rhythm` skalar **prosarytm** (stycke-/rubrikavstånd i brödtext).
+> - `--layout-block-scale` skalar **kompositions-block/kort** (`block-gap`-familjen).
+>   Default `var(--layout-prose-rhythm)` → no-op idag, men en layout kan sätta den
+>   ensam (t.ex. tät text men luftiga kort). `block-gap` / `title-gap` / `label-gap`
+>   / `card-gap` läser `--layout-block-scale`; prosareglerna i `typography.css` läser
+>   `--layout-prose-rhythm`.
+
+> **Layout-knutet vs konstant** — principen för när en spacing ska skala med layouten:
+>
+> - **Layout-knutet** (skalar med täthet): kompositionsrytm — section, hero, block,
+>   kort, prosans stycke-/rubrikrytm. Läs en `--layout-*`-token.
+> - **Konstant** (typografisk närhet/läsbarhet, samma i alla layouter): mikro-avstånd
+>   som "rubrik hugger sin text" (`.content :is(h…)` 8px), etikett-/ikon-gap (4–12px),
+>   specialsidor, `type-display` 160. Lämnas på rå `--spacing-*` **med en kommentar**
+>   som säger att det är avsiktligt.
+>
+> Känd kvarleva att besluta: `.content.post .prose p` (rå 16px) skriver över den
+> layout-knutna `.prose p`-rytmen — se kommentar i `typography.css`.
+
+> **Blockrytm:** `block-gap` / `title-gap` / `label-gap` / `card-gap` skalas av
+> `--layout-block-scale` (kolumn ×1 = no-op; editorial 1.25 = luftigare; index 0.8
 > och terminal 0.9 = tätare). Kompositions-marginaler (about/works/contact-titlar,
 > kort, project-info) läser dessa i stället för rå `--spacing`, vilket knyter
-> blockrytmen till layouten. Komponent-interna småmarginaler (ikoner 4–8 px,
-> specialsidor, `type-display` 160) lämnas på råa `--spacing`.
+> blockrytmen till layouten.
 
 > **Hem-hero (index):** hero-sektionen bär redan `--layout-hero-rhythm`, så
 > `--layout-hero-heading-top` staplade dubbelt utrymme ovanför leden. Index drar ned den till

--- a/docs/layout-dimension-plan.md
+++ b/docs/layout-dimension-plan.md
@@ -18,16 +18,32 @@ Definieras i `:root` (defaults) i `tokens/semantic.css`, åsidosätts per `:root
 
 ### A. Sektionsrytm (vertikal)
 
-| Token                       | Default (idag)      | Konsument                                          |
-| --------------------------- | ------------------- | -------------------------------------------------- |
-| `--layout-section-rhythm`   | `var(--spacing-64)` | `.home-section` padding                            |
-| `--layout-hero-rhythm`      | `var(--spacing-96)` | hero padding                                       |
-| `--layout-heading-gap`      | `var(--spacing-32)` | `.section-heading` margin-bottom                   |
-| `--layout-block-gap`        | `var(--spacing-32)` | vertikalt mellanrum mellan content-block / row-gap |
-| `--layout-content-top`      | `var(--spacing-80)` | `.content` padding-top (innersidor)                |
-| `--layout-hero-heading-top` | `var(--spacing-80)` | `.startpage-heading` padding-top (hem-hero)        |
-| `--layout-about-cv-gap`     | `var(--spacing-64)` | `.about-cv` margin-top                             |
-| `--layout-contact-info-gap` | `var(--spacing-64)` | `.contact-info` margin-bottom                      |
+| Token                       | Default (kolumn)                              | Konsument                                                |
+| --------------------------- | --------------------------------------------- | -------------------------------------------------------- |
+| `--layout-section-rhythm`   | `clamp(2rem, 0.92rem + 4.82vw, 4rem)` (32→64) | `.home-section` padding                                  |
+| `--layout-hero-rhythm`      | `clamp(4rem, 2.92rem + 4.82vw, 6rem)` (64→96) | hero padding                                             |
+| `--layout-heading-gap`      | `var(--spacing-32)`                           | `.section-heading` margin-bottom                         |
+| `--layout-block-gap`        | `calc(var(--spacing-32) * prose-rhythm)`      | mellan/inuti kompositionsblock (titlar, sektioner, kort) |
+| `--layout-title-gap`        | `calc(var(--spacing-24) * prose-rhythm)`      | under masthead-/hero-titel                               |
+| `--layout-label-gap`        | `calc(var(--spacing-16) * prose-rhythm)`      | under liten etikett/underrubrik                          |
+| `--layout-content-top`      | `var(--spacing-80)`                           | `.content` padding-top (innersidor)                      |
+| `--layout-hero-heading-top` | `var(--spacing-80)`                           | `.startpage-heading` padding-top (hem-hero)              |
+| `--layout-about-cv-gap`     | `var(--spacing-64)`                           | `.about-cv` margin-top                                   |
+| `--layout-contact-info-gap` | `var(--spacing-64)`                           | `.contact-info` margin-bottom                            |
+
+> **Fluid rytm:** `section-rhythm` och `hero-rhythm` är `clamp()` — tokenen skalar
+> själv med viewporten (min på telefon → max på desktop), så små skärmar komprimeras
+> automatiskt utan egenskaps-overrides i media-queries. Varje layout re-klampar till
+> sina egna min/max; `.home-section` / `.hero-section` (och kritisk CSS i `head.html`)
+> läser bara tokenen. Detta ersatte de gamla `.home-section`/`.hero-section`
+> padding-överskrivningarna som ignorerade layoutens rytm på små skärmar.
+
+> **Blockrytm:** `block-gap` / `title-gap` / `label-gap` skalas av
+> `--layout-prose-rhythm` (kolumn ×1 = no-op; editorial 1.25 = luftigare; index 0.8
+> och terminal 0.9 = tätare). Kompositions-marginaler (about/works/contact-titlar,
+> kort, project-info) läser dessa i stället för rå `--spacing`, vilket knyter
+> blockrytmen till layouten. Komponent-interna småmarginaler (ikoner 4–8 px,
+> specialsidor, `type-display` 160) lämnas på råa `--spacing`.
 
 > **Hem-hero (index):** hero-sektionen bär redan `--layout-hero-rhythm`, så
 > `--layout-hero-heading-top` staplade dubbelt utrymme ovanför leden. Index drar ned den till

--- a/docs/layout-dimension-plan.md
+++ b/docs/layout-dimension-plan.md
@@ -17,39 +17,53 @@ Palett och typografi ligger kvar exakt som idag. Layout äger **spatial struktur
 Definieras i `:root` (defaults) i `tokens/semantic.css`, åsidosätts per `:root[data-layout="…"]`.
 
 ### A. Sektionsrytm (vertikal)
-| Token | Default (idag) | Konsument |
-|---|---|---|
-| `--layout-section-rhythm` | `var(--spacing-64)` | `.home-section` padding |
-| `--layout-hero-rhythm` | `var(--spacing-96)` | hero padding |
-| `--layout-heading-gap` | `var(--spacing-32)` | `.section-heading` margin-bottom |
-| `--layout-block-gap` | `var(--spacing-32)` | vertikalt mellanrum mellan content-block / row-gap |
+
+| Token                       | Default (idag)      | Konsument                                          |
+| --------------------------- | ------------------- | -------------------------------------------------- |
+| `--layout-section-rhythm`   | `var(--spacing-64)` | `.home-section` padding                            |
+| `--layout-hero-rhythm`      | `var(--spacing-96)` | hero padding                                       |
+| `--layout-heading-gap`      | `var(--spacing-32)` | `.section-heading` margin-bottom                   |
+| `--layout-block-gap`        | `var(--spacing-32)` | vertikalt mellanrum mellan content-block / row-gap |
+| `--layout-content-top`      | `var(--spacing-80)` | `.content` padding-top (innersidor)                |
+| `--layout-hero-heading-top` | `var(--spacing-80)` | `.startpage-heading` padding-top (hem-hero)        |
+| `--layout-about-cv-gap`     | `var(--spacing-64)` | `.about-cv` margin-top                             |
+| `--layout-contact-info-gap` | `var(--spacing-64)` | `.contact-info` margin-bottom                      |
+
+> **Hem-hero (index):** hero-sektionen bär redan `--layout-hero-rhythm`, så
+> `--layout-hero-heading-top` staplade dubbelt utrymme ovanför leden. Index drar ned den till
+> `var(--spacing-8)` (och editorial till `var(--spacing-24)`) så leden sitter nära toppen i stället
+> för att flyta mitt på skärmen.
 
 ### B. Grid (horisontell)
-| Token | Default (idag) | Konsument |
-|---|---|---|
-| `--layout-col-gap` | `var(--spacing-24)` | `.page-grid` / `.use-subgrid` / `.grid-cols-2` column-gap |
-| `--layout-row-gap` | `var(--spacing-32)` | `.page-grid` row-gap |
-| `--layout-default-place` | `8` (≈ `.place-prose`) | default kolumnspann för brödtext-block |
 
-> Kolumn­_antalet_ (12) lämnas oförändrat — variera **placering** via `.place-*` / `--col`,
+| Token                    | Default (idag)         | Konsument                                                 |
+| ------------------------ | ---------------------- | --------------------------------------------------------- |
+| `--layout-col-gap`       | `var(--spacing-24)`    | `.page-grid` / `.use-subgrid` / `.grid-cols-2` column-gap |
+| `--layout-row-gap`       | `var(--spacing-32)`    | `.page-grid` row-gap                                      |
+| `--layout-default-place` | `8` (≈ `.place-prose`) | default kolumnspann för brödtext-block                    |
+
+> Kolumn­*antalet* (12) lämnas oförändrat — variera **placering** via `.place-*` / `--col`,
 > inte rasterupplösningen. Att byta 12→ annat är invasivt och onödigt.
 
 ### C. Satsbredd (measure)
-| Token | Default (idag) | Konsument |
-|---|---|---|
+
+| Token              | Default (idag)                | Konsument                          |
+| ------------------ | ----------------------------- | ---------------------------------- |
 | `--layout-measure` | `var(--measure-prose)` (70ch) | `typography.css` prose `max-width` |
 
 ### D. Typskala
-| Token | Default (idag) | Konsument |
-|---|---|---|
-| `--layout-scale-ratio` | `1` | multiplikator på display/heading clamp (redan finns som `--type-scale-display` i `home.css:82`) |
+
+| Token                  | Default (idag) | Konsument                                                                                       |
+| ---------------------- | -------------- | ----------------------------------------------------------------------------------------------- |
+| `--layout-scale-ratio` | `1`            | multiplikator på display/heading clamp (redan finns som `--type-scale-display` i `home.css:82`) |
 
 ### E. Strukturella toggles (0/1, läses i selektorer)
-| Token | Default | Effekt |
-|---|---|---|
-| `--layout-pullquotes` | `0` | aktiverar pull-quote-utbrytning |
-| `--layout-dropcap` | `0` | anfang på första stycket |
-| `--layout-rule-style` | `none` | linjal/divider-behandling mellan block |
+
+| Token                 | Default | Effekt                                 |
+| --------------------- | ------- | -------------------------------------- |
+| `--layout-pullquotes` | `0`     | aktiverar pull-quote-utbrytning        |
+| `--layout-dropcap`    | `0`     | anfang på första stycket               |
+| `--layout-rule-style` | `none`  | linjal/divider-behandling mellan block |
 
 ---
 
@@ -57,22 +71,52 @@ Definieras i `:root` (defaults) i `tokens/semantic.css`, åsidosätts per `:root
 
 Varje rad: byt direkt primitiv-referens → `--layout-*`. Inga utseende­ändringar (defaults = dagens).
 
-| Fil:rad | Idag | Byt till |
-|---|---|---|
-| `assets/css/pages/home.css:11` | `padding: var(--spacing-64) 0;` | `padding: var(--layout-section-rhythm) 0;` |
-| `assets/css/pages/home.css:74` | hero `padding: var(--spacing-96) 0;` | `var(--layout-hero-rhythm) 0;` |
-| `assets/css/pages/home.css:61` | `.section-heading … margin-bottom: var(--spacing-32);` | `var(--layout-heading-gap);` |
-| `assets/css/pages/home.css:26,31` | `column-gap: var(--spacing-24);` | `var(--layout-col-gap);` |
-| `assets/css/pages/home.css:79` | `max-width: var(--content-max-width-narrow);` | (lämna — hero-specifik) |
-| `assets/css/pages/home.css:82` | `* var(--type-scale-display)` | `* var(--layout-scale-ratio)` (alias `--type-scale-display` → `--layout-scale-ratio`) |
-| `assets/css/utilities/grid.css:13` | `.page-grid column-gap: var(--spacing-24);` | `var(--layout-col-gap);` |
-| `assets/css/utilities/grid.css:14` | `.page-grid row-gap: var(--spacing-32);` | `var(--layout-row-gap);` |
-| `assets/css/utilities/grid.css:24,52` | subgrid `column-gap: var(--spacing-24/16);` | `var(--layout-col-gap);` (behåll sm-override) |
-| `assets/css/utilities/typography.css:425` | `max-width: var(--measure-prose);` | `var(--layout-measure);` |
-| `assets/css/utilities/_legacy-grid.css:5` | `column-gap: 1.5rem;` **(rått värde)** | `var(--layout-col-gap);` ← enda äkta värde-extraktionen |
+| Fil:rad                                     | Idag                                                   | Byt till                                                                              |
+| ------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `assets/css/pages/home.css:11`              | `padding: var(--spacing-64) 0;`                        | `padding: var(--layout-section-rhythm) 0;`                                            |
+| `assets/css/pages/home.css:74`              | hero `padding: var(--spacing-96) 0;`                   | `var(--layout-hero-rhythm) 0;`                                                        |
+| `assets/css/pages/home.css:61`              | `.section-heading … margin-bottom: var(--spacing-32);` | `var(--layout-heading-gap);`                                                          |
+| `assets/css/pages/home.css:26,31`           | `column-gap: var(--spacing-24);`                       | `var(--layout-col-gap);`                                                              |
+| `assets/css/pages/home.css:79`              | `max-width: var(--content-max-width-narrow);`          | (lämna — hero-specifik)                                                               |
+| `assets/css/pages/home.css:82`              | `* var(--type-scale-display)`                          | `* var(--layout-scale-ratio)` (alias `--type-scale-display` → `--layout-scale-ratio`) |
+| `assets/css/utilities/grid.css:13`          | `.page-grid column-gap: var(--spacing-24);`            | `var(--layout-col-gap);`                                                              |
+| `assets/css/utilities/grid.css:14`          | `.page-grid row-gap: var(--spacing-32);`               | `var(--layout-row-gap);`                                                              |
+| `assets/css/utilities/grid.css:24,52`       | subgrid `column-gap: var(--spacing-24/16);`            | `var(--layout-col-gap);` (behåll sm-override)                                         |
+| `assets/css/utilities/typography.css:425`   | `max-width: var(--measure-prose);`                     | `var(--layout-measure);`                                                              |
+| `assets/css/utilities/_legacy-grid.css:5`   | `column-gap: 1.5rem;` **(rått värde)**                 | `var(--layout-col-gap);` ← enda äkta värde-extraktionen                               |
+| `assets/css/style.css` `.content`           | `padding-top: var(--spacing-80);`                      | `var(--layout-content-top);` ✅                                                       |
+| `assets/css/style.css` `.startpage-heading` | `padding-top: var(--spacing-80);`                      | `var(--layout-hero-heading-top);` ✅                                                  |
+| `assets/css/style.css` `.about-cv`          | `margin-top: var(--spacing-64);`                       | `var(--layout-about-cv-gap);` ✅                                                      |
+| `assets/css/style.css` `.contact-info`      | `margin-bottom: var(--spacing-64);`                    | `var(--layout-contact-info-gap);` ✅                                                  |
 
 **Lämna orört:** `utilities/layout.css` `.flex { gap: 1rem }`, `.gap-xs/.gap-*` — det är en
 generisk util-skala, inte komposition på sidnivå. Att koppla in dem ger brus utan vinst.
+
+---
+
+## 2b. Hero-radbrytning per layout × typografi (`pages/home.css`)
+
+Rollen (`role-swapper`) släpps till egen rad när led + längsta roll slutar rymmas på en rad. Den
+tidigare enda brytpunkten (`42.5em`) var kalibrerad för den stora hero-fonten och slog därför alltför
+tidigt för **index** (vars hero är nedskruvad till `~text-lg`). Brytpunkten skalar nu med hero-fontens
+storlek (layout) och typsnittets bredd (mono/technical bryter tidigast). Verifierat med Chrome-screenshots
+mot längsta rollen vid gränsvidderna:
+
+| Layout             | Bas (serif/sans/expressive) | + `technical` (mono) |
+| ------------------ | --------------------------- | -------------------- |
+| column (default)   | `≤ 38em`                    | `≤ 42em`             |
+| editorial (1.15×)  | `≤ 42em`                    | `≤ 46em`             |
+| index (`~text-lg`) | `≤ 26em`                    | `≤ 30em`             |
+
+---
+
+## 2c. Delbar komposition — `?theme=` (jfr §7 "seed")
+
+Den delbara/reproducerbara seed som §7 pekar ut finns nu: knappen **"Share this look"** i
+inställningspanelen kodar `layout, font (typography), mode, palette, pantone-år, blend, grain` till en
+`?theme=`-parameter (`theme-share.js`). Avkodaren ligger i det inline-script i `partials/head.html` som
+körs **före** första paint, så en delad länk målas rätt utan flash och persisteras till `localStorage`;
+paramen städas därefter bort från adressfältet. Custom-palett är enhetslokal och utelämnas.
 
 ---
 
@@ -92,14 +136,14 @@ medvetet **inte** typografi-namnen (signalerar oberoende).
 /* dimensions/layout/editorial.css — asymmetriskt, luftigt, redaktionellt */
 :root[data-layout="editorial"] {
   --layout-section-rhythm: var(--spacing-96);
-  --layout-heading-gap:    var(--spacing-48);
-  --layout-col-gap:        var(--spacing-32);
-  --layout-measure:        var(--measure-wide);   /* 45ch */
-  --layout-scale-ratio:    1.18;
-  --layout-default-place:  col-start 3 / span 8;  /* ≈ .place-article */
-  --layout-pullquotes:     1;
-  --layout-dropcap:        1;
-  --layout-rule-style:     hairline;
+  --layout-heading-gap: var(--spacing-48);
+  --layout-col-gap: var(--spacing-32);
+  --layout-measure: var(--measure-wide); /* 45ch */
+  --layout-scale-ratio: 1.18;
+  --layout-default-place: col-start 3 / span 8; /* ≈ .place-article */
+  --layout-pullquotes: 1;
+  --layout-dropcap: 1;
+  --layout-rule-style: hairline;
 }
 ```
 
@@ -107,12 +151,12 @@ medvetet **inte** typografi-namnen (signalerar oberoende).
 /* dimensions/layout/index.css — tätt, modulärt, bild-framåt */
 :root[data-layout="index"] {
   --layout-section-rhythm: var(--spacing-40);
-  --layout-heading-gap:    var(--spacing-16);
-  --layout-col-gap:        var(--spacing-16);
-  --layout-row-gap:        var(--spacing-16);
-  --layout-measure:        var(--measure-prose);
-  --layout-scale-ratio:    0.95;
-  --layout-default-place:  col-start 1 / span 12; /* ≈ .place-full */
+  --layout-heading-gap: var(--spacing-16);
+  --layout-col-gap: var(--spacing-16);
+  --layout-row-gap: var(--spacing-16);
+  --layout-measure: var(--measure-prose);
+  --layout-scale-ratio: 0.95;
+  --layout-default-place: col-start 1 / span 12; /* ≈ .place-full */
 }
 ```
 
@@ -121,14 +165,17 @@ medvetet **inte** typografi-namnen (signalerar oberoende).
 ## 4. Registrering & inkoppling (spegla typografi-dimensionen)
 
 1. **CSS-bundle** — `layouts/partials/head.html`, efter typografi-blocket (rad ~148):
+
    ```go-html-template
    {{ $dimensions_layout_column    := resources.Get "css/dimensions/layout/column.css" }}
    {{ $dimensions_layout_editorial := resources.Get "css/dimensions/layout/editorial.css" }}
    {{ $dimensions_layout_index     := resources.Get "css/dimensions/layout/index.css" }}
    ```
+
    Lägg dem i samma `slice … | resources.Concat`-lista som de andra dimensionerna.
 
 2. **Pre-paint (no-FOUC)** — `head.html:~541`, direkt efter typografi-raden:
+
    ```js
    var storedLayout = localStorage.getItem("theme-layout") || "column";
    document.documentElement.setAttribute("data-layout", storedLayout);
@@ -136,11 +183,12 @@ medvetet **inte** typografi-namnen (signalerar oberoende).
 
 3. **JS** — `assets/js/darkmode.js`: spegla `setTypography`/`applyTypography`/`updateTypographyUI`,
    **minus hela `TYPOGRAPHY_FONTS`-förladdningen** (layout har inga webbfonter → enklare):
+
    ```js
    function setLayout(layout) {
      localStorage.setItem("theme-layout", layout);
      updateLayoutUI(layout);
-     applyLayout(layout);                 // setAttribute("data-layout", layout)
+     applyLayout(layout); // setAttribute("data-layout", layout)
      if (window.Toast) window.Toast.show(layoutCategoryLabel, layoutLabel);
    }
    ```

--- a/docs/layout-dimension-plan.md
+++ b/docs/layout-dimension-plan.md
@@ -26,6 +26,7 @@ Definieras i `:root` (defaults) i `tokens/semantic.css`, åsidosätts per `:root
 | `--layout-block-gap`        | `calc(var(--spacing-32) * prose-rhythm)`      | mellan/inuti kompositionsblock (titlar, sektioner, kort) |
 | `--layout-title-gap`        | `calc(var(--spacing-24) * prose-rhythm)`      | under masthead-/hero-titel                               |
 | `--layout-label-gap`        | `calc(var(--spacing-16) * prose-rhythm)`      | under liten etikett/underrubrik                          |
+| `--layout-card-gap`         | `calc(var(--spacing-48) * prose-rhythm)`      | `article` inter-kort-marginal (index/terminal nollar)    |
 | `--layout-content-top`      | `var(--spacing-80)`                           | `.content` padding-top (innersidor)                      |
 | `--layout-hero-heading-top` | `var(--spacing-80)`                           | `.startpage-heading` padding-top (hem-hero)              |
 | `--layout-about-cv-gap`     | `var(--spacing-64)`                           | `.about-cv` margin-top                                   |

--- a/docs/spacing-streamline-plan.md
+++ b/docs/spacing-streamline-plan.md
@@ -1,0 +1,130 @@
+# Spacing-streamline — inventering & plan
+
+> Status: **plan för granskning** (ingen kod skriven än). Uppföljning på
+> `layout-dimension-plan.md`. Mål: all komposition-/sidspacing går genom ett
+> lager som kan knytas till `data-layout`, med **en sanningskälla per rytm** och
+> responsiv variation i _tokenen_ — inte i egenskapen.
+
+---
+
+## 1. Princip
+
+> **All komposition-/sidspacing läser en `--layout-*`-token. Responsiv variation
+> bor i tokenen (media-query eller `clamp()` sätter variabeln), aldrig som en
+> egenskaps-override. Block-/prosarytm skalas mot layout via
+> `--layout-prose-rhythm`. Komponent-interna spacings står utanför och rörs inte.**
+
+Idag lever **två parallella mönster** sida vid sida, och det är blandningen som
+skaver:
+
+- **Mönster A (bra, redan i bruk):** `calc(var(--spacing-X) * var(--layout-prose-rhythm))`
+  — skalar mot layout. Finns i `footer.css`, `gallery.css`, `utilities/typography.css`
+  (prosa), `style.css` (`--post-media-gap`) och `home.css` (`.about-content`).
+- **Mönster B (skaver):** rå `var(--spacing-X)` direkt på egenskapen, ofta i en
+  media-query som skriver över det layouten redan bestämt.
+
+---
+
+## 2. Inventering
+
+### 2.1 Kontraktet idag (`--layout-*`)
+
+Definierat i `tokens/semantic.css` (defaults) och per `:root[data-layout="…"]`
+i `dimensions/layout/{column,editorial,index,terminal}.css`:
+
+`--layout-section-rhythm`, `--layout-hero-rhythm`, `--layout-heading-gap`,
+`--layout-col-gap`, `--layout-row-gap`, `--layout-content-top`,
+`--layout-hero-heading-top`, `--layout-about-cv-gap`, `--layout-contact-info-gap`,
+`--layout-measure`, `--layout-scale-ratio`, `--layout-prose-rhythm`.
+
+**Lucka:** `--layout-block-gap` står dokumenterad i `layout-dimension-plan.md`
+men är **aldrig definierad**.
+
+### 2.2 Problemen (mönster B + läckor)
+
+| #   | Var                               | Vad                                                                    | Problem                                                                                                                                                                         |
+| --- | --------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1  | `home.css:435–448`                | `.home-section` (sm 48 / xs 32) + `.hero-section` (sm 64)              | Skriver över **egenskapen** i media-query → `--layout-section-rhythm` / `--layout-hero-rhythm` ignoreras på små skärmar för _alla_ layouter. Detta är buggen som rapporterades. |
+| P2  | `head.html:325,378` (kritisk CSS) | `.hero-section` padding hårdkodad (96 bas / 64 sm)                     | **Tredje sanningskällan** för hero-rytmen, fryst — respekterar inte tokenen. Måste hållas i synk manuellt idag.                                                                 |
+| P3  | `style.css:800,808,915,927`       | `.project-info` `padding: 2rem`, `grid-column-gap: 3/2/1.5rem`         | **Råa literaler** utanför spacing-skalan.                                                                                                                                       |
+| P4  | `tokens/semantic.css`             | `--layout-block-gap`                                                   | Dokumenterad men odefinierad — kontraktslucka.                                                                                                                                  |
+| P5  | `style.css` (~25 st) + `home.css` | rubrik/titel/kort/kontakt-marginaler `margin-bottom: spacing-16/24/32` | Rå `--spacing`, **utan** prose-rhythm → skalar inte med layout fast grannar (prosa, media) gör det. Inkonsekvent block-rytm.                                                    |
+
+Exempel på P5-kandidater: `.startpage-heading h1`, `.about-cv__title`,
+`.about-main__headline`, `.about-cv__heading/__text/__section`, `.works-section
+.section-heading`, `.project-info` inre marginaler, `.content.newsletter h3`.
+
+### 2.3 Lämnas ifred (komponent-internt)
+
+`theme-dropdown.css` (72), `ui-library.css` (69), `language-dropdown.css`,
+`settings-dropdown.css`, `form.css`, `toast.css`, `accordion.css`,
+`button.css`, m.fl. — widget-interna spacings. Ska **inte** knytas till layout;
+använder redan `--spacing-*`-skalan konsekvent.
+
+---
+
+## 3. Responsiv-strategi (designval — behöver ditt beslut)
+
+P1/P2 kräver att rytmen varierar med skärmbredd _via tokenen_. Två vägar:
+
+- **(a) Fluid — `clamp()` i tokenen.** T.ex.
+  `--layout-section-rhythm: clamp(var(--spacing-32), 4vw, var(--spacing-64));`
+  per layout. Inga diskreta sm/xs-steg, ingen media-query, en rad per layout.
+  Mest strömlinjeformat; ger mjuk skalning i stället för hopp.
+- **(b) Diskret — token-override i media-query.** Behåll sm/xs-brytpunkter men
+  flytta dem från egenskapen till variabeln, per layout (som `editorial.css`
+  redan gör för `--layout-hero-rhythm`). Mer förutsägbart, mer upprepning.
+
+**Rekommendation:** (a) för `section-rhythm` + `hero-rhythm` (kontinuerlig rytm
+mår bra av att vara fluid), (b) vid behov för enstaka undantag. Oavsett väg
+försvinner egenskaps-överskrivningarna och den kritiska CSS-dubbletten.
+
+---
+
+## 4. Prioriterad plan (faser)
+
+### Fas A — sektion/hero-rytmen genom tokens _(litet, säkert; löser buggen)_
+
+1. Gör `--layout-section-rhythm` och `--layout-hero-rhythm` responsiva i
+   tokenen (väg 3a eller 3b), i `semantic.css` (default) + varje layout-fil.
+2. Ta bort `.home-section` / `.hero-section` padding-override i `home.css:435–448`.
+3. Kritisk CSS i `head.html`: låt `.hero-section` läsa `var(--layout-hero-rhythm)`
+   och ta bort den hårdkodade sm-överskrivningen (en sanningskälla).
+4. Verifiera alla 4 layouter × xs/sm/md/lg med screenshots.
+
+### Fas B — knyt block-rytmen till layout _(mellan)_
+
+1. Definiera `--layout-block-gap` (default `var(--spacing-32)`) och ev.
+   `--layout-title-gap` (default `var(--spacing-16)`) i `semantic.css`; skala dem
+   per layout eller härled ur `--layout-prose-rhythm`.
+2. Route:a P5-marginalerna (rubriker/titlar/kort/kontakt) till dessa tokens i
+   stället för rå `--spacing`, så de skalar konsekvent med layouten.
+3. Verifiera att index (tätt) / editorial (luftigt) / terminal (kompakt) ger
+   sammanhängande block-rytm.
+
+### Fas C — literal-läckor + kontrakt _(städning)_
+
+1. `.project-info` `padding: 2rem` → spacing-skala; `grid-column-gap: 3/2/1.5rem`
+   → `--layout-col-gap`-familjen (respektera befintlig sm-nedtrappning).
+2. Uppdatera `layout-dimension-plan.md`: markera `--layout-block-gap` som
+   definierad, lägg till block/title-tokens och sektion/hero-fluid-noten.
+
+---
+
+## 5. Verifiering (per fas)
+
+- `npx jest` (inkl. `token-validation.test.js`), `eslint`, `prettier`.
+- Hugo-bygge grönt.
+- Chrome-screenshots: alla 4 layouter vid xs (≤360), sm (≤480/768), md, lg —
+  hero-topp, sektionsavstånd, block-rytm i about/works/contact.
+- Diff-koll: Fas A/C ska vara visuellt no-op _förutom_ på xs/sm där buggen fixas.
+
+---
+
+## 6. Öppna frågor till dig
+
+1. **Responsiv väg:** fluid `clamp()` (3a) eller diskreta token-steg (3b)?
+2. **Omfattning nu:** kör vi A, A+B eller A+B+C? (Kan tas som separata PR:er.)
+3. **Separat PR eller på nuvarande gren?** Denna plan ligger nu på
+   `claude/layout-spacing-tokens-eccmno` (PR #223) — säg till om du hellre vill ha
+   streamline-arbetet i en egen PR ovanpå master.

--- a/docs/spacing-streamline-plan.md
+++ b/docs/spacing-streamline-plan.md
@@ -1,9 +1,15 @@
 # Spacing-streamline — inventering & plan
 
-> Status: **plan för granskning** (ingen kod skriven än). Uppföljning på
-> `layout-dimension-plan.md`. Mål: all komposition-/sidspacing går genom ett
-> lager som kan knytas till `data-layout`, med **en sanningskälla per rytm** och
-> responsiv variation i _tokenen_ — inte i egenskapen.
+> Status: **genomförd (A+B+C)** på gren `claude/layout-spacing-tokens-eccmno`
+> (PR #223). Beslut: fluid `clamp()` för section/hero-rytm; blockrytm skalad av
+> `--layout-prose-rhythm`. Kontraktet dokumenteras i `layout-dimension-plan.md`.
+> Uppföljning på `layout-dimension-plan.md`. Mål: all komposition-/sidspacing går
+> genom ett lager som kan knytas till `data-layout`, med **en sanningskälla per
+> rytm** och responsiv variation i _tokenen_ — inte i egenskapen.
+>
+> **Utfall:** de gamla `.home-section`/`.hero-section` padding-överskrivningarna
+> och `head.html`-dubbletten är borta; index/terminal fick faktiska buggfixar på
+> sm/xs (de bumpades tidigare _större_ än layouten avsåg). Kolumn är oförändrad.
 
 ---
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -370,6 +370,18 @@ other = "On"
 [toast_grid_off]
 other = "Off"
 
+[share_theme]
+other = "Share this look"
+
+[toast_share_title]
+other = "Share"
+
+[toast_share_copied]
+other = "Link copied"
+
+[toast_share_failed]
+other = "Copy failed"
+
 [no_posts_yet]
 other = "No posts yet. Check back soon!"
 

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -370,6 +370,18 @@ other = "På"
 [toast_grid_off]
 other = "Av"
 
+[share_theme]
+other = "Dela den här looken"
+
+[toast_share_title]
+other = "Dela"
+
+[toast_share_copied]
+other = "Länk kopierad"
+
+[toast_share_failed]
+other = "Kopiering misslyckades"
+
 [no_posts_yet]
 other = "Inga inlägg ännu. Kom tillbaka snart!"
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -321,8 +321,10 @@
   {{ if $isHomePage }}
     <!-- Critical CSS - Above the fold -->
     <style>
-      /* Hero Section - Critical for LCP */
-      .hero-section { padding: var(--spacing-96) 0; }
+      /* Hero Section - Critical for LCP. Rides the fluid layout token (one source
+         of truth); the data-layout attribute is already set by the head script
+         above, so the right layout's clamp applies before first paint. */
+      .hero-section { padding: var(--layout-hero-rhythm) 0; }
       .hero-title {
         max-width: var(--content-max-width-narrow);
         line-height: 1.4;
@@ -373,9 +375,6 @@
       .reveal.is-revealed {
         opacity: 1;
         transform: translateY(0);
-      }
-      @media (max-width: 47.9375em) {
-        .hero-section { padding: var(--spacing-64) 0; }
       }
       @media (prefers-reduced-motion: reduce) {
         .role-swapper { transition: none; }

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -545,6 +545,49 @@
   <!-- Dark mode -->
   <script>
     (function () {
+      // Shareable-look links: a ?theme= param encodes a full composition
+      // (layout, typography, mode, palette, Pantone year, blend, grain). Applied
+      // here — before the CSS below reads the data-* attributes — so a shared
+      // link paints correctly with no flash, and persisted to localStorage so the
+      // choice sticks after the query is cleaned from the URL (see theme-share.js).
+      try {
+        var params = new URLSearchParams(window.location.search);
+        var payload = params.get("theme");
+        if (payload) {
+          var allow = {
+            layout: ["column", "editorial", "index", "terminal"],
+            font: ["editorial", "refined", "expressive", "technical", "system"],
+            mode: ["light", "dark", "system"],
+            palette: ["standard", "pantone"],
+          };
+          var map = { layout: "theme-layout", font: "theme-typography", mode: "theme-mode", palette: "theme-palette" };
+          var kv = {};
+          payload.split(",").forEach(function (pair) {
+            var i = pair.indexOf(":");
+            if (i > 0) { kv[pair.slice(0, i).trim()] = pair.slice(i + 1).trim(); }
+          });
+          Object.keys(map).forEach(function (k) {
+            if (kv[k] && allow[k].indexOf(kv[k]) > -1) {
+              localStorage.setItem(map[k], kv[k]);
+            }
+          });
+          if (kv.palette === "pantone") {
+            localStorage.setItem("theme-pantone-state", "paused");
+            if (/^\d{4}$/.test(kv.year || "")) {
+              localStorage.setItem("theme-coty-year", kv.year);
+            }
+          } else if (kv.palette === "standard") {
+            localStorage.setItem("theme-pantone-state", "inactive");
+          }
+          if (kv.blend === "0" || kv.blend === "1") {
+            localStorage.setItem("theme-effect-blend", kv.blend);
+          }
+          if (kv.grain === "0" || kv.grain === "1") {
+            localStorage.setItem("theme-effect-grain", kv.grain);
+          }
+        }
+      } catch (e) {}
+
       // Set mode (light/dark/system)
       var storedMode = localStorage.getItem("theme-mode") || "system";
       if (storedMode === "system") {
@@ -578,6 +621,19 @@
         storedLayout = "column";
       }
       document.documentElement.setAttribute("data-layout", storedLayout);
+
+      // Image blend + grain effects up front too, so a shared look (or a returning
+      // visitor) paints with the correct treatment instead of flashing the default.
+      var storedBlend = localStorage.getItem("theme-effect-blend");
+      document.documentElement.setAttribute(
+        "data-effect-blend",
+        storedBlend === null ? "on" : storedBlend === "1" ? "on" : "off"
+      );
+      var storedGrain = localStorage.getItem("theme-effect-grain");
+      document.documentElement.setAttribute(
+        "data-effect-grain",
+        storedGrain === "1" ? "on" : "off"
+      );
 
       // CotyScale (Pantone engine) is lazy-loaded. Expose its URL for
       // darkmode.js, and when Pantone is already active inject it now — before
@@ -623,6 +679,7 @@
   {{ $js9 := resources.Get "js/role-swapper.js" }}
   {{ $js10 := resources.Get "js/ui-library-tabs.js" }}
   {{ $js11 := resources.Get "js/settings-dropdown.js" }}
+  {{ $js_theme_share := resources.Get "js/theme-share.js" }}
   {{ $js12 := resources.Get "js/reveal-on-scroll.js" }}
   {{ $js13 := resources.Get "js/newsletter-form.js" }}
   {{ $js14 := resources.Get "js/toc-active.js" }}
@@ -662,6 +719,7 @@
       <script src="{{ $js10.RelPermalink }}" defer></script>
     {{ end }}
     <script src="{{ $js11.RelPermalink }}" defer></script>
+    <script src="{{ $js_theme_share.RelPermalink }}" defer></script>
     <script src="{{ $js12.RelPermalink }}" defer></script>
     <script src="{{ $js13.RelPermalink }}" defer></script>
     <script src="{{ $js14.RelPermalink }}" defer></script>
@@ -681,7 +739,7 @@
     <script src="{{ $js_lightbox.RelPermalink }}" defer></script>
   {{ else }}
     <!-- JavaScript production -->
-    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox }}
+    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox }}
     {{ $js = $js | resources.Concat "js.js" | minify | fingerprint }}
     <script src="{{ $js.RelPermalink }}" defer></script>
     {{ $pageJs := slice }}

--- a/layouts/partials/settings-dropdown.html
+++ b/layouts/partials/settings-dropdown.html
@@ -454,8 +454,41 @@
       </div>
     </div>
 
+    <div class="theme-divider"></div>
+
+    <div class="theme-section">
+      <button
+        type="button"
+        class="settings-share"
+        data-js="theme-share"
+        data-toast-title="{{ i18n "toast_share_title" }}"
+        data-toast-copied="{{ i18n "toast_share_copied" }}"
+        data-toast-failed="{{ i18n "toast_share_failed" }}"
+        data-toast-icon="icon-new-window"
+      >
+        <svg
+          class="settings-share__icon"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M9.5 13.5 14.5 8.5m-6.25 1.5H6a3 3 0 0 0 0 6h2.25m7.5-6H18a3 3 0 0 1 0 6h-2.25"
+            stroke="currentColor"
+            stroke-width="1.75"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <span class="settings-share__label">{{ i18n "share_theme" }}</span>
+      </button>
+    </div>
+
     {{- if gt $languageCount 1 -}}
       <div class="theme-divider"></div>
+
 
       <div class="theme-section">
         <div class="theme-section-heading">

--- a/layouts/partials/settings-dropdown.html
+++ b/layouts/partials/settings-dropdown.html
@@ -464,23 +464,17 @@
         data-toast-title="{{ i18n "toast_share_title" }}"
         data-toast-copied="{{ i18n "toast_share_copied" }}"
         data-toast-failed="{{ i18n "toast_share_failed" }}"
-        data-toast-icon="icon-new-window"
+        data-toast-icon="icon-share"
       >
         <svg
           class="settings-share__icon"
           width="20"
           height="20"
-          viewBox="0 0 24 24"
-          fill="none"
           aria-hidden="true"
         >
-          <path
-            d="M9.5 13.5 14.5 8.5m-6.25 1.5H6a3 3 0 0 0 0 6h2.25m7.5-6H18a3 3 0 0 1 0 6h-2.25"
-            stroke="currentColor"
-            stroke-width="1.75"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
+          <use
+            href="{{ "img/svg/sprite.svg?v=20260708a" | relURL }}#icon-share"
+          ></use>
         </svg>
         <span class="settings-share__label">{{ i18n "share_theme" }}</span>
       </button>
@@ -488,7 +482,6 @@
 
     {{- if gt $languageCount 1 -}}
       <div class="theme-divider"></div>
-
 
       <div class="theme-section">
         <div class="theme-section-heading">

--- a/static/img/svg/sprite.svg
+++ b/static/img/svg/sprite.svg
@@ -305,4 +305,10 @@
     <path d="M0.5 7.5h2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
     <path d="M9.5 2.5H6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
   </symbol>
+  <!-- Share / Hyperlink Icon -->
+  <symbol id="icon-share" viewBox="0 0 24 24">
+    <path d="M10.082 9.5A4.47 4.47 0 0 0 6.75 8h-1.5a4.5 4.5 0 0 0 0 9h1.5a4.474 4.474 0 0 0 3.332 -1.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+    <path d="M13.918 9.5A4.469 4.469 0 0 1 17.25 8h1.5a4.5 4.5 0 1 1 0 9h-1.5a4.472 4.472 0 0 1 -3.332 -1.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+    <path d="m6.75 12.499 10.5 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+  </symbol>
 </svg>


### PR DESCRIPTION
Three related pieces of work on the composition/layout system, rebased on top of the new terminal layout (#222) and integrated with it.

## 1. Page spacing → the `--layout-*` contract
Lifted the last hardcoded page margins/paddings into the layout token layer, so each composition tunes its own breathing room. New tokens in `tokens/semantic.css` (defaults equal today's values → **column is a visual no-op**):

- `--layout-content-top` — `.content` top padding (inner pages)
- `--layout-hero-heading-top` — `.startpage-heading` top padding (home hero)
- `--layout-about-cv-gap` — `.about-cv` margin-top
- `--layout-contact-info-gap` — `.contact-info` margin-bottom

**Index:** the hero section already carries `--layout-hero-rhythm`, so the heading's own top pad stacked a double gap above the lead. Index dials it down to `spacing-8` so the lead sits near the top instead of floating mid-screen; inner-page/about/contact gaps tighten to match. **Editorial** trims the redundant double hero pad and opens the rest up. **Terminal** now drives its `.content`/`.startpage-heading` padding through the tokens (replacing its direct selector override) and aligns about/contact gaps to its tight `spacing-24` stream rhythm.

## 2. Hero role line-break, tuned per layout × typeface
The single `42.5em` breakpoint was calibrated for the large hero font and fired far too early for index (whose hero is `~text-lg`). Breakpoints now track hero font size (layout) and typeface width (mono breaks earliest), verified with Chrome screenshots against the longest role at the boundary widths:

| Layout | Base | + mono (`technical`) |
|---|---|---|
| column (default) | ≤38em | ≤42em |
| editorial (1.15×) | ≤42em | ≤46em |
| index (`~text-lg`) | ≤26em | ≤30em |
| terminal (`~text-base`, still role) | ≤28em | — |

Index at ~680px now keeps the role on the lead's line instead of dropping it prematurely.

## 3. Shareable-look links
A **"Share this look"** action in the settings panel encodes `layout, typography, mode, palette, Pantone year, blend, grain` into a `?theme=` link. The decoder runs in the inline head script **before first paint** (no flash) and persists to `localStorage`; `theme-share.js` copies the link and cleans the query from the address bar afterwards. A custom palette is device-local and is omitted. Round-trip verified: a fresh visitor opening the link gets the full composition (e.g. index + technical + dark + Pantone 2020 Classic Blue + blend + grain), including the terminal layout.

## Verification
- 458 unit tests pass; ESLint + Prettier clean; Hugo build green.
- All 4 layouts × 3 typefaces screenshot-checked; every role-break config breaks at or before its natural wrap (no ugly reflow) and no longer breaks too early.
- Share round-trip driven end-to-end in Chrome (sender copies link → fresh recipient applies state → URL cleaned).

Docs: `docs/layout-dimension-plan.md` updated with the new tokens, the per-layout break table, and the shareable-seed note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdAWuNi5hTD4QiKzLEbf81)_