### PR TITLE
Terminal mode: mobile-typable prompt, inline Pantone controls, commands

### DIFF
--- a/assets/css/components/footer.css
+++ b/assets/css/components/footer.css
@@ -7,9 +7,11 @@
   margin-top: calc(var(--spacing-64) * var(--layout-prose-rhythm));
 }
 
-/* Terminal-layout tail prompt: rendered only when data-layout="terminal"
-   (see dimensions/layout/terminal.css). */
-.terminal-tail {
+/* Terminal-layout prompt + command-output log: rendered only when
+   data-layout="terminal" (see dimensions/layout/terminal.css). Hidden
+   everywhere else so a session's scrollback never leaks into other layouts. */
+.terminal-tail,
+.terminal-session {
   display: none;
 }
 

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1218,15 +1218,32 @@
   font-size: var(--terminal-font-size);
 }
 
+:root[data-layout="terminal"] .terminal-tail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+
 :root[data-layout="terminal"] .terminal-tail__prompt::before {
   content: var(--terminal-ps1);
   color: var(--text-muted, inherit);
 }
 
-/* Fish-style ghost suggestion after the caret: exit, with the hint. */
-:root[data-layout="terminal"] .terminal-tail__suggest {
-  color: var(--text-muted, inherit);
-  opacity: 0.7;
+/* The live command line: seamless with the buffer — no chrome, mono font,
+   themed native caret. Auto-sized to its content (JS keeps size in sync) so
+   the trailing hint hugs the text instead of floating to the far right. */
+:root[data-layout="terminal"] .terminal-tail__input {
+  flex: 0 1 auto;
+  min-width: 1ch;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  caret-color: var(--text-accent, currentColor);
+  outline: none;
 }
 
 :root[data-layout="terminal"] .terminal-tail::after {
@@ -1236,6 +1253,8 @@
   opacity: 0.7;
 }
 
+/* Idle block caret hugging the prompt — an invitation to tap. It gives way to
+   the native text caret the moment the input is focused or holds text. */
 :root[data-layout="terminal"] .terminal-tail__caret {
   display: inline-block;
   width: 0.55em;
@@ -1243,6 +1262,11 @@
   vertical-align: text-bottom;
   background: var(--text-accent, currentColor);
   animation: terminal-caret-blink 1.1s steps(1) infinite;
+}
+
+:root[data-layout="terminal"] .terminal-tail:focus-within .terminal-tail__caret,
+:root[data-layout="terminal"] .terminal-tail.is-typing .terminal-tail__caret {
+  display: none;
 }
 
 @keyframes terminal-caret-blink {
@@ -1259,6 +1283,47 @@
 
 :root[data-effect-reduced-motion="on"] .terminal-tail__caret {
   animation: none;
+}
+
+/* Command output: each executed line prints into the buffer above the live
+   prompt, so the page reads as one continuous session. Empty (and so invisible)
+   until a command runs. */
+:root[data-layout="terminal"] .terminal-session {
+  display: block;
+  grid-column: content-start / content-end;
+  justify-self: start;
+  margin-top: var(--spacing-24);
+  font-size: var(--terminal-font-size);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+:root[data-layout="terminal"] .terminal-session:empty {
+  display: none;
+}
+
+/* First tail after a non-empty session log sits tight against it, not a full
+   buffer gap — the prompt follows its own output. */
+:root[data-layout="terminal"] .terminal-session:not(:empty) + .terminal-tail {
+  margin-top: var(--spacing-8);
+}
+
+:root[data-layout="terminal"] .terminal-session__line {
+  display: block;
+}
+
+/* Echoed command lines carry the real prompt string, like scrollback. */
+:root[data-layout="terminal"] .terminal-session__cmd::before {
+  content: var(--terminal-ps1);
+  color: var(--text-muted, inherit);
+}
+
+:root[data-layout="terminal"] .terminal-session__out {
+  color: var(--text-muted, inherit);
+}
+
+:root[data-layout="terminal"] .terminal-session__out--art {
+  color: inherit;
 }
 
 :root[data-layout="terminal"] .footer-column {
@@ -1530,19 +1595,40 @@
    ============================================================================ */
 
 :root[data-layout="terminal"] .coty-transport {
-  left: var(--size-page-margins);
-  right: var(--size-page-margins);
+  /* Inline job line inside the settings buffer, not a floating pill: JS moves
+     the node under the Effects toggles (see syncCotyTransportPlacement in
+     darkmode.js), and these overrides drop the fixed positioning so it lays
+     out in normal flow. */
+  position: static;
+  inset: auto;
+  z-index: auto;
+  left: auto;
+  right: auto;
+  margin: 0;
   width: auto;
   max-width: none;
   justify-content: flex-start;
-  padding: var(--spacing-4) 0;
-  background: var(--surface-page);
+  padding: var(--spacing-4) 0 0;
+  background: transparent;
   border: none;
   border-radius: 0;
   box-shadow: none;
+  transform: none;
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
   font-size: var(--terminal-font-size);
+}
+
+/* The pill's mobile rule hides .coty-transport while a panel is open; inline in
+   the terminal that is exactly when we want it, so keep it visible. */
+@media (max-width: 29.9375em) {
+  html[data-layout="terminal"][data-settings-panel-open="true"] .coty-transport,
+  html[data-layout="terminal"][data-theme-panel-open="true"] .coty-transport {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: none;
+  }
 }
 
 :root[data-layout="terminal"]

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1456,6 +1456,12 @@
   display: none;
 }
 
+/* No mobile bottom-sheet drag handle — the panel is inline buffer text here,
+   not a sheet. (Below 30em the component CSS draws one via ::before.) */
+:root[data-layout="terminal"] .settings-panel::before {
+  display: none;
+}
+
 /* --- Text-only panel content (all widths) --- */
 
 :root[data-layout="terminal"] .settings-panel .theme-section,
@@ -1652,6 +1658,7 @@
   margin: 0;
   width: auto;
   max-width: none;
+  flex-wrap: wrap;
   justify-content: flex-start;
   padding: var(--spacing-4) 0 0;
   background: transparent;
@@ -1659,9 +1666,18 @@
   border-radius: 0;
   box-shadow: none;
   transform: none;
+  /* Inline in the buffer the pill's clipping (for its collapse animation) just
+     truncates the job-line controls on a phone — let them wrap and show. */
+  overflow: visible;
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
   font-size: var(--terminal-font-size);
+}
+
+/* Drop the floating pill's rim-light border — the inline job line is plain
+   buffer text, not a raised surface. */
+:root[data-layout="terminal"] .coty-transport::after {
+  display: none;
 }
 
 /* The pill's mobile rule hides .coty-transport while a panel is open; inline in
@@ -1704,11 +1720,17 @@
   border: none;
   box-shadow: none;
   padding: 0;
+  /* The pill caps its width and clips for the expand animation; inline we want
+     the full control row, wrapping onto more lines if the phone is narrow. */
+  max-width: none;
+  overflow: visible;
 }
 
 :root[data-layout="terminal"] .coty-player__controls {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
+  justify-content: flex-start;
   gap: 2ch;
   padding: 0;
 }

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1209,6 +1209,10 @@
 }
 
 /* The buffer ends with an empty prompt, waiting. */
+/* The buffer ends with a live prompt. Kept as a normal block so the prompt,
+   caret, input and hint all flow inline like one line of terminal text —
+   crucially NOT a flex row, which (with the input's native field box) pushed
+   the field onto its own line on mobile. */
 :root[data-layout="terminal"] .terminal-tail {
   display: block;
   grid-column: content-start / content-end;
@@ -1218,32 +1222,47 @@
   font-size: var(--terminal-font-size);
 }
 
-:root[data-layout="terminal"] .terminal-tail {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-}
-
 :root[data-layout="terminal"] .terminal-tail__prompt::before {
   content: var(--terminal-ps1);
   color: var(--text-muted, inherit);
 }
 
-/* The live command line: seamless with the buffer — no chrome, mono font,
-   themed native caret. Auto-sized to its content (JS keeps size in sync) so
-   the trailing hint hugs the text instead of floating to the far right. */
+/* The live command line: an inline field with all native chrome stripped
+   (-webkit-appearance:none kills the rounded box / focus ring iOS draws), so
+   it reads as raw prompt text with the themed caret. Auto-sized to its content
+   (JS keeps the size attribute in sync) so the trailing hint hugs the text. */
 :root[data-layout="terminal"] .terminal-tail__input {
-  flex: 0 1 auto;
+  -webkit-appearance: none;
+  appearance: none;
+  display: inline;
+  width: auto;
   min-width: 1ch;
   margin: 0;
   padding: 0;
   border: 0;
+  border-radius: 0;
   background: none;
+  box-shadow: none;
   color: inherit;
   font: inherit;
   line-height: inherit;
+  vertical-align: baseline;
   caret-color: var(--text-accent, currentColor);
   outline: none;
+}
+
+/* Belt-and-braces for iOS Safari, which still paints an inner box otherwise. */
+:root[data-layout="terminal"] .terminal-tail__input:focus,
+:root[data-layout="terminal"] .terminal-tail__input:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
+:root[data-layout="terminal"] .terminal-tail::after {
+  content: "  # " attr(data-exit-hint);
+  font-family: var(--font-mono);
+  color: var(--text-muted, inherit);
+  opacity: 0.7;
 }
 
 :root[data-layout="terminal"] .terminal-tail::after {
@@ -1324,6 +1343,26 @@
 
 :root[data-layout="terminal"] .terminal-session__out--art {
   color: inherit;
+}
+
+/* Echoed answers inside an interactive flow (contact / subscribe) read like
+   what the user typed at the field prompt. */
+:root[data-layout="terminal"] .terminal-session__flow {
+  display: block;
+  color: var(--text-default, inherit);
+}
+
+/* During a flow the prompt shows the current field name (email>, name>, …)
+   instead of the shell PS1, and the trailing hint offers the abort word. */
+:root[data-layout="terminal"]
+  .terminal-tail[data-flow-label]
+  .terminal-tail__prompt::before {
+  content: attr(data-flow-label) " ";
+  color: var(--text-muted, inherit);
+}
+
+:root[data-layout="terminal"] .terminal-tail[data-flow-label]::after {
+  content: "  # type cancel to abort";
 }
 
 :root[data-layout="terminal"] .footer-column {

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1353,10 +1353,10 @@
 }
 
 /* During a flow the prompt shows the current field name (email>, name>, …)
-   instead of the shell PS1, and the trailing hint offers the abort word. */
-:root[data-layout="terminal"]
-  .terminal-tail[data-flow-label]
-  .terminal-tail__prompt::before {
+   instead of the shell PS1, and the trailing hint offers the abort word. The
+   label is read from the prompt span's OWN attribute — attr() can't reach an
+   ancestor's — so darkmode.js sets data-flow-label on both. */
+:root[data-layout="terminal"] .terminal-tail__prompt[data-flow-label]::before {
   content: attr(data-flow-label) " ";
   color: var(--text-muted, inherit);
 }

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -552,6 +552,12 @@
   flex: none;
 }
 
+/* The `cd` echo carried in from a nav click (see darkmode.js): the command
+   that got you here, printed above this page's own prompt as scrollback. */
+:root[data-layout="terminal"] .terminal-prompt--cd {
+  margin-bottom: var(--spacing-4);
+}
+
 :root[data-layout="terminal"] .terminal-prompt__host-plain {
   font-weight: 700;
 }
@@ -1208,7 +1214,14 @@
   font-family: var(--font-mono);
 }
 
-/* The buffer ends with an empty prompt, waiting. */
+/* Subsequent pages in a session skip the login banner (ASCII art + status):
+   a MOTD prints once, not on every cd. The exit hint stays — it's navigation
+   help, not boot chrome. Flag is set pre-paint in head.html, so no flash. */
+:root[data-terminal-booted][data-layout="terminal"] .terminal-boot__art,
+:root[data-terminal-booted][data-layout="terminal"] .terminal-boot__meta {
+  display: none;
+}
+
 /* The buffer ends with a live prompt. Kept as a normal block so the prompt,
    caret, input and hint all flow inline like one line of terminal text —
    crucially NOT a flex row, which (with the input's native field box) pushed

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1265,13 +1265,6 @@
   opacity: 0.7;
 }
 
-:root[data-layout="terminal"] .terminal-tail::after {
-  content: "  # " attr(data-exit-hint);
-  font-family: var(--font-mono);
-  color: var(--text-muted, inherit);
-  opacity: 0.7;
-}
-
 /* Idle block caret hugging the prompt — an invitation to tap. It gives way to
    the native text caret the moment the input is focused or holds text. */
 :root[data-layout="terminal"] .terminal-tail__caret {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -75,6 +75,11 @@ describe("terminal command line", () => {
           </div>
         </div>
         <button data-js="grid-toggle" aria-pressed="false"></button>
+        <a class="terminal-prompt__host" href="/"></a>
+        <nav class="top-menu__nav">
+          <a class="top-menu__link" href="/writing/">Writing</a>
+          <a class="top-menu__link" href="/about/">About</a>
+        </nav>
         <div data-js="coty-transport" hidden>
           <button data-js="coty-transport-trigger" aria-label="Show"></button>
           <button
@@ -283,6 +288,94 @@ describe("terminal command line", () => {
     typeCommand("cancel");
     expect(tailPrompt()).toBeNull();
     expect(sessionText()).toContain("^C");
+  });
+
+  test("pantone <year> activates and sets that year", () => {
+    loadModule();
+    typeCommand("pantone 2026");
+    expect(sessionText()).toContain("year → 2026");
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+    expect(window.CotyScaleActions.setYear).toHaveBeenCalled();
+  });
+
+  test("pantone rejects a year that isn't available", () => {
+    loadModule();
+    typeCommand("pantone 1999");
+    expect(sessionText()).toContain("no year 1999");
+    // No activation on a rejected year.
+    expect(document.documentElement.getAttribute("data-palette")).not.toBe(
+      "pantone"
+    );
+  });
+
+  test("an unknown pantone option reports usage without toggling", () => {
+    loadModule();
+    typeCommand("pantone on");
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+    typeCommand("pantone wat");
+    expect(sessionText()).toContain("unknown option 'wat'");
+    // Still active — an unknown option must not toggle Pantone off.
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+  });
+
+  test("pantone next advances the year and activates", () => {
+    loadModule();
+    typeCommand("pantone next");
+    expect(sessionText()).toContain("next year");
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+  });
+
+  test("grain on / off / toggle drives the grain effect", () => {
+    loadModule();
+    typeCommand("grain on");
+    expect(document.documentElement.getAttribute("data-effect-grain")).toBe(
+      "on"
+    );
+    typeCommand("grain off");
+    expect(document.documentElement.getAttribute("data-effect-grain")).toBe(
+      "off"
+    );
+    typeCommand("grain");
+    expect(document.documentElement.getAttribute("data-effect-grain")).toBe(
+      "on"
+    );
+  });
+
+  test("blend and motion effects respond to on/off", () => {
+    loadModule();
+    typeCommand("blend on");
+    expect(document.documentElement.getAttribute("data-effect-blend")).toBe(
+      "on"
+    );
+    typeCommand("motion on");
+    expect(
+      document.documentElement.getAttribute("data-effect-reduced-motion")
+    ).toBe("on");
+  });
+
+  test("cd rejects unknown pages and resolves known ones", () => {
+    // jsdom's window.location is non-configurable, so the navigation side
+    // effect isn't observable here — assert the resolution logic instead: an
+    // unknown page errors, a known nav page does not (it produces a navigate
+    // action, exercised for real in the browser check).
+    loadModule();
+    typeCommand("cd nope");
+    expect(sessionText()).toContain("no such file or directory: nope");
+
+    const before = sessionText();
+    typeCommand("cd writing");
+    // No new error line for a page that exists in the nav.
+    expect(sessionText().slice(before.length)).not.toContain(
+      "no such file or directory"
+    );
   });
 
   test("subscribe reuses the newsletter form action", async () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1,0 +1,218 @@
+/**
+ * Terminal command line (darkmode.js): the tail <input> that fixes mobile
+ * typing and hosts the small command set + easter eggs. Driven the same way as
+ * darkmode-pantone.test.js — require the module, fire DOMContentLoaded, then
+ * dispatch real events at the input.
+ */
+describe("terminal command line", () => {
+  function setupCotyActions() {
+    const entries = [{ year: 2026, name: "Latest" }];
+    let currentYear = 2026;
+    window.CotyScaleActions = {
+      init: jest.fn(),
+      applyPreviewForMode: jest.fn(),
+      applyForMode: jest.fn(),
+      clearRuntime: jest.fn(),
+      getEntries: jest.fn(() => entries),
+      getCurrentYear: jest.fn(() => currentYear),
+      getEntry: jest.fn(
+        (year) =>
+          entries.find((entry) => Number(entry.year) === Number(year)) || null
+      ),
+      setYear: jest.fn((year) => {
+        currentYear = Number(year);
+        return (
+          entries.find((entry) => Number(entry.year) === currentYear) || null
+        );
+      }),
+    };
+  }
+
+  function loadModule() {
+    jest.isolateModules(() => {
+      require("../darkmode.js");
+    });
+    document.dispatchEvent(new window.Event("DOMContentLoaded"));
+  }
+
+  function typeCommand(value) {
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = value;
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    input.dispatchEvent(
+      new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+    );
+  }
+
+  function sessionText() {
+    return document.querySelector('[data-js="terminal-session"]').textContent;
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    localStorage.clear();
+    localStorage.setItem("theme-layout", "terminal");
+    document.documentElement.setAttribute("data-layout", "terminal");
+
+    document.documentElement.innerHTML = `
+      <head><meta name="theme-color" content="#ffffff"></head>
+      <body>
+        <div class="terminal-boot">
+          <pre class="terminal-boot__art terminal-boot__art--sm">  ██\n ████</pre>
+        </div>
+        <button data-js="mode-option" data-mode="light"></button>
+        <button data-js="mode-option" data-mode="dark"></button>
+        <div data-js="settings-panel" hidden>
+          <div class="theme-section">
+            <button
+              data-js="coty-mode-toggle"
+              data-label-activate="Activate Pantone"
+              data-label-deactivate="Deactivate Pantone"
+              aria-label="Activate Pantone"
+              aria-pressed="false"
+            ></button>
+          </div>
+        </div>
+        <button data-js="grid-toggle" aria-pressed="false"></button>
+        <div data-js="coty-transport" hidden>
+          <button data-js="coty-transport-trigger" aria-label="Show"></button>
+          <button
+            data-js="coty-transport-toggle"
+            data-label-play="Play"
+            data-label-pause="Pause"
+            aria-label="Play"
+          ><svg data-js="coty-play-icon"></svg></button>
+        </div>
+        <div class="terminal-session" data-js="terminal-session" aria-live="polite"></div>
+        <p class="terminal-tail" data-exit-hint="type exit or press esc">
+          <span class="terminal-tail__prompt"></span
+          ><span class="terminal-tail__caret"></span
+          ><input id="terminal-input" class="terminal-tail__input" data-js="terminal-input" type="text" size="1" />
+        </p>
+      </body>
+    `;
+
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+    window.getComputedStyle = jest.fn(() => ({
+      getPropertyValue: jest.fn(() => "#ffffff"),
+    }));
+    window.Toast = { show: jest.fn() };
+    window.requestAnimationFrame = jest.fn();
+    window.scrollTo = jest.fn();
+    setupCotyActions();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("the prompt is a real, focusable input (mobile keyboard fix)", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    expect(input).not.toBeNull();
+    expect(input.tagName).toBe("INPUT");
+    // Not hidden from assistive tech / not disabled — tapping it must focus.
+    expect(input.getAttribute("aria-hidden")).toBeNull();
+    expect(input.disabled).toBe(false);
+  });
+
+  test("Enter runs a command, echoes it, and clears the input", () => {
+    loadModule();
+    typeCommand("help");
+    expect(sessionText()).toContain("help");
+    expect(sessionText()).toContain("available commands:");
+    expect(document.querySelector('[data-js="terminal-input"]').value).toBe("");
+  });
+
+  test("dark / light change the colour mode", () => {
+    loadModule();
+    typeCommand("dark");
+    expect(document.documentElement.getAttribute("data-mode")).toBe("dark");
+    typeCommand("light");
+    expect(document.documentElement.getAttribute("data-mode")).toBe("light");
+  });
+
+  test("pantone on activates the colour-of-the-year effect", () => {
+    loadModule();
+    typeCommand("pantone on");
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+    typeCommand("pantone off");
+    expect(document.documentElement.getAttribute("data-palette")).not.toBe(
+      "pantone"
+    );
+  });
+
+  test("grid toggles the grid overlay button", () => {
+    loadModule();
+    const gridBtn = document.querySelector('[data-js="grid-toggle"]');
+    const clickSpy = jest.spyOn(gridBtn, "click");
+    typeCommand("grid");
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  test("echo prints its argument", () => {
+    loadModule();
+    typeCommand("echo hello world");
+    expect(sessionText()).toContain("hello world");
+  });
+
+  test("sudo refuses with a joke", () => {
+    loadModule();
+    typeCommand("sudo rm -rf /");
+    expect(sessionText().toLowerCase()).toContain("permission denied");
+  });
+
+  test("neofetch prints a session summary", () => {
+    loadModule();
+    typeCommand("neofetch");
+    expect(sessionText()).toContain("layout    terminal");
+  });
+
+  test("unknown commands report command not found", () => {
+    loadModule();
+    typeCommand("frobnicate");
+    expect(sessionText()).toContain("frobnicate: command not found");
+  });
+
+  test("clear empties the session log", () => {
+    loadModule();
+    typeCommand("whoami");
+    expect(sessionText().length).toBeGreaterThan(0);
+    typeCommand("clear");
+    expect(sessionText()).toBe("");
+  });
+
+  test("Pantone controls render inline inside the settings panel (not floating)", () => {
+    loadModule();
+    const panel = document.querySelector('[data-js="settings-panel"]');
+    const transport = document.querySelector('[data-js="coty-transport"]');
+    // In the terminal the transport is moved out of its floating home and into
+    // the settings panel, right after the Effects section — the core of the
+    // "render inline under the settings" change. (Restoring the floating pill on
+    // leaving the terminal is exercised in the browser, not here: this harness
+    // reloads the module against a shared jsdom window, which accumulates the
+    // layout listener and makes a within-suite layout switch unreliable.)
+    expect(transport.parentNode).toBe(panel);
+    expect(transport.previousElementSibling).toBe(
+      document
+        .querySelector('[data-js="coty-mode-toggle"]')
+        .closest(".theme-section")
+    );
+  });
+
+  test("exit leaves the terminal layout", () => {
+    localStorage.setItem("theme-layout-previous", "column");
+    loadModule();
+    typeCommand("exit");
+    expect(document.documentElement.getAttribute("data-layout")).not.toBe(
+      "terminal"
+    );
+  });
+});

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -95,6 +95,7 @@ describe("terminal command line", () => {
             <a class="terminal-prompt__host" href="/"></a>
             <a class="top-menu__link" href="/writing/">Writing</a>
             <a class="top-menu__link" href="/about/">About</a>
+            <a class="terminal-quick terminal-quick--lang" href="/sv/writing/" lang="sv">sv</a>
           </nav>
         </div>
         <div data-js="coty-transport" hidden>
@@ -526,6 +527,15 @@ describe("terminal command line", () => {
     document.querySelector('.top-menu__link[href="/writing/"]').click();
     const stashed = JSON.parse(sessionStorage.getItem("terminal-cd"));
     expect(stashed.cmd).toBe("cd ~/writing");
+  });
+
+  test("clicking the statusbar language toggle does NOT stash a cd echo", () => {
+    loadModule();
+    sessionStorage.removeItem("terminal-cd");
+    // A language switch changes language, not directory — no `cd` echo, and its
+    // /sv/writing/ href must not poison the "writing" cd target either.
+    document.querySelector(".terminal-quick--lang").click();
+    expect(sessionStorage.getItem("terminal-cd")).toBeNull();
   });
 
   test("a pending cd prints as scrollback above the page's first prompt", () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -225,6 +225,15 @@ describe("terminal command line", () => {
     );
   });
 
+  test("exit wipes the command scrollback (no leak into other layouts)", () => {
+    localStorage.setItem("theme-layout-previous", "column");
+    loadModule();
+    typeCommand("whoami");
+    expect(sessionText().length).toBeGreaterThan(0);
+    typeCommand("exit");
+    expect(sessionText()).toBe("");
+  });
+
   // ---- Interactive flows (contact / subscribe) --------------------------
 
   const flush = async () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -76,6 +76,17 @@ describe("terminal command line", () => {
         </div>
         <button data-js="grid-toggle" aria-pressed="false"></button>
         <button data-js="terminal-exit">[exit]</button>
+        <div class="language-list">
+          <label class="language-option"
+            ><input data-language-code="en" data-language-name="English" checked
+          /></label>
+          <label class="language-option"
+            ><input
+              data-language-code="sv"
+              data-language-name="Svenska"
+              data-language-href="/sv/"
+          /></label>
+        </div>
         <div class="top-menu__container">
           <span class="terminal-prompt terminal-prompt--nav"
             ><span class="terminal-prompt__cmd">ls nav/</span></span
@@ -473,6 +484,38 @@ describe("terminal command line", () => {
     expect(document.documentElement.hasAttribute("data-terminal-booted")).toBe(
       false
     );
+  });
+
+  // ---- language command -------------------------------------------------
+
+  test("lang lists the current and available languages", () => {
+    loadModule();
+    typeCommand("lang");
+    expect(sessionText()).toContain("language: en");
+    expect(sessionText()).toContain("sv");
+  });
+
+  test("lang <current> reports it's already active", () => {
+    loadModule();
+    typeCommand("lang en");
+    expect(sessionText().toLowerCase()).toContain("already");
+  });
+
+  test("lang rejects an unknown language", () => {
+    loadModule();
+    typeCommand("lang xx");
+    expect(sessionText()).toContain("unknown language 'xx'");
+  });
+
+  test("lang sv switches without a spurious cd echo", () => {
+    sessionStorage.removeItem("terminal-cd");
+    loadModule();
+    typeCommand("lang sv");
+    const txt = sessionText().toLowerCase();
+    expect(txt).not.toContain("unknown");
+    expect(txt).not.toContain("already");
+    // A language switch is the same directory — no cd echo may be stashed.
+    expect(sessionStorage.getItem("terminal-cd")).toBeNull();
   });
 
   // ---- Nav "cd" feedback ------------------------------------------------

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -119,6 +119,14 @@ describe("terminal command line", () => {
     window.Toast = { show: jest.fn() };
     window.requestAnimationFrame = jest.fn();
     window.scrollTo = jest.fn();
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: {
+        load: jest.fn(() => Promise.resolve()),
+        ready: Promise.resolve(),
+        check: jest.fn(() => true),
+      },
+    });
     setupCotyActions();
   });
 
@@ -453,6 +461,18 @@ describe("terminal command line", () => {
     expect(url).toBe("https://example.test/subscribe");
     expect(opts.body).toContain("EMAIL=me%40example.com");
     expect(sessionText().toLowerCase()).toContain("subscribed");
+  });
+
+  test("re-entering the terminal un-hides the boot banner", () => {
+    // A subsequent page hides the banner via data-terminal-booted; starting the
+    // terminal again (a fresh boot) must reveal it.
+    document.documentElement.setAttribute("data-terminal-booted", "1");
+    loadModule();
+    window.ThemeActions.setLayout("column");
+    window.ThemeActions.setLayout("terminal");
+    expect(document.documentElement.hasAttribute("data-terminal-booted")).toBe(
+      false
+    );
   });
 
   // ---- Nav "cd" feedback ------------------------------------------------

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -76,11 +76,16 @@ describe("terminal command line", () => {
         </div>
         <button data-js="grid-toggle" aria-pressed="false"></button>
         <button data-js="terminal-exit">[exit]</button>
-        <a class="terminal-prompt__host" href="/"></a>
-        <nav class="top-menu__nav">
-          <a class="top-menu__link" href="/writing/">Writing</a>
-          <a class="top-menu__link" href="/about/">About</a>
-        </nav>
+        <div class="top-menu__container">
+          <span class="terminal-prompt terminal-prompt--nav"
+            ><span class="terminal-prompt__cmd">ls nav/</span></span
+          >
+          <nav class="top-menu__nav">
+            <a class="terminal-prompt__host" href="/"></a>
+            <a class="top-menu__link" href="/writing/">Writing</a>
+            <a class="top-menu__link" href="/about/">About</a>
+          </nav>
+        </div>
         <div data-js="coty-transport" hidden>
           <button data-js="coty-transport-trigger" aria-label="Show"></button>
           <button
@@ -448,6 +453,37 @@ describe("terminal command line", () => {
     expect(url).toBe("https://example.test/subscribe");
     expect(opts.body).toContain("EMAIL=me%40example.com");
     expect(sessionText().toLowerCase()).toContain("subscribed");
+  });
+
+  // ---- Nav "cd" feedback ------------------------------------------------
+
+  test("clicking a nav link stashes a cd command for the next page", () => {
+    loadModule();
+    sessionStorage.removeItem("terminal-cd");
+    document.querySelector('.top-menu__link[href="/writing/"]').click();
+    const stashed = JSON.parse(sessionStorage.getItem("terminal-cd"));
+    expect(stashed.cmd).toBe("cd ~/writing");
+  });
+
+  test("a pending cd prints as scrollback above the page's first prompt", () => {
+    sessionStorage.setItem(
+      "terminal-cd",
+      JSON.stringify({ from: "~/writing", cmd: "cd ~/about" })
+    );
+    loadModule();
+    const container = document.querySelector(".top-menu__container");
+    const first = container.querySelector(":scope > .terminal-prompt");
+    // The injected echo is the container's first prompt, before the nav prompt.
+    expect(first.classList.contains("terminal-prompt--cd")).toBe(true);
+    expect(first.querySelector(".terminal-prompt__cmd").textContent).toBe(
+      "cd ~/about"
+    );
+    // Its cwd is overridden to where we came from.
+    expect(first.style.getPropertyValue("--terminal-cwd")).toContain(
+      "~/writing"
+    );
+    // Consumed — not shown again on a plain reload.
+    expect(sessionStorage.getItem("terminal-cd")).toBeNull();
   });
 
   test("subscribe reports a server error instead of parsing non-OK JSON", async () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -84,6 +84,10 @@ describe("terminal command line", () => {
             aria-label="Play"
           ><svg data-js="coty-play-icon"></svg></button>
         </div>
+        <form class="footer-newsletter__form" action="https://example.test/subscribe" method="post" data-mc-form novalidate>
+          <input type="email" name="EMAIL" />
+          <input type="hidden" name="locale" value="en" />
+        </form>
         <div class="terminal-session" data-js="terminal-session" aria-live="polite"></div>
         <p class="terminal-tail" data-exit-hint="type exit or press esc">
           <span class="terminal-tail__prompt"></span
@@ -125,7 +129,7 @@ describe("terminal command line", () => {
     loadModule();
     typeCommand("help");
     expect(sessionText()).toContain("help");
-    expect(sessionText()).toContain("available commands:");
+    expect(sessionText()).toContain("commands:");
     expect(document.querySelector('[data-js="terminal-input"]').value).toBe("");
   });
 
@@ -214,5 +218,92 @@ describe("terminal command line", () => {
     expect(document.documentElement.getAttribute("data-layout")).not.toBe(
       "terminal"
     );
+  });
+
+  // ---- Interactive flows (contact / subscribe) --------------------------
+
+  const flush = async () => {
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  function tailPrompt() {
+    return document
+      .querySelector(".terminal-tail")
+      .getAttribute("data-flow-label");
+  }
+
+  test("contact walks through prompts and POSTs to the Netlify form", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    window.fetch = fetchMock;
+
+    loadModule();
+    typeCommand("contact");
+    // The prompt switches to the first field.
+    expect(tailPrompt()).toBe("email>");
+    expect(sessionText()).toContain("contact —");
+
+    typeCommand("me@example.com");
+    expect(tailPrompt()).toBe("name>");
+    typeCommand("Ada");
+    expect(tailPrompt()).toBe("message>");
+    typeCommand("hello there");
+    // Now at the confirmation step.
+    expect(tailPrompt()).toBe("send this? [Y/n]");
+
+    typeCommand("y");
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/");
+    expect(opts.body).toContain("form-name=contact");
+    expect(opts.body).toContain("email=me%40example.com");
+    expect(opts.body).toContain("name=Ada");
+    expect(sessionText().toLowerCase()).toContain("message sent");
+    // Flow ended: prompt restored.
+    expect(tailPrompt()).toBeNull();
+  });
+
+  test("contact re-prompts on an invalid email", () => {
+    loadModule();
+    typeCommand("contact");
+    typeCommand("not-an-email");
+    // Still on the email step, with an error printed.
+    expect(tailPrompt()).toBe("email>");
+    expect(sessionText().toLowerCase()).toContain("email");
+  });
+
+  test("cancel aborts a flow", () => {
+    loadModule();
+    typeCommand("contact");
+    typeCommand("cancel");
+    expect(tailPrompt()).toBeNull();
+    expect(sessionText()).toContain("^C");
+  });
+
+  test("subscribe reuses the newsletter form action", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+    window.fetch = fetchMock;
+
+    loadModule();
+    typeCommand("subscribe");
+    expect(tailPrompt()).toBe("email>");
+    typeCommand("me@example.com");
+    expect(tailPrompt()).toBe("subscribe with this address? [Y/n]");
+    typeCommand("y");
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.test/subscribe");
+    expect(opts.body).toContain("EMAIL=me%40example.com");
+    expect(sessionText().toLowerCase()).toContain("subscribed");
   });
 });

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -75,6 +75,7 @@ describe("terminal command line", () => {
           </div>
         </div>
         <button data-js="grid-toggle" aria-pressed="false"></button>
+        <button data-js="terminal-exit">[exit]</button>
         <a class="terminal-prompt__host" href="/"></a>
         <nav class="top-menu__nav">
           <a class="top-menu__link" href="/writing/">Writing</a>
@@ -299,6 +300,33 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("^C");
   });
 
+  test("exit during a flow resets it (no stale flow on re-entry)", () => {
+    localStorage.setItem("theme-layout-previous", "column");
+    loadModule();
+    typeCommand("contact");
+    expect(tailPrompt()).toBe("email>");
+    // Leaving via the [exit] button (typing "exit" mid-flow would be flow
+    // input, not the command) must clear the flow state + label.
+    document.querySelector('[data-js="terminal-exit"]').click();
+    expect(document.documentElement.getAttribute("data-layout")).not.toBe(
+      "terminal"
+    );
+    expect(tailPrompt()).toBeNull();
+  });
+
+  test("Escape aborting a flow clears the half-typed input", () => {
+    loadModule();
+    typeCommand("contact");
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "hello";
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    input.dispatchEvent(
+      new window.KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+    expect(tailPrompt()).toBeNull(); // flow aborted
+    expect(input.value).toBe(""); // stale text cleared
+  });
+
   test("pantone <year> activates and sets that year", () => {
     loadModule();
     typeCommand("pantone 2026");
@@ -358,13 +386,26 @@ describe("terminal command line", () => {
     );
   });
 
-  test("blend and motion effects respond to on/off", () => {
+  test("blend responds to on/off", () => {
     loadModule();
     typeCommand("blend on");
     expect(document.documentElement.getAttribute("data-effect-blend")).toBe(
       "on"
     );
+    typeCommand("blend off");
+    expect(document.documentElement.getAttribute("data-effect-blend")).toBe(
+      "off"
+    );
+  });
+
+  test("motion on means animation ON (reduced-motion off), and vice versa", () => {
+    loadModule();
+    // "motion on" = motion enabled = reduced-motion OFF (inverse of the attr).
     typeCommand("motion on");
+    expect(
+      document.documentElement.getAttribute("data-effect-reduced-motion")
+    ).toBe("off");
+    typeCommand("motion off");
     expect(
       document.documentElement.getAttribute("data-effect-reduced-motion")
     ).toBe("on");
@@ -407,5 +448,24 @@ describe("terminal command line", () => {
     expect(url).toBe("https://example.test/subscribe");
     expect(opts.body).toContain("EMAIL=me%40example.com");
     expect(sessionText().toLowerCase()).toContain("subscribed");
+  });
+
+  test("subscribe reports a server error instead of parsing non-OK JSON", async () => {
+    // Non-OK response with an HTML body — response.json() would reject; the
+    // guard must report a server error, not the generic "offline".
+    window.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error("not json")),
+    });
+
+    loadModule();
+    typeCommand("subscribe");
+    typeCommand("me@example.com");
+    typeCommand("y");
+    await flush();
+
+    expect(sessionText().toLowerCase()).toContain("server rejected");
+    expect(sessionText().toLowerCase()).not.toContain("offline");
   });
 });

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -722,23 +722,27 @@
   var terminalBootTimer = null;
 
   function playTerminalBoot() {
-    if (
-      (typeof window.matchMedia === "function" &&
-        window.matchMedia("(prefers-reduced-motion: reduce)").matches) ||
-      document.documentElement.getAttribute("data-effect-reduced-motion") ===
-        "on"
-    ) {
-      return;
-    }
     var root = document.documentElement;
-    root.classList.remove("terminal-booting");
-    void root.offsetWidth;
-    root.classList.add("terminal-booting");
+    // A boot means the banner is shown fresh: un-hide it (an earlier page this
+    // session may have set data-terminal-booted to hide it) and record that the
+    // session has now booted, so later pages skip the banner. Done regardless
+    // of reduced motion — only the staged animation below is motion-gated.
+    root.removeAttribute("data-terminal-booted");
     try {
       sessionStorage.setItem("terminal-boot-played", "1");
     } catch (e) {
       /* storage unavailable — the boot simply replays next load */
     }
+    if (
+      (typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches) ||
+      root.getAttribute("data-effect-reduced-motion") === "on"
+    ) {
+      return; // banner shown, but skip the staged print
+    }
+    root.classList.remove("terminal-booting");
+    void root.offsetWidth;
+    root.classList.add("terminal-booting");
     if (terminalBootTimer) {
       window.clearTimeout(terminalBootTimer);
     }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1243,6 +1243,12 @@
           ? cotyTransportHome.next
           : null;
       cotyTransportHome.parent.insertBefore(node, ref);
+      // Back as the floating pill: land in the collapsed three-dot resting
+      // state right away rather than leaving the full player expanded (it was
+      // forced open while inline in the terminal settings).
+      if (isPantoneModeActive()) {
+        setCotyTransportUiState("collapsed");
+      }
     }
   }
 
@@ -2174,10 +2180,12 @@
       "  whoami    who's asking",
       "  date      date & time",
       "  pwd       working dir",
+      "  cd <page> change page",
       "  echo      print text",
       "  neofetch  session info",
       "  dark|light|system  mode",
-      "  pantone   [on|off] effect",
+      "  pantone   [on|off|YYYY]",
+      "  grain|blend|motion on/off",
       "  grid      layout grid",
       "  contact   message me",
       "  subscribe newsletter",
@@ -2216,6 +2224,63 @@
         "lang      " + (document.documentElement.getAttribute("lang") || "en"),
         "shell     tor-sh 1.0",
       ];
+    }
+
+    // "on"/"off" from an argument, otherwise "toggle".
+    function onOffState(arg) {
+      var value = (arg || "").toLowerCase();
+      if (value === "on" || value === "enable" || value === "1") {
+        return "on";
+      }
+      if (value === "off" || value === "disable" || value === "0") {
+        return "off";
+      }
+      return "toggle";
+    }
+
+    // The home link the terminal prompt already points at (falls back to root).
+    function terminalHomeUrl() {
+      var host = document.querySelector(".terminal-prompt__host[href]");
+      return (host && host.getAttribute("href")) || "/";
+    }
+
+    // Map the nav's pages to `cd` targets, keyed by both URL slug and link text
+    // (so `cd writing` and `cd essays` both resolve if that's the label).
+    function terminalNavTargets() {
+      var map = {};
+      var links = document.querySelectorAll(
+        ".top-menu__nav a[href], .top-menu__link[href]"
+      );
+      links.forEach(function (link) {
+        var href = link.getAttribute("href");
+        if (!href || href.charAt(0) === "#") {
+          return;
+        }
+        var path = href.replace(/[?#].*$/, "").replace(/\/+$/, "");
+        var slug = path.split("/").filter(Boolean).pop();
+        if (slug) {
+          map[slug.toLowerCase()] = href;
+        }
+        var text = (link.textContent || "").trim().toLowerCase();
+        if (text) {
+          map[text] = href;
+        }
+      });
+      return map;
+    }
+
+    function resolveCdTarget(dest) {
+      var key = String(dest || "")
+        .replace(/^\/+|\/+$/g, "")
+        .toLowerCase();
+      if (!key) {
+        return terminalHomeUrl();
+      }
+      if (key === "home" || key === "~") {
+        return terminalHomeUrl();
+      }
+      var targets = terminalNavTargets();
+      return targets[key] || null;
     }
 
     // Returns { echo, lines, action }. `echo` is the command as typed (printed
@@ -2267,18 +2332,103 @@
               action: { type: "pantone", state: "on" },
             };
           }
+          if (sub === "next" || sub === "prev" || sub === "previous") {
+            var step = sub === "next" ? 1 : -1;
+            return {
+              echo: input,
+              lines: ["pantone: " + (step > 0 ? "next" : "previous") + " year"],
+              action: { type: "pantone", state: "step", step: step },
+            };
+          }
+          if (/^\d{4}$/.test(sub)) {
+            var wanted = parseInt(sub, 10);
+            var actions = getCotyActions();
+            var entries =
+              actions && typeof actions.getEntries === "function"
+                ? actions.getEntries()
+                : null;
+            if (
+              entries &&
+              entries.length &&
+              !entries.some(function (entry) {
+                return Number(entry.year) === wanted;
+              })
+            ) {
+              var years = entries
+                .map(function (entry) {
+                  return entry.year;
+                })
+                .join(", ");
+              return {
+                echo: input,
+                lines: ["pantone: no year " + wanted + " — try: " + years],
+                action: null,
+              };
+            }
+            return {
+              echo: input,
+              lines: ["pantone: year → " + wanted],
+              action: { type: "pantone", state: "year", year: wanted },
+            };
+          }
+          if (sub) {
+            return {
+              echo: input,
+              lines: [
+                "pantone: unknown option '" +
+                  sub +
+                  "' — try on, off, next, prev, or a year",
+              ],
+              action: null,
+            };
+          }
           return {
             echo: input,
             lines: ["pantone: colour-of-the-year toggled"],
             action: { type: "pantone", state: "toggle" },
           };
         }
-        case "grid":
+        case "grid": {
+          var gridState = onOffState(args[0]);
           return {
             echo: input,
-            lines: ["grid: toggled"],
-            action: { type: "grid" },
+            lines: ["grid: " + gridState],
+            action: { type: "grid", state: gridState },
           };
+        }
+        case "grain":
+        case "blend":
+        case "motion": {
+          var effectState = onOffState(args[0]);
+          return {
+            echo: input,
+            lines: [cmd + ": " + effectState],
+            action: { type: "effect", effect: cmd, state: effectState },
+          };
+        }
+        case "cd": {
+          var dest = args[0] || "~";
+          if (dest === "~" || dest === "/" || dest === "..") {
+            return {
+              echo: input,
+              lines: [],
+              action: { type: "navigate", url: terminalHomeUrl() },
+            };
+          }
+          var target = resolveCdTarget(dest);
+          if (!target) {
+            return {
+              echo: input,
+              lines: ["cd: no such file or directory: " + dest],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: [],
+            action: { type: "navigate", url: target },
+          };
+        }
         case "contact":
           return {
             echo: input,
@@ -2381,17 +2531,77 @@
             if (!isPantoneModeActive()) {
               activatePantone({ playing: false, resetYear: true });
             }
+          } else if (action.state === "year") {
+            if (!isPantoneModeActive()) {
+              activatePantone({ playing: false, resetYear: false });
+            }
+            setCotyYear(action.year, {
+              fromUser: true,
+              transitionDuration: PANTONE_MANUAL_TRANSITION_MS,
+            });
+          } else if (action.state === "step") {
+            if (!isPantoneModeActive()) {
+              activatePantone({ playing: false, resetYear: false });
+            }
+            advanceCotyYear(action.step, {
+              fromUser: true,
+              transitionDuration: PANTONE_MANUAL_TRANSITION_MS,
+            });
           } else {
             togglePantoneMode();
           }
           break;
         case "grid": {
           var gridBtn = document.querySelector('[data-js="grid-toggle"]');
-          if (gridBtn) {
+          if (!gridBtn) {
+            break;
+          }
+          var gridOn =
+            document.documentElement.hasAttribute("data-grid-overlay");
+          if (action.state === "toggle" || (action.state === "on") !== gridOn) {
             gridBtn.click();
           }
           break;
         }
+        case "effect": {
+          var effects = {
+            grain: {
+              attr: "data-effect-grain",
+              set: setGrainEnabled,
+            },
+            blend: {
+              attr: "data-effect-blend",
+              set: setBlendEnabled,
+            },
+            motion: {
+              attr: "data-effect-reduced-motion",
+              set: setReducedMotionEnabled,
+            },
+          };
+          var effect = effects[action.effect];
+          if (!effect) {
+            break;
+          }
+          var isOn =
+            document.documentElement.getAttribute(effect.attr) === "on";
+          var target =
+            action.state === "on"
+              ? true
+              : action.state === "off"
+              ? false
+              : !isOn;
+          effect.set(target);
+          break;
+        }
+        case "navigate":
+          if (action.url) {
+            try {
+              window.location.assign(action.url);
+            } catch (err) {
+              window.location.href = action.url;
+            }
+          }
+          break;
         case "flow":
           startTerminalFlow(action.flow);
           break;
@@ -2599,15 +2809,25 @@
     };
 
     // The prompt is shown verbatim; field steps pass "email>", the confirm step
-    // passes its full question. Pass null to restore the shell PS1.
+    // passes its full question. Pass null to restore the shell PS1. The label is
+    // set on BOTH the tail (so the hint's ::after can switch) and the prompt
+    // span (so its ::before can read the label via attr() — attr() only sees the
+    // pseudo-element's own element, not an ancestor).
     function setFlowPrompt(prompt) {
       if (!terminalTail) {
         return;
       }
+      var promptEl = terminalTail.querySelector(".terminal-tail__prompt");
       if (prompt) {
         terminalTail.setAttribute("data-flow-label", prompt);
+        if (promptEl) {
+          promptEl.setAttribute("data-flow-label", prompt);
+        }
       } else {
         terminalTail.removeAttribute("data-flow-label");
+        if (promptEl) {
+          promptEl.removeAttribute("data-flow-label");
+        }
       }
     }
 

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -754,6 +754,12 @@
     if (document.documentElement.getAttribute("data-layout") !== "terminal") {
       return;
     }
+    // Wipe the command scrollback so it neither lingers on the way out nor
+    // greets the next terminal session (it is hidden in other layouts anyway).
+    var sessionLog = document.querySelector('[data-js="terminal-session"]');
+    if (sessionLog) {
+      sessionLog.textContent = "";
+    }
     var previousLayout =
       localStorage.getItem("theme-layout-previous") || "column";
     if (previousLayout === "terminal") {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2292,8 +2292,11 @@
         return terminalNavTargetsCache;
       }
       var map = {};
+      // Exclude the statusbar quick-toggles (:not(.terminal-quick)): the
+      // language toggle is an <a> to the *other* language's URL, whose slug
+      // collides with the current page's and would overwrite the real target.
       var links = document.querySelectorAll(
-        ".top-menu__nav a[href], .top-menu__link[href]"
+        ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href]"
       );
       links.forEach(function (link) {
         var href = link.getAttribute("href");
@@ -3213,7 +3216,10 @@
       var link =
         e.target && e.target.closest
           ? e.target.closest(
-              ".top-menu__nav a[href], .terminal-prompt__host[href]"
+              // Skip the statusbar quick-toggles — the language toggle switches
+              // language, not directory, so it must not print a `cd` echo.
+              ".top-menu__nav a[href]:not(.terminal-quick), " +
+                ".terminal-prompt__host[href]"
             )
           : null;
       if (!link) {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -747,11 +747,16 @@
     }, 2400);
   }
 
+  // Set by the command engine's init to its endTerminalFlow(), so exitTerminal
+  // (which lives out here, unable to reach the init closure) can abort any
+  // half-finished contact/subscribe flow on the way out.
+  var terminalFlowReset = null;
+
   // Leave the terminal: back to the snapshotted layout, and restore the
   // snapshotted typography if the pairing's choice (technical) is still
   // active — a manual typography change inside the terminal is respected.
   function exitTerminal() {
-    if (document.documentElement.getAttribute("data-layout") !== "terminal") {
+    if (!isTerminalLayout()) {
       return;
     }
     // Wipe the command scrollback so it neither lingers on the way out nor
@@ -759,6 +764,10 @@
     var sessionLog = document.querySelector('[data-js="terminal-session"]');
     if (sessionLog) {
       sessionLog.textContent = "";
+    }
+    // Reset any in-progress interactive flow so re-entering starts clean.
+    if (terminalFlowReset) {
+      terminalFlowReset();
     }
     var previousLayout =
       localStorage.getItem("theme-layout-previous") || "column";
@@ -1234,8 +1243,13 @@
       } else if (panel && node.parentNode !== panel) {
         panel.appendChild(node);
       }
-      // Inline, it is always expanded — no floating collapse state.
-      setCotyTransportUiState("expanded");
+      // Inline, it is always expanded — but only touch (and persist) the
+      // ui-state when Pantone is actually active/visible, so entering the
+      // terminal with the effect off doesn't clobber the floating pill's
+      // collapsed preference.
+      if (isPantoneModeActive()) {
+        setCotyTransportUiState("expanded");
+      }
     } else if (
       cotyTransportHome &&
       cotyTransportHome.parent &&
@@ -2199,6 +2213,20 @@
       "  exit      leave the terminal",
     ];
 
+    // Toggleable image effects, keyed by command word. `invert` flags that the
+    // command's sense is the opposite of its data-attribute: "motion on" means
+    // animation on, i.e. data-effect-reduced-motion OFF. Built once, not per
+    // command.
+    const TERMINAL_EFFECTS = {
+      grain: { attr: "data-effect-grain", set: setGrainEnabled, invert: false },
+      blend: { attr: "data-effect-blend", set: setBlendEnabled, invert: false },
+      motion: {
+        attr: "data-effect-reduced-motion",
+        set: setReducedMotionEnabled,
+        invert: true,
+      },
+    };
+
     function terminalHost() {
       return (window.location && window.location.hostname) || "tor-bjorn.com";
     }
@@ -2251,8 +2279,13 @@
     }
 
     // Map the nav's pages to `cd` targets, keyed by both URL slug and link text
-    // (so `cd writing` and `cd essays` both resolve if that's the label).
+    // (so `cd writing` and `cd essays` both resolve if that's the label). Built
+    // once — the nav is static for the page's lifetime.
+    var terminalNavTargetsCache = null;
     function terminalNavTargets() {
+      if (terminalNavTargetsCache) {
+        return terminalNavTargetsCache;
+      }
       var map = {};
       var links = document.querySelectorAll(
         ".top-menu__nav a[href], .top-menu__link[href]"
@@ -2272,6 +2305,7 @@
           map[text] = href;
         }
       });
+      terminalNavTargetsCache = map;
       return map;
     }
 
@@ -2562,41 +2596,36 @@
           if (!gridBtn) {
             break;
           }
-          var gridOn =
-            document.documentElement.hasAttribute("data-grid-overlay");
+          // "closing" means the overlay is animating out — treat it as off, the
+          // same as grid-overlay.js's own open() guard, so a mid-close toggle
+          // isn't misread as on.
+          var gridAttr =
+            document.documentElement.getAttribute("data-grid-overlay");
+          var gridOn = gridAttr !== null && gridAttr !== "closing";
           if (action.state === "toggle" || (action.state === "on") !== gridOn) {
             gridBtn.click();
           }
           break;
         }
         case "effect": {
-          var effects = {
-            grain: {
-              attr: "data-effect-grain",
-              set: setGrainEnabled,
-            },
-            blend: {
-              attr: "data-effect-blend",
-              set: setBlendEnabled,
-            },
-            motion: {
-              attr: "data-effect-reduced-motion",
-              set: setReducedMotionEnabled,
-            },
-          };
-          var effect = effects[action.effect];
+          var effect = TERMINAL_EFFECTS[action.effect];
           if (!effect) {
             break;
           }
-          var isOn =
+          // `feature` is what the command word means (grain/blend present, or
+          // motion playing). For motion that is the inverse of the underlying
+          // data-effect-reduced-motion attribute, so `motion on` restores
+          // animation rather than suppressing it.
+          var attrOn =
             document.documentElement.getAttribute(effect.attr) === "on";
-          var target =
+          var featureOn = effect.invert ? !attrOn : attrOn;
+          var targetFeature =
             action.state === "on"
               ? true
               : action.state === "off"
               ? false
-              : !isOn;
-          effect.set(target);
+              : !featureOn;
+          effect.set(effect.invert ? !targetFeature : targetFeature);
           break;
         }
         case "navigate":
@@ -2658,10 +2687,7 @@
     }
 
     function scrollTerminalToEnd() {
-      if (
-        terminalInput &&
-        document.documentElement.getAttribute("data-layout") === "terminal"
-      ) {
+      if (terminalInput && isTerminalLayout()) {
         window.requestAnimationFrame(function () {
           window.scrollTo(0, document.body.scrollHeight);
           terminalInput.focus();
@@ -2743,15 +2769,28 @@
           body: new window.URLSearchParams(formData).toString(),
         })
         .then(function (response) {
+          // A non-OK status returns HTML, not JSON — surface it as a server
+          // error rather than letting response.json() reject into the generic
+          // "offline" catch.
+          if (!response || !response.ok) {
+            printTerminalLine(
+              "couldn't subscribe — the server rejected it.",
+              "terminal-session__out"
+            );
+            return null;
+          }
           return response.json();
         })
         .then(function (result) {
-          if (result && result.success) {
+          if (!result) {
+            return; // non-OK already reported
+          }
+          if (result.success) {
             printTerminalLine(
               "subscribed — check your inbox to confirm.",
               "terminal-session__out"
             );
-          } else if (result && result.error === "already_subscribed") {
+          } else if (result.error === "already_subscribed") {
             printTerminalLine(
               "you're already subscribed.",
               "terminal-session__out"
@@ -2852,6 +2891,9 @@
       setFlowPrompt(null);
     }
 
+    // Let the top-level exitTerminal() abort a flow when leaving the terminal.
+    terminalFlowReset = endTerminalFlow;
+
     function handleTerminalFlowInput(raw) {
       var flow = terminalFlow;
       var value = String(raw === null || raw === undefined ? "" : raw).trim();
@@ -2928,11 +2970,22 @@
           }
         } else if (e.key === "Escape") {
           if (terminalFlow) {
-            // Escape aborts an in-progress flow rather than leaving.
+            // Escape aborts an in-progress flow rather than leaving — clear the
+            // half-typed value too, so it isn't run as a command on next Enter.
             e.preventDefault();
+            terminalInput.value = "";
+            syncTerminalInputSize();
             printTerminalLine("^C", "terminal-session__out");
             endTerminalFlow();
             scrollTerminalToEnd();
+          } else if (
+            e.defaultPrevented ||
+            document.documentElement.classList.contains("lightbox-open") ||
+            document.documentElement.hasAttribute("data-settings-panel-open")
+          ) {
+            // An open overlay owns this Escape — let it close first, exactly as
+            // the global handler defers.
+            return;
           } else if (terminalInput.value === "") {
             // Empty prompt + Escape leaves the terminal, matching the global
             // handler (which ignores events targeting inputs).

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2205,6 +2205,7 @@
       "  date      date & time",
       "  pwd       working dir",
       "  cd <page> change page",
+      "  lang [sv|en]  language",
       "  echo      print text",
       "  neofetch  session info",
       "  dark|light|system  mode",
@@ -2326,6 +2327,44 @@
       var targets = terminalNavTargets();
       return targets[key] || null;
     }
+
+    // Languages from the settings language selector, keyed by code. The current
+    // language's radio has no data-language-href; every other one carries the
+    // translated page's URL (or a homepage fallback).
+    function terminalLanguages() {
+      var map = {};
+      document
+        .querySelectorAll(".language-option input[data-language-code]")
+        .forEach(function (input) {
+          var code = (
+            input.getAttribute("data-language-code") || ""
+          ).toLowerCase();
+          if (!code) {
+            return;
+          }
+          map[code] = {
+            href: input.getAttribute("data-language-href"),
+            name: (
+              input.getAttribute("data-language-name") || ""
+            ).toLowerCase(),
+          };
+        });
+      return map;
+    }
+
+    function currentLang() {
+      return (document.documentElement.getAttribute("lang") || "en")
+        .slice(0, 2)
+        .toLowerCase();
+    }
+
+    var LANG_ALIASES = {
+      en: "en",
+      english: "en",
+      sv: "sv",
+      svenska: "sv",
+      swedish: "sv",
+    };
 
     // Returns { echo, lines, action }. `echo` is the command as typed (printed
     // with the prompt), `lines` are output rows, `action` (or null) is applied
@@ -2471,6 +2510,62 @@
             echo: input,
             lines: [],
             action: { type: "navigate", url: target },
+          };
+        }
+        case "lang":
+        case "language": {
+          var languages = terminalLanguages();
+          var available = Object.keys(languages);
+          var here = currentLang();
+          var wanted = (args[0] || "").toLowerCase();
+          if (!wanted) {
+            return {
+              echo: input,
+              lines: [
+                "language: " + here,
+                "available: " + (available.join(", ") || here),
+              ],
+              action: null,
+            };
+          }
+          var langTarget = LANG_ALIASES[wanted] || wanted;
+          if (!languages[langTarget]) {
+            return {
+              echo: input,
+              lines: [
+                "lang: unknown language '" +
+                  wanted +
+                  "' — try: " +
+                  (available.join(", ") || here),
+              ],
+              action: null,
+            };
+          }
+          if (langTarget === here) {
+            return {
+              echo: input,
+              lines: ["language: already " + here],
+              action: null,
+            };
+          }
+          if (!languages[langTarget].href) {
+            return {
+              echo: input,
+              lines: ["lang: " + langTarget + " unavailable for this page"],
+              action: null,
+            };
+          }
+          // Switch language by loading the translated page. cd:false so the
+          // navigation doesn't print a spurious `cd` echo (same directory,
+          // different language).
+          return {
+            echo: input,
+            lines: [],
+            action: {
+              type: "navigate",
+              url: languages[langTarget].href,
+              cd: false,
+            },
           };
         }
         case "contact":
@@ -2634,8 +2729,11 @@
         }
         case "navigate":
           if (action.url) {
-            // Carry a `cd` echo to the destination, same as a nav click.
-            stashTerminalCd(currentTerminalCwd(), hrefToCwd(action.url));
+            // Carry a `cd` echo to the destination, same as a nav click —
+            // unless the caller opts out (e.g. a language switch).
+            if (action.cd !== false) {
+              stashTerminalCd(currentTerminalCwd(), hrefToCwd(action.url));
+            }
             try {
               window.location.assign(action.url);
             } catch (err) {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2630,6 +2630,8 @@
         }
         case "navigate":
           if (action.url) {
+            // Carry a `cd` echo to the destination, same as a nav click.
+            stashTerminalCd(currentTerminalCwd(), hrefToCwd(action.url));
             try {
               window.location.assign(action.url);
             } catch (err) {
@@ -2996,6 +2998,133 @@
       });
       syncTerminalInputSize();
     }
+
+    // ----------------------------------------------------------------------
+    // Nav "cd" feedback
+    // A full page load gives almost no signal that navigation happened. So a
+    // nav click (or a typed `cd`) reads like running `cd <page>`: we stash the
+    // command, and the destination page prints it as the first scrollback line
+    // above its own `~/cwd$ ls nav/` prompt — the real cd→ls sequence, with no
+    // scroll and no boot theater. Purely additive; navigation is never delayed.
+    // ----------------------------------------------------------------------
+    const TERMINAL_CD_KEY = "terminal-cd";
+
+    function currentTerminalCwd() {
+      var value = window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue("--terminal-cwd")
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      return value || "~";
+    }
+
+    // Derive a page's cwd (~ or ~/segment) from a link href, mirroring the
+    // per-page logic in head.html (strip origin, query/hash, and lang prefix).
+    function hrefToCwd(href) {
+      var path = String(href || "")
+        .replace(/^[a-z]+:\/\/[^/]+/i, "")
+        .replace(/[?#].*$/, "")
+        .replace(/^\/+|\/+$/g, "");
+      var lang = (
+        document.documentElement.getAttribute("lang") || ""
+      ).toLowerCase();
+      var parts = path.split("/").filter(Boolean);
+      if (parts.length && parts[0].toLowerCase() === lang) {
+        parts.shift();
+      }
+      return parts.length ? "~/" + parts[0] : "~";
+    }
+
+    function stashTerminalCd(fromCwd, targetCwd) {
+      if (fromCwd === targetCwd) {
+        return; // same directory — nothing to echo
+      }
+      try {
+        sessionStorage.setItem(
+          TERMINAL_CD_KEY,
+          JSON.stringify({ from: fromCwd, cmd: "cd " + targetCwd })
+        );
+      } catch (e) {
+        /* sessionStorage unavailable — skip the echo */
+      }
+    }
+
+    // Print any pending `cd` as scrollback above this page's first prompt.
+    function printPendingTerminalCd() {
+      if (!isTerminalLayout()) {
+        return;
+      }
+      var raw;
+      try {
+        raw = sessionStorage.getItem(TERMINAL_CD_KEY);
+        sessionStorage.removeItem(TERMINAL_CD_KEY);
+      } catch (e) {
+        return;
+      }
+      if (!raw) {
+        return;
+      }
+      var data;
+      try {
+        data = JSON.parse(raw);
+      } catch (e) {
+        return;
+      }
+      if (!data || !data.cmd) {
+        return;
+      }
+      var container = document.querySelector(".top-menu__container");
+      var anchor = container
+        ? container.querySelector(":scope > .terminal-prompt")
+        : null;
+      if (!container || !anchor) {
+        return;
+      }
+      var line = document.createElement("span");
+      line.className = "terminal-prompt terminal-prompt--cd";
+      line.setAttribute("aria-hidden", "true");
+      // Override the prompt's cwd to where we came from, so CSS renders the
+      // exact PS1 (responsive compact form included) for that directory.
+      line.style.setProperty("--terminal-cwd", '"' + data.from + '"');
+      line.innerHTML =
+        '<span class="terminal-prompt__user"></span>' +
+        '<span class="terminal-prompt__host-plain"></span>' +
+        '<span class="terminal-prompt__cwd"></span>' +
+        '<span class="terminal-prompt__cmd"></span>';
+      line.querySelector(".terminal-prompt__cmd").textContent = data.cmd;
+      container.insertBefore(line, anchor);
+    }
+
+    // Nav clicks that change page read as `cd <page>` on the next screen.
+    document.addEventListener("click", function (e) {
+      if (
+        !isTerminalLayout() ||
+        e.defaultPrevented ||
+        e.button !== 0 ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.altKey
+      ) {
+        return;
+      }
+      var link =
+        e.target && e.target.closest
+          ? e.target.closest(
+              ".top-menu__nav a[href], .terminal-prompt__host[href]"
+            )
+          : null;
+      if (!link) {
+        return;
+      }
+      var href = link.getAttribute("href");
+      if (!href || href.charAt(0) === "#") {
+        return;
+      }
+      stashTerminalCd(currentTerminalCwd(), hrefToCwd(href));
+    });
+
+    printPendingTerminalCd();
 
     // Terminal layout: statusbar quick toggle that shows the resolved mode as
     // a bracketed word; clicking flips light/dark (an explicit choice, so it

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2166,19 +2166,23 @@
       '[data-js="terminal-session"]'
     );
 
+    // Kept narrow (a ~12-char command column + short descriptions) so every
+    // line fits a phone's ~36-char terminal width without wrapping mid-column.
     const TERMINAL_HELP = [
-      "available commands:",
-      "  help              this list",
-      "  whoami            who's asking",
-      "  date              current date & time",
-      "  pwd               print working directory",
-      "  echo <text>       print text",
-      "  neofetch          session summary",
-      "  dark | light | system   colour mode",
-      "  pantone [on|off]  colour-of-the-year effect",
-      "  grid              toggle the layout grid",
-      "  clear             clear the screen",
-      "  exit              leave the terminal",
+      "commands:",
+      "  help      this list",
+      "  whoami    who's asking",
+      "  date      date & time",
+      "  pwd       working dir",
+      "  echo      print text",
+      "  neofetch  session info",
+      "  dark|light|system  mode",
+      "  pantone   [on|off] effect",
+      "  grid      layout grid",
+      "  contact   message me",
+      "  subscribe newsletter",
+      "  clear     wipe the screen",
+      "  exit      leave the terminal",
     ];
 
     function terminalHost() {
@@ -2274,6 +2278,18 @@
             echo: input,
             lines: ["grid: toggled"],
             action: { type: "grid" },
+          };
+        case "contact":
+          return {
+            echo: input,
+            lines: [],
+            action: { type: "flow", flow: "contact" },
+          };
+        case "subscribe":
+          return {
+            echo: input,
+            lines: [],
+            action: { type: "flow", flow: "subscribe" },
           };
         case "echo":
           return { echo: input, lines: [rest], action: null };
@@ -2376,6 +2392,9 @@
           }
           break;
         }
+        case "flow":
+          startTerminalFlow(action.flow);
+          break;
         default:
           break;
       }
@@ -2410,6 +2429,19 @@
       applyTerminalAction(result.action);
       // Keep the newest output and the prompt in view; refocus so the mobile
       // keyboard stays up for the next command.
+      scrollTerminalToEnd();
+    }
+
+    // The boot banner's small block-curl, reused as neofetch art when present.
+    function terminalArtLines() {
+      var art = document.querySelector(".terminal-boot__art--sm");
+      if (!art || !art.textContent) {
+        return [];
+      }
+      return art.textContent.replace(/^\n+|\n+$/g, "").split("\n");
+    }
+
+    function scrollTerminalToEnd() {
       if (
         terminalInput &&
         document.documentElement.getAttribute("data-layout") === "terminal"
@@ -2421,13 +2453,227 @@
       }
     }
 
-    // The boot banner's small block-curl, reused as neofetch art when present.
-    function terminalArtLines() {
-      var art = document.querySelector(".terminal-boot__art--sm");
-      if (!art || !art.textContent) {
-        return [];
+    // ----------------------------------------------------------------------
+    // Interactive prompt flows (contact, subscribe)
+    // Some commands aren't one-shot: they collect a few fields one prompt at a
+    // time, like a CLI wizard, then POST to the very same backend the on-page
+    // forms use. While a flow runs, Enter feeds the current step (not the
+    // command parser), the prompt shows the field name, and `cancel`/Escape
+    // aborts. Contact posts to the Netlify form endpoint; subscribe reuses the
+    // footer newsletter form's action and hidden fields.
+    // ----------------------------------------------------------------------
+    let terminalFlow = null;
+
+    function isEmailish(value) {
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+    }
+
+    function nonEmpty(value) {
+      return value.length > 0;
+    }
+
+    function submitContactFlow(data) {
+      printTerminalLine("sending…", "terminal-session__out");
+      var body = new window.URLSearchParams({
+        "form-name": "contact",
+        "bot-field": "",
+        name: data.name || "",
+        email: data.email || "",
+        message: data.message || "",
+      }).toString();
+      window
+        .fetch("/", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: body,
+        })
+        .then(function (response) {
+          printTerminalLine(
+            response && response.ok
+              ? "message sent — thanks, I'll be in touch."
+              : "send failed — try the contact page instead.",
+            "terminal-session__out"
+          );
+        })
+        .catch(function () {
+          printTerminalLine(
+            "send failed — you may be offline.",
+            "terminal-session__out"
+          );
+        })
+        .then(scrollTerminalToEnd);
+    }
+
+    function submitSubscribeFlow(data) {
+      var form = document.querySelector("form[data-mc-form]");
+      if (!form) {
+        printTerminalLine(
+          "subscribe: the newsletter isn't available here.",
+          "terminal-session__out"
+        );
+        scrollTerminalToEnd();
+        return;
       }
-      return art.textContent.replace(/^\n+|\n+$/g, "").split("\n");
+      var emailField = form.querySelector('input[type="email"]');
+      var formData = new window.FormData(form);
+      if (emailField && emailField.name) {
+        formData.set(emailField.name, data.email);
+      }
+      printTerminalLine("subscribing…", "terminal-session__out");
+      window
+        .fetch(form.action, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new window.URLSearchParams(formData).toString(),
+        })
+        .then(function (response) {
+          return response.json();
+        })
+        .then(function (result) {
+          if (result && result.success) {
+            printTerminalLine(
+              "subscribed — check your inbox to confirm.",
+              "terminal-session__out"
+            );
+          } else if (result && result.error === "already_subscribed") {
+            printTerminalLine(
+              "you're already subscribed.",
+              "terminal-session__out"
+            );
+          } else {
+            printTerminalLine(
+              "couldn't subscribe — try the footer form.",
+              "terminal-session__out"
+            );
+          }
+        })
+        .catch(function () {
+          printTerminalLine(
+            "couldn't subscribe — you may be offline.",
+            "terminal-session__out"
+          );
+        })
+        .then(scrollTerminalToEnd);
+    }
+
+    var TERMINAL_FLOWS = {
+      contact: {
+        intro: "contact — send me a message. type 'cancel' to abort.",
+        steps: [
+          {
+            key: "email",
+            label: "email",
+            validate: isEmailish,
+            error: "that doesn't look like an email — try again",
+          },
+          {
+            key: "name",
+            label: "name",
+            validate: nonEmpty,
+            error: "name can't be empty",
+          },
+          {
+            key: "message",
+            label: "message",
+            validate: nonEmpty,
+            error: "message can't be empty",
+          },
+        ],
+        confirm: "send this? [Y/n]",
+        submit: submitContactFlow,
+      },
+      subscribe: {
+        intro:
+          "subscribe — the occasional note, no spam. type 'cancel' to abort.",
+        steps: [
+          {
+            key: "email",
+            label: "email",
+            validate: isEmailish,
+            error: "that doesn't look like an email — try again",
+          },
+        ],
+        confirm: "subscribe with this address? [Y/n]",
+        submit: submitSubscribeFlow,
+      },
+    };
+
+    // The prompt is shown verbatim; field steps pass "email>", the confirm step
+    // passes its full question. Pass null to restore the shell PS1.
+    function setFlowPrompt(prompt) {
+      if (!terminalTail) {
+        return;
+      }
+      if (prompt) {
+        terminalTail.setAttribute("data-flow-label", prompt);
+      } else {
+        terminalTail.removeAttribute("data-flow-label");
+      }
+    }
+
+    function startTerminalFlow(name) {
+      var def = TERMINAL_FLOWS[name];
+      if (!def) {
+        return;
+      }
+      terminalFlow = { def: def, step: 0, data: {}, confirming: false };
+      printTerminalLine(def.intro, "terminal-session__out");
+      setFlowPrompt(def.steps[0].label + ">");
+    }
+
+    function endTerminalFlow() {
+      terminalFlow = null;
+      setFlowPrompt(null);
+    }
+
+    function handleTerminalFlowInput(raw) {
+      var flow = terminalFlow;
+      var value = String(raw === null || raw === undefined ? "" : raw).trim();
+
+      if (value.toLowerCase() === "cancel") {
+        printTerminalLine("^C", "terminal-session__out");
+        endTerminalFlow();
+        return;
+      }
+
+      if (!flow.confirming) {
+        var stepDef = flow.def.steps[flow.step];
+        printTerminalLine(
+          stepDef.label + "> " + value,
+          "terminal-session__flow"
+        );
+        if (stepDef.validate && !stepDef.validate(value)) {
+          printTerminalLine(stepDef.error, "terminal-session__out");
+          return; // stay on this step
+        }
+        flow.data[stepDef.key] = value;
+        flow.step += 1;
+        if (flow.step < flow.def.steps.length) {
+          setFlowPrompt(flow.def.steps[flow.step].label + ">");
+        } else {
+          flow.confirming = true;
+          setFlowPrompt(flow.def.confirm);
+        }
+        return;
+      }
+
+      // Confirmation step: empty / y / yes sends; n / no aborts.
+      printTerminalLine(
+        flow.def.confirm + " " + value,
+        "terminal-session__flow"
+      );
+      var answer = value.toLowerCase();
+      if (answer === "" || answer === "y" || answer === "yes") {
+        var submit = flow.def.submit;
+        var data = flow.data;
+        endTerminalFlow();
+        submit(data);
+      } else if (answer === "n" || answer === "no") {
+        printTerminalLine("cancelled", "terminal-session__out");
+        endTerminalFlow();
+      } else {
+        printTerminalLine("please answer y or n", "terminal-session__out");
+      }
     }
 
     function syncTerminalInputSize() {
@@ -2448,12 +2694,25 @@
           var value = terminalInput.value;
           terminalInput.value = "";
           syncTerminalInputSize();
-          runTerminalInput(value);
-        } else if (e.key === "Escape" && terminalInput.value === "") {
-          // Empty prompt + Escape leaves the terminal, matching the global
-          // handler (which ignores events targeting inputs).
-          terminalInput.blur();
-          exitTerminal();
+          if (terminalFlow) {
+            handleTerminalFlowInput(value);
+            scrollTerminalToEnd();
+          } else {
+            runTerminalInput(value);
+          }
+        } else if (e.key === "Escape") {
+          if (terminalFlow) {
+            // Escape aborts an in-progress flow rather than leaving.
+            e.preventDefault();
+            printTerminalLine("^C", "terminal-session__out");
+            endTerminalFlow();
+            scrollTerminalToEnd();
+          } else if (terminalInput.value === "") {
+            // Empty prompt + Escape leaves the terminal, matching the global
+            // handler (which ignores events targeting inputs).
+            terminalInput.blur();
+            exitTerminal();
+          }
         }
       });
       syncTerminalInputSize();

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1094,8 +1094,18 @@
     });
   }
 
+  function isTerminalLayout() {
+    return document.documentElement.getAttribute("data-layout") === "terminal";
+  }
+
   function collapseCotyTransport() {
-    if (!isPantoneModeActive() || isAnyBottomSheetOpen()) {
+    // Inline in the terminal the controls stay open — the collapse/hover
+    // choreography is only for the floating pill.
+    if (
+      !isPantoneModeActive() ||
+      isAnyBottomSheetOpen() ||
+      isTerminalLayout()
+    ) {
       return;
     }
     stopCotyTransportCollapseTimer();
@@ -1107,7 +1117,11 @@
 
   function scheduleCotyTransportCollapse() {
     stopCotyTransportCollapseTimer();
-    if (!isPantoneModeActive() || isAnyBottomSheetOpen()) {
+    if (
+      !isPantoneModeActive() ||
+      isAnyBottomSheetOpen() ||
+      isTerminalLayout()
+    ) {
       return;
     }
     cotyTransportCollapseTimer = window.setTimeout(function () {
@@ -1180,6 +1194,55 @@
       stopCotyTransportHoverEnterTimer();
       cotyTransportHasUserEngaged = false;
       setCotyTransportUiState("expanded");
+    }
+  }
+
+  // The Pantone controls are one node reused at every layout. In the terminal
+  // they belong inline inside the settings panel (under the Effects toggles),
+  // not floating over the page; everywhere else they float. Rather than
+  // duplicate the DOM, move the node and remember its home so it returns to
+  // exactly where it started when the user leaves the terminal.
+  let cotyTransportHome = null;
+
+  function rememberCotyTransportHome(node) {
+    if (cotyTransportHome || !node || !node.parentNode) {
+      return;
+    }
+    cotyTransportHome = { parent: node.parentNode, next: node.nextSibling };
+  }
+
+  function syncCotyTransportPlacement() {
+    const node = document.querySelector('[data-js="coty-transport"]');
+    if (!node) {
+      return;
+    }
+    rememberCotyTransportHome(node);
+    if (isTerminalLayout()) {
+      const panel = document.querySelector('[data-js="settings-panel"]');
+      const modeToggle = document.querySelector('[data-js="coty-mode-toggle"]');
+      const anchor = modeToggle ? modeToggle.closest(".theme-section") : null;
+      if (panel && anchor && anchor.parentNode === panel) {
+        if (anchor.nextSibling !== node) {
+          panel.insertBefore(node, anchor.nextSibling);
+        }
+      } else if (panel && node.parentNode !== panel) {
+        panel.appendChild(node);
+      }
+      // Inline, it is always expanded — no floating collapse state.
+      setCotyTransportUiState("expanded");
+    } else if (
+      cotyTransportHome &&
+      cotyTransportHome.parent &&
+      cotyTransportHome.parent.isConnected &&
+      node.parentNode !== cotyTransportHome.parent
+    ) {
+      // Only restore into a home that is still part of the live document, and
+      // never anchor to a detached reference node.
+      const ref =
+        cotyTransportHome.next && cotyTransportHome.next.isConnected
+          ? cotyTransportHome.next
+          : null;
+      cotyTransportHome.parent.insertBefore(node, ref);
     }
   }
 
@@ -1864,6 +1927,11 @@
     syncCustomPaletteOptionVisibility();
     applyPalette(initialPalette);
     applyTypography(storedTypography);
+    // Record the Pantone controls' authored (floating) home before applyLayout
+    // can move them, so returning from the terminal restores them correctly.
+    rememberCotyTransportHome(
+      document.querySelector('[data-js="coty-transport"]')
+    );
     applyLayout(storedLayout);
     setBlendEnabled(readBooleanPreference(EFFECT_BLEND_KEY, true), {
       silent: true,
@@ -1894,6 +1962,20 @@
         expandCotyTransport({ autoCollapse: true });
       }
     }
+
+    // Park the Pantone controls where the current layout wants them (inline in
+    // the terminal settings, floating otherwise), and keep them in sync as the
+    // user switches layouts. Deregister any handler from a previous init so the
+    // listener never accumulates if this ever runs more than once.
+    if (window.__cotyPlacementHandler) {
+      window.removeEventListener(
+        "theme:layout-changed",
+        window.__cotyPlacementHandler
+      );
+    }
+    window.__cotyPlacementHandler = syncCotyTransportPlacement;
+    window.addEventListener("theme:layout-changed", syncCotyTransportPlacement);
+    syncCotyTransportPlacement();
 
     window.ThemeActions = {
       setMode: setMode,
@@ -2066,6 +2148,316 @@
         );
       }
     });
+
+    // ======================================================================
+    // Terminal command line
+    // The tail's <input> is a real prompt. Tapping it focuses the field and
+    // opens the on-screen keyboard (the fix that makes the terminal usable on
+    // touch devices), and Enter runs a small set of commands + easter eggs.
+    // Parsing is separated from side effects: runTerminalCommand() returns the
+    // text to print plus an optional action, and applyTerminalAction() carries
+    // it out by reusing the theme/layout functions already defined above.
+    // ======================================================================
+    const terminalInput = document.querySelector('[data-js="terminal-input"]');
+    const terminalTail = terminalInput
+      ? terminalInput.closest(".terminal-tail")
+      : null;
+    const terminalSession = document.querySelector(
+      '[data-js="terminal-session"]'
+    );
+
+    const TERMINAL_HELP = [
+      "available commands:",
+      "  help              this list",
+      "  whoami            who's asking",
+      "  date              current date & time",
+      "  pwd               print working directory",
+      "  echo <text>       print text",
+      "  neofetch          session summary",
+      "  dark | light | system   colour mode",
+      "  pantone [on|off]  colour-of-the-year effect",
+      "  grid              toggle the layout grid",
+      "  clear             clear the screen",
+      "  exit              leave the terminal",
+    ];
+
+    function terminalHost() {
+      return (window.location && window.location.hostname) || "tor-bjorn.com";
+    }
+
+    function resolvedModeLabel() {
+      return document.documentElement.getAttribute("data-mode") === "dark"
+        ? "dark"
+        : "light";
+    }
+
+    function paletteLabel() {
+      var palette =
+        document.documentElement.getAttribute("data-palette") || "standard";
+      if (palette === "pantone") {
+        return "pantone (" + getCurrentCotyYear() + ")";
+      }
+      return palette;
+    }
+
+    function neofetchLines() {
+      var host = terminalHost();
+      return [
+        "visitor@" + host,
+        "-----------------",
+        "host      " + host,
+        "layout    terminal",
+        "mode      " + resolvedModeLabel(),
+        "palette   " + paletteLabel(),
+        "lang      " + (document.documentElement.getAttribute("lang") || "en"),
+        "shell     tor-sh 1.0",
+      ];
+    }
+
+    // Returns { echo, lines, action }. `echo` is the command as typed (printed
+    // with the prompt), `lines` are output rows, `action` (or null) is applied
+    // separately. Kept free of DOM mutation so it is straightforward to test.
+    function runTerminalCommand(raw) {
+      var input = String(raw === null || raw === undefined ? "" : raw).trim();
+      if (!input) {
+        return { echo: "", lines: [], action: null };
+      }
+      var parts = input.split(/\s+/);
+      var cmd = parts[0].toLowerCase();
+      var args = parts.slice(1);
+      var rest = input.slice(parts[0].length).trim();
+
+      switch (cmd) {
+        case "help":
+        case "?":
+          return { echo: input, lines: TERMINAL_HELP.slice(), action: null };
+        case "exit":
+        case "quit":
+        case "logout":
+          return { echo: input, lines: [], action: { type: "exit" } };
+        case "clear":
+          return { echo: "", lines: [], action: { type: "clear" } };
+        case "dark":
+        case "light":
+        case "system":
+          return {
+            echo: input,
+            lines: ["mode → " + cmd],
+            action: { type: "mode", mode: cmd },
+          };
+        case "pantone": {
+          var sub = (args[0] || "").toLowerCase();
+          if (sub === "off" || sub === "stop") {
+            return {
+              echo: input,
+              lines: ["pantone: colour-of-the-year off"],
+              action: { type: "pantone", state: "off" },
+            };
+          }
+          if (sub === "on" || sub === "start") {
+            return {
+              echo: input,
+              lines: [
+                "pantone: colour-of-the-year on (" + getCurrentCotyYear() + ")",
+              ],
+              action: { type: "pantone", state: "on" },
+            };
+          }
+          return {
+            echo: input,
+            lines: ["pantone: colour-of-the-year toggled"],
+            action: { type: "pantone", state: "toggle" },
+          };
+        }
+        case "grid":
+          return {
+            echo: input,
+            lines: ["grid: toggled"],
+            action: { type: "grid" },
+          };
+        case "echo":
+          return { echo: input, lines: [rest], action: null };
+        case "whoami":
+          return {
+            echo: input,
+            lines: ["visitor", "(not logged in — but welcome anyway)"],
+            action: null,
+          };
+        case "date":
+          return {
+            echo: input,
+            lines: [new Date().toString()],
+            action: null,
+          };
+        case "pwd":
+          return {
+            echo: input,
+            lines: [(window.location && window.location.pathname) || "/"],
+            action: null,
+          };
+        case "neofetch":
+        case "screenfetch":
+          return {
+            echo: input,
+            lines: neofetchLines(),
+            action: { type: "art" },
+          };
+        case "sudo":
+          return {
+            echo: input,
+            lines: [
+              "permission denied: nice try 😏",
+              "(this incident has been reported)",
+            ],
+            action: null,
+          };
+        case "coffee":
+        case "brew":
+          return {
+            echo: input,
+            lines: ["HTTP 418 — I'm a teapot ☕"],
+            action: null,
+          };
+        case "make":
+          if ((args[0] || "").toLowerCase() === "coffee") {
+            return {
+              echo: input,
+              lines: ["HTTP 418 — I'm a teapot ☕"],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: [
+              "make: *** no rule to make target '" + (args[0] || "") + "'.",
+            ],
+            action: null,
+          };
+        default:
+          return {
+            echo: input,
+            lines: [cmd + ": command not found — try 'help'"],
+            action: null,
+          };
+      }
+    }
+
+    function applyTerminalAction(action) {
+      if (!action) {
+        return;
+      }
+      switch (action.type) {
+        case "exit":
+          exitTerminal();
+          break;
+        case "clear":
+          if (terminalSession) {
+            terminalSession.textContent = "";
+          }
+          break;
+        case "mode":
+          setMode(action.mode);
+          break;
+        case "pantone":
+          if (action.state === "off") {
+            stopPantone();
+          } else if (action.state === "on") {
+            if (!isPantoneModeActive()) {
+              activatePantone({ playing: false, resetYear: true });
+            }
+          } else {
+            togglePantoneMode();
+          }
+          break;
+        case "grid": {
+          var gridBtn = document.querySelector('[data-js="grid-toggle"]');
+          if (gridBtn) {
+            gridBtn.click();
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    function printTerminalLine(text, className) {
+      if (!terminalSession) {
+        return;
+      }
+      var line = document.createElement("span");
+      line.className = "terminal-session__line " + className;
+      line.textContent = text;
+      terminalSession.appendChild(line);
+    }
+
+    function runTerminalInput(raw) {
+      var result = runTerminalCommand(raw);
+      if (result.echo) {
+        printTerminalLine(result.echo, "terminal-session__cmd");
+      }
+      var artLines =
+        result.action && result.action.type === "art" ? terminalArtLines() : [];
+      artLines.forEach(function (line) {
+        printTerminalLine(
+          line,
+          "terminal-session__out terminal-session__out--art"
+        );
+      });
+      (result.lines || []).forEach(function (line) {
+        printTerminalLine(line, "terminal-session__out");
+      });
+      applyTerminalAction(result.action);
+      // Keep the newest output and the prompt in view; refocus so the mobile
+      // keyboard stays up for the next command.
+      if (
+        terminalInput &&
+        document.documentElement.getAttribute("data-layout") === "terminal"
+      ) {
+        window.requestAnimationFrame(function () {
+          window.scrollTo(0, document.body.scrollHeight);
+          terminalInput.focus();
+        });
+      }
+    }
+
+    // The boot banner's small block-curl, reused as neofetch art when present.
+    function terminalArtLines() {
+      var art = document.querySelector(".terminal-boot__art--sm");
+      if (!art || !art.textContent) {
+        return [];
+      }
+      return art.textContent.replace(/^\n+|\n+$/g, "").split("\n");
+    }
+
+    function syncTerminalInputSize() {
+      if (!terminalInput) {
+        return;
+      }
+      terminalInput.size = Math.max(1, terminalInput.value.length);
+      if (terminalTail) {
+        terminalTail.classList.toggle("is-typing", terminalInput.value !== "");
+      }
+    }
+
+    if (terminalInput) {
+      terminalInput.addEventListener("input", syncTerminalInputSize);
+      terminalInput.addEventListener("keydown", function (e) {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          var value = terminalInput.value;
+          terminalInput.value = "";
+          syncTerminalInputSize();
+          runTerminalInput(value);
+        } else if (e.key === "Escape" && terminalInput.value === "") {
+          // Empty prompt + Escape leaves the terminal, matching the global
+          // handler (which ignores events targeting inputs).
+          terminalInput.blur();
+          exitTerminal();
+        }
+      });
+      syncTerminalInputSize();
+    }
 
     // Terminal layout: statusbar quick toggle that shows the resolved mode as
     // a bracketed word; clicking flips light/dark (an explicit choice, so it

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -453,3 +453,6 @@ other = "[ ok ] palette · typography · layout loaded"
 
 [terminal_exit_hint]
 other = "type exit or press esc to leave the terminal"
+
+[terminal_input_label]
+other = "Terminal command input — type a command and press Enter (try 'help')"

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -447,3 +447,6 @@ other = "[ ok ] palett · typografi · layout laddade"
 
 [terminal_exit_hint]
 other = "skriv exit eller tryck esc för att lämna terminalen"
+
+[terminal_input_label]
+other = "Terminalens kommandorad — skriv ett kommando och tryck Enter (testa 'help')"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -164,9 +164,28 @@
       </ul>
     </div>
 
-    {{/* Terminal layout: the buffer ends with an empty prompt awaiting input. Prompt text comes from the CSS vars in head.html; hidden in every other layout. */}}
-    <p class="terminal-tail" aria-hidden="true" data-exit-hint="{{ i18n "terminal_exit_hint" }}">
-      <span class="terminal-tail__prompt"></span><span class="terminal-tail__caret"></span><span class="terminal-tail__suggest">exit</span>
+    {{/* Terminal layout: the buffer ends with a live prompt. A real <input> so
+         mobile keyboards open on tap and commands / easter eggs can be typed —
+         see the command engine in darkmode.js. The session log above it holds
+         the printed output of executed commands. Prompt text comes from the CSS
+         vars in head.html; the whole block is hidden in every other layout. */}}
+    <div class="terminal-session" data-js="terminal-session" aria-live="polite"></div>
+    <p class="terminal-tail" data-exit-hint="{{ i18n "terminal_exit_hint" }}">
+      <span class="terminal-tail__prompt" aria-hidden="true"></span
+      ><span class="terminal-tail__caret" aria-hidden="true"></span
+      ><label class="sr-only" for="terminal-input">{{ i18n "terminal_input_label" }}</label
+      ><input
+        id="terminal-input"
+        class="terminal-tail__input"
+        data-js="terminal-input"
+        type="text"
+        size="1"
+        autocomplete="off"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false"
+        enterkeyhint="go"
+      />
     </p>
   </div>
 </footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -621,6 +621,20 @@
       }
       document.documentElement.setAttribute("data-layout", storedLayout);
 
+      // Terminal boot banner is a login MOTD: shown once per session. If the
+      // boot already played, mark the document so the ASCII art + status line
+      // are hidden pre-paint on this (subsequent) page — no flash.
+      try {
+        if (
+          storedLayout === "terminal" &&
+          sessionStorage.getItem("terminal-boot-played")
+        ) {
+          document.documentElement.setAttribute("data-terminal-booted", "1");
+        }
+      } catch (e) {
+        /* sessionStorage unavailable — banner simply shows */
+      }
+
       // Image blend + grain effects up front too, so a shared look (or a returning
       // visitor) paints with the correct treatment instead of flashing the default.
       var storedBlend = localStorage.getItem("theme-effect-blend");


### PR DESCRIPTION
The terminal layout's "last line" was decorative (a CSS caret + ghost
"exit"), with typing handled by a global physical-keyboard listener. Phones
have no physical keyboard and nothing was focusable, so the on-screen
keyboard never opened — the prompt was dead on mobile.

- Replace the tail with a real, focusable <input> plus a session log. Tapping
  it focuses the field and opens the mobile keyboard. The idle block caret and
  ghost "exit" give way to the native caret once focused/typing.
- Add a command engine (parse/execute split for testability): help, exit,
  clear, echo, whoami, date, pwd, neofetch, plus functional site controls
  (dark/light/system, pantone [on|off], grid) and easter eggs (sudo, coffee →
  418). Unknown input reports "command not found". Command names/output stay
  English for an authentic shell feel; only the a11y input label is localized.
- Move the Pantone (COTY) controls inline into the settings panel under the
  Effects toggles in terminal mode instead of floating them as a fixed overlay.
  The single node is relocated in the DOM on layout change (with an isConnected
  guard so it never lands in a detached tree) and restored to its floating home
  on exit; CSS drops the fixed positioning and the mobile panel-open hide rule.

Verified end-to-end in Chromium (mobile viewport): input focuses on tap,
commands run and print, Pantone renders static/inline in terminal and returns
to fixed/floating on exit. 475 unit tests pass; Hugo build clean in EN + SV.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NLptTVtnuAidNbznkssVwQ