### PR TITLE
Terminal: add a batch of easter-egg commands

### DIFF
--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1333,6 +1333,43 @@
   margin-top: var(--spacing-8);
 }
 
+/* Party mode — the Konami code (or `konami`) sets data-konami, and the whole
+   terminal cycles hue. Motion-gated: reduced-motion visitors get a single
+   colourful tint instead of the animation. */
+:root[data-konami="on"][data-layout="terminal"] .top-menu__container,
+:root[data-konami="on"][data-layout="terminal"] .terminal-session,
+:root[data-konami="on"][data-layout="terminal"] .terminal-tail {
+  animation: terminal-konami-hue 6s linear infinite;
+}
+
+@keyframes terminal-konami-hue {
+  from {
+    filter: hue-rotate(0deg);
+  }
+  to {
+    filter: hue-rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-konami="on"][data-layout="terminal"] .top-menu__container,
+  :root[data-konami="on"][data-layout="terminal"] .terminal-session,
+  :root[data-konami="on"][data-layout="terminal"] .terminal-tail {
+    animation: none;
+    filter: hue-rotate(150deg) saturate(1.4);
+  }
+}
+
+:root[data-effect-reduced-motion="on"][data-konami="on"][data-layout="terminal"]
+  .top-menu__container,
+:root[data-effect-reduced-motion="on"][data-konami="on"][data-layout="terminal"]
+  .terminal-session,
+:root[data-effect-reduced-motion="on"][data-konami="on"][data-layout="terminal"]
+  .terminal-tail {
+  animation: none;
+  filter: hue-rotate(150deg) saturate(1.4);
+}
+
 :root[data-layout="terminal"] .terminal-session__line {
   display: block;
 }

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -216,6 +216,154 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("frobnicate: command not found");
   });
 
+  // ---- Additional commands & easter eggs --------------------------------
+
+  test("ls lists the nav pages as directories", () => {
+    loadModule();
+    typeCommand("ls");
+    expect(sessionText()).toContain("writing/");
+    expect(sessionText()).toContain("about/");
+  });
+
+  test("cat prints a known pseudo-file and 404s unknown ones", () => {
+    loadModule();
+    typeCommand("cat readme");
+    expect(sessionText().toLowerCase()).toContain("portfolio");
+    typeCommand("cat nope");
+    expect(sessionText()).toContain("No such file or directory");
+  });
+
+  test("cat strips a leading dot and extension", () => {
+    loadModule();
+    typeCommand("cat .secret");
+    expect(sessionText().toLowerCase()).toContain("no secrets");
+  });
+
+  test("man pulls a one-line description from help", () => {
+    loadModule();
+    typeCommand("man whoami");
+    expect(sessionText()).toContain("who's asking");
+    typeCommand("man nope");
+    expect(sessionText()).toContain("No manual entry for nope");
+  });
+
+  test("uname -a reports the session, plain uname the shell", () => {
+    loadModule();
+    typeCommand("uname");
+    expect(sessionText()).toContain("tor-sh");
+    typeCommand("uname -a");
+    expect(sessionText()).toContain("terminal");
+  });
+
+  test("colour prints the active palette swatches", () => {
+    loadModule();
+    typeCommand("colour");
+    expect(sessionText().toLowerCase()).toContain("paper");
+    expect(sessionText()).toContain("#ffffff");
+  });
+
+  test("fortune prints one of the aphorisms", () => {
+    loadModule();
+    typeCommand("fortune");
+    // Every fortune carries an em-dash attribution.
+    expect(sessionText()).toContain("—");
+  });
+
+  test("history records commands, newest last, including itself", () => {
+    loadModule();
+    typeCommand("whoami");
+    typeCommand("date");
+    typeCommand("history");
+    const text = sessionText();
+    expect(text).toContain("1  whoami");
+    expect(text).toContain("2  date");
+    expect(text).toContain("3  history");
+  });
+
+  test("uptime reports an 'up' line", () => {
+    loadModule();
+    typeCommand("uptime");
+    expect(sessionText()).toContain("up ");
+  });
+
+  test("top prints a tongue-in-cheek process list", () => {
+    loadModule();
+    typeCommand("top");
+    expect(sessionText()).toContain("tor-sh");
+    expect(sessionText().toLowerCase()).toContain("coffee");
+  });
+
+  test("editor jokes point back at exit", () => {
+    loadModule();
+    typeCommand("vim");
+    expect(sessionText().toLowerCase()).toContain("exit");
+  });
+
+  test(":wq leaves the terminal like exit", () => {
+    localStorage.setItem("theme-layout-previous", "column");
+    loadModule();
+    typeCommand(":wq");
+    expect(document.documentElement.getAttribute("data-layout")).not.toBe(
+      "terminal"
+    );
+  });
+
+  test("rm -rf / refuses with the git joke", () => {
+    loadModule();
+    typeCommand("rm -rf /");
+    expect(sessionText().toLowerCase()).toContain("it's all in git");
+  });
+
+  test("git subcommands answer in character", () => {
+    loadModule();
+    typeCommand("git blame");
+    expect(sessionText().toLowerCase()).toContain("you");
+    typeCommand("git commit");
+    expect(sessionText().toLowerCase()).toContain("working tree clean");
+  });
+
+  test("npm install fakes a dependency resolve", () => {
+    loadModule();
+    typeCommand("npm install");
+    expect(sessionText().toLowerCase()).toContain("vanilla js");
+  });
+
+  test("hello greets back", () => {
+    loadModule();
+    typeCommand("hello");
+    expect(sessionText()).toContain("hey");
+  });
+
+  test("konami command toggles party mode", () => {
+    loadModule();
+    typeCommand("konami");
+    expect(document.documentElement.getAttribute("data-konami")).toBe("on");
+    typeCommand("konami");
+    expect(document.documentElement.getAttribute("data-konami")).toBeNull();
+  });
+
+  test("the Konami key sequence at the prompt enables party mode", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    const press = (key) =>
+      input.dispatchEvent(
+        new window.KeyboardEvent("keydown", { key, bubbles: true })
+      );
+    [
+      "ArrowUp",
+      "ArrowUp",
+      "ArrowDown",
+      "ArrowDown",
+      "ArrowLeft",
+      "ArrowRight",
+      "ArrowLeft",
+      "ArrowRight",
+      "b",
+      "a",
+    ].forEach(press);
+    expect(document.documentElement.getAttribute("data-konami")).toBe("on");
+  });
+
   test("clear empties the session log", () => {
     loadModule();
     typeCommand("whoami");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -334,10 +334,29 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("hey");
   });
 
-  test("konami command toggles party mode", () => {
+  test("easteregg lists the hidden commands but stays out of help", () => {
+    loadModule();
+    typeCommand("easteregg");
+    const eggs = sessionText();
+    expect(eggs).toContain("easter eggs:");
+    expect(eggs).toContain("konami");
+    expect(eggs).toContain("fortune");
+    typeCommand("clear");
+    typeCommand("help");
+    const help = sessionText();
+    expect(help).toContain("commands:");
+    // The index itself is not advertised in help.
+    expect(help).not.toContain("easter eggs:");
+    expect(help).not.toContain("konami");
+  });
+
+  test("konami command toggles party mode", async () => {
     loadModule();
     typeCommand("konami");
     expect(document.documentElement.getAttribute("data-konami")).toBe("on");
+    // toggleKonami de-dupes a synchronous burst (see darkmode.js), so let the
+    // guard clear on the microtask queue before toggling back off.
+    await Promise.resolve();
     typeCommand("konami");
     expect(document.documentElement.getAttribute("data-konami")).toBeNull();
   });

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -322,9 +322,13 @@ describe("terminal command line", () => {
     expect(sessionText().toLowerCase()).toContain("working tree clean");
   });
 
-  test("npm install fakes a dependency resolve", () => {
+  test("npm install fakes a dependency resolve, then reveals the joke", () => {
     loadModule();
     typeCommand("npm install");
+    // The "working" line lands immediately; the punchline is held back.
+    expect(sessionText().toLowerCase()).toContain("resolving 4271");
+    expect(sessionText().toLowerCase()).not.toContain("vanilla js");
+    jest.advanceTimersByTime(1000);
     expect(sessionText().toLowerCase()).toContain("vanilla js");
   });
 

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -93,11 +93,26 @@ describe("terminal command line", () => {
           >
           <nav class="top-menu__nav">
             <a class="terminal-prompt__host" href="/"></a>
+            <a class="top-menu__link" href="/works/">Works</a>
+            <a class="top-menu__link" href="/works/tags/">Tags</a>
             <a class="top-menu__link" href="/writing/">Writing</a>
             <a class="top-menu__link" href="/about/">About</a>
             <a class="terminal-quick terminal-quick--lang" href="/sv/writing/" lang="sv">sv</a>
           </nav>
         </div>
+        <div class="article-card"><a href="/writing/the-grid-inherited/">The grid</a></div>
+        <footer>
+          <nav class="footer-nav">
+            <a href="/ui-library/">UI Library</a>
+            <a href="/palette-generator/">Palette</a>
+          </nav>
+          <address class="footer-contact">
+            <ul class="footer-menu">
+              <li><a href="mailto:hej@tor-bjorn.com">hej@tor-bjorn.com</a></li>
+              <li><a href="https://www.linkedin.com/in/tbhedberg/">LinkedIn</a></li>
+            </ul>
+          </address>
+        </footer>
         <div data-js="coty-transport" hidden>
           <button data-js="coty-transport-trigger" aria-label="Show"></button>
           <button
@@ -126,7 +141,9 @@ describe("terminal command line", () => {
       removeEventListener: jest.fn(),
     }));
     window.getComputedStyle = jest.fn(() => ({
-      getPropertyValue: jest.fn(() => "#ffffff"),
+      getPropertyValue: jest.fn((prop) =>
+        prop === "--terminal-cwd" ? "~" : "#ffffff"
+      ),
     }));
     window.Toast = { show: jest.fn() };
     window.requestAnimationFrame = jest.fn();
@@ -352,6 +369,212 @@ describe("terminal command line", () => {
     // The index itself is not advertised in help.
     expect(help).not.toContain("easter eggs:");
     expect(help).not.toContain("konami");
+  });
+
+  // ---- Round 4: directory tree, utilities, fundamentals -----------------
+
+  function keydown(opts) {
+    document
+      .querySelector('[data-js="terminal-input"]')
+      .dispatchEvent(
+        new window.KeyboardEvent("keydown", { bubbles: true, ...opts })
+      );
+  }
+
+  test("ls lists the current directory's sections", () => {
+    loadModule();
+    typeCommand("ls");
+    expect(sessionText()).toContain("works/");
+    expect(sessionText()).toContain("writing/");
+  });
+
+  test("ls <path> lists that directory; unknown paths error", () => {
+    loadModule();
+    typeCommand("ls works");
+    expect(sessionText()).toContain("tags/");
+    typeCommand("ls nope");
+    expect(sessionText()).toContain(
+      "cannot access 'nope': No such file or directory"
+    );
+  });
+
+  test("ls -a reveals hidden entries", () => {
+    loadModule();
+    typeCommand("ls -a");
+    expect(sessionText()).toContain(".secret");
+    expect(sessionText()).toContain(".config");
+  });
+
+  test("ls inside a section lists the page's own content links", () => {
+    loadModule();
+    // Pretend the page is /writing/ so the cwd is ~/writing.
+    window.getComputedStyle = jest.fn(() => ({
+      getPropertyValue: jest.fn((prop) =>
+        prop === "--terminal-cwd" ? "~/writing" : "#ffffff"
+      ),
+    }));
+    typeCommand("ls");
+    expect(sessionText()).toContain("the-grid-inherited/");
+  });
+
+  test("tree draws the site map", () => {
+    loadModule();
+    typeCommand("tree");
+    const text = sessionText();
+    expect(text).toContain("works/");
+    expect(text).toContain("tags/");
+    expect(text).toMatch(/[├└]/);
+  });
+
+  test("hire starts the contact flow", () => {
+    loadModule();
+    typeCommand("hire");
+    expect(tailPrompt()).toBe("email>");
+  });
+
+  test("social lists the real footer links", () => {
+    loadModule();
+    typeCommand("social");
+    const text = sessionText();
+    expect(text).toContain("hej@tor-bjorn.com");
+    expect(text.toLowerCase()).toContain("linkedin");
+  });
+
+  test("email prints the contact address", () => {
+    loadModule();
+    typeCommand("email");
+    expect(sessionText()).toContain("hej@tor-bjorn.com");
+  });
+
+  test("resume heads to the about page", () => {
+    loadModule();
+    typeCommand("resume");
+    expect(sessionText().toLowerCase()).toContain("about");
+  });
+
+  test("layout switches the layout and lists options with no arg", () => {
+    loadModule();
+    typeCommand("layout");
+    expect(sessionText()).toContain("available:");
+    typeCommand("layout editorial");
+    expect(document.documentElement.getAttribute("data-layout")).toBe(
+      "editorial"
+    );
+  });
+
+  test("debug prints the theme state", () => {
+    loadModule();
+    typeCommand("debug");
+    const text = sessionText();
+    expect(text).toContain("layout");
+    expect(text).toContain("palette");
+  });
+
+  test("reset restores theme defaults", () => {
+    localStorage.setItem("theme-mode", "dark");
+    localStorage.setItem("theme-palette", "custom");
+    loadModule();
+    typeCommand("reset");
+    expect(sessionText()).toContain("reset:");
+    expect(localStorage.getItem("theme-mode")).toBe("system");
+    expect(localStorage.getItem("theme-palette")).toBe("standard");
+  });
+
+  test("copy writes to the clipboard and confirms", () => {
+    const writeText = jest.fn();
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    loadModule();
+    typeCommand("copy email");
+    expect(sessionText()).toContain("copied:");
+    expect(writeText).toHaveBeenCalledWith("hej@tor-bjorn.com");
+  });
+
+  test("classic eggs respond", () => {
+    loadModule();
+    typeCommand("xyzzy");
+    expect(sessionText()).toContain("Nothing happens.");
+    typeCommand("42");
+    expect(sessionText()).toContain("42");
+    typeCommand("ping");
+    expect(sessionText().toLowerCase()).toContain("pong");
+    typeCommand("sl");
+    expect(sessionText().toLowerCase()).toContain("choo");
+  });
+
+  test("cowsay speaks the argument", () => {
+    loadModule();
+    typeCommand("cowsay hello");
+    const text = sessionText();
+    expect(text).toContain("hello");
+    expect(text).toContain("^__^");
+  });
+
+  test("logo prints the boot art", () => {
+    loadModule();
+    typeCommand("logo");
+    expect(sessionText()).toContain("██");
+  });
+
+  test("weather prints a fake forecast", () => {
+    loadModule();
+    typeCommand("weather");
+    expect(sessionText().toLowerCase()).toContain("breeze");
+  });
+
+  test("matrix rains, then wakes up", () => {
+    loadModule();
+    typeCommand("matrix");
+    jest.advanceTimersByTime(1500);
+    expect(sessionText()).toContain("wake up");
+  });
+
+  test("sudo make me a sandwich vs make me a sandwich", () => {
+    loadModule();
+    typeCommand("sudo make me a sandwich");
+    expect(sessionText()).toContain("okay.");
+    typeCommand("make me a sandwich");
+    expect(sessionText()).toContain("make it yourself");
+  });
+
+  test("↑ recalls the previous command", () => {
+    loadModule();
+    typeCommand("whoami");
+    keydown({ key: "ArrowUp" });
+    expect(document.querySelector('[data-js="terminal-input"]').value).toBe(
+      "whoami"
+    );
+  });
+
+  test("Tab completes a command name", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "wea";
+    keydown({ key: "Tab" });
+    expect(input.value).toBe("weather ");
+  });
+
+  test("Tab completes a cd path from the tree", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "cd wri";
+    keydown({ key: "Tab" });
+    expect(input.value).toBe("cd writing");
+  });
+
+  test("Ctrl+L clears the screen, Ctrl+C cancels the line", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    typeCommand("whoami");
+    expect(sessionText().length).toBeGreaterThan(0);
+    keydown({ key: "l", ctrlKey: true });
+    expect(sessionText()).toBe("");
+    input.value = "half typed";
+    keydown({ key: "c", ctrlKey: true });
+    expect(input.value).toBe("");
+    expect(sessionText()).toContain("^C");
   });
 
   test("konami command toggles party mode", async () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -417,6 +417,27 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("the-grid-inherited/");
   });
 
+  test("ls of another section hints at cd instead of printing nothing", () => {
+    loadModule();
+    // Sitting on /works/, ask for a different section's contents.
+    window.getComputedStyle = jest.fn(() => ({
+      getPropertyValue: jest.fn((prop) =>
+        prop === "--terminal-cwd" ? "~/works" : "#ffffff"
+      ),
+    }));
+    typeCommand("ls ~/writing");
+    expect(sessionText()).toContain("cd writing");
+  });
+
+  test("ls lists several paths with per-directory headers", () => {
+    loadModule();
+    typeCommand("ls works writing");
+    const text = sessionText();
+    expect(text).toContain("works:");
+    expect(text).toContain("writing:");
+    expect(text).toContain("tags/");
+  });
+
   test("tree draws the site map", () => {
     loadModule();
     typeCommand("tree");

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2640,10 +2640,12 @@
       return out;
     }
 
-    // `ls [path]`: list a directory's children. Structural children come from
-    // the nav/footer tree; for the current directory, the page's own content
-    // links are merged in. Unknown path → an ls-style error.
-    function terminalLsLines(pathArg, showHidden) {
+    // List a single directory. Structural children come from the nav/footer
+    // tree; for the current directory, the page's own content links are merged
+    // in. Unknown path → an ls-style error; a real page whose contents can't
+    // be listed from here (a different section) → a `cd` hint rather than a
+    // bare empty result.
+    function terminalLsOne(pathArg, showHidden) {
       var targetSegs = terminalResolveSegments(pathArg);
       var node = terminalNodeAt(targetSegs);
       if (!node) {
@@ -2651,12 +2653,13 @@
           "ls: cannot access '" + pathArg + "': No such file or directory",
         ];
       }
+      var isCwd = targetSegs.join("/") === terminalCwdSegments().join("/");
       var entries = Object.keys(node.children)
         .sort()
         .map(function (k) {
           return node.children[k].name + "/";
         });
-      if (targetSegs.join("/") === terminalCwdSegments().join("/")) {
+      if (isCwd) {
         terminalPageContentSlugs(targetSegs).forEach(function (slug) {
           var entry = slug + "/";
           if (entries.indexOf(entry) === -1) {
@@ -2668,7 +2671,12 @@
         entries = [".secret", ".config"].concat(entries);
       }
       if (!entries.length) {
-        return []; // empty directory — real `ls` prints nothing
+        // A real page (has an href) that we're not currently on: its contents
+        // live on that page, so point there instead of printing nothing.
+        if (node.href && !isCwd && node.name !== "~") {
+          return ["(cd " + node.name + " to list it)"];
+        }
+        return []; // genuinely empty — real `ls` prints nothing
       }
       var MAX = 40;
       var lines = [entries.slice(0, MAX).join("  ")];
@@ -2676,6 +2684,26 @@
         lines.push("… (" + (entries.length - MAX) + " more)");
       }
       return lines;
+    }
+
+    // `ls [path...]`: with 0 or 1 paths, list that directory. With several,
+    // print a `path:`-headed block per directory, blank-line separated, like
+    // real `ls`. Flags (e.g. -a) apply to every path.
+    function terminalLsLines(paths, showHidden) {
+      if (paths.length <= 1) {
+        return terminalLsOne(paths[0] || "", showHidden);
+      }
+      var out = [];
+      paths.forEach(function (path, i) {
+        if (i > 0) {
+          out.push("");
+        }
+        out.push(path + ":");
+        terminalLsOne(path, showHidden).forEach(function (line) {
+          out.push(line);
+        });
+      });
+      return out;
     }
 
     // Whole-tree view for `tree`, drawn with ├──/└── connectors.
@@ -3164,13 +3192,12 @@
           var lsShowHidden = args.some(function (a) {
             return a.charAt(0) === "-" && /a/.test(a);
           });
-          var lsPath =
-            args.filter(function (a) {
-              return a.charAt(0) !== "-";
-            })[0] || "";
+          var lsPaths = args.filter(function (a) {
+            return a.charAt(0) !== "-";
+          });
           return {
             echo: input,
-            lines: terminalLsLines(lsPath, lsShowHidden),
+            lines: terminalLsLines(lsPaths, lsShowHidden),
             action: null,
           };
         }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2317,6 +2317,29 @@
       "Type is a beautiful group of letters, not a group of beautiful letters. — Matthew Carter",
     ];
 
+    // A private index of the hidden commands, surfaced only by `easteregg` —
+    // deliberately kept out of `help` so it stays a discovery, not a menu.
+    const TERMINAL_EASTER_EGGS = [
+      "easter eggs:",
+      "  sudo      permission denied",
+      "  coffee    HTTP 418",
+      "  cat <f>   readme/about/colophon…",
+      "  man <cmd> one-line manual",
+      "  uname     shell / -a session",
+      "  colour    palette swatches",
+      "  fortune   design aphorism",
+      "  history   command scrollback",
+      "  uptime    session age",
+      "  top       process list",
+      "  vim/nano/emacs  editor jokes",
+      "  :q :wq    quit like vim",
+      "  rm -rf /  it's all in git",
+      "  git <sub> blame/commit/push…",
+      "  npm i     fake resolve",
+      "  hello     greeting",
+      "  konami    party (↑↑↓↓←→←→ba)",
+    ];
+
     function terminalHost() {
       return (window.location && window.location.hostname) || "tor-bjorn.com";
     }
@@ -3060,6 +3083,13 @@
             lines: ["konami: party mode 🌈"],
             action: { type: "konami" },
           };
+        case "easteregg":
+        case "eastereggs":
+          return {
+            echo: input,
+            lines: TERMINAL_EASTER_EGGS.slice(),
+            action: null,
+          };
         default:
           return {
             echo: input,
@@ -3071,7 +3101,21 @@
 
     // Party mode: a root attribute CSS hangs a playful hue-cycle off. Toggled
     // by the `konami` command and by the arrow-key Konami code at the prompt.
+    //
+    // The guard collapses a synchronous burst of calls into a single toggle.
+    // In the browser this is a no-op — one handler fires once. It matters under
+    // test, where re-requiring the module re-runs its DOMContentLoaded init and
+    // stacks duplicate prompt handlers that would otherwise all toggle for one
+    // keypress; the flag lives on `window` so every stacked copy shares it, and
+    // clears on the next microtask so genuine later toggles still register.
     function toggleKonami() {
+      if (window.__konamiToggling) {
+        return;
+      }
+      window.__konamiToggling = true;
+      window.Promise.resolve().then(function () {
+        window.__konamiToggling = false;
+      });
       var root = document.documentElement;
       if (root.getAttribute("data-konami") === "on") {
         root.removeAttribute("data-konami");

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2224,6 +2224,30 @@
       '[data-js="terminal-session"]'
     );
 
+    // Session start, for `uptime` — captured when the command engine boots.
+    var terminalSessionStart = Date.now();
+
+    // Command scrollback for `history`, oldest first. Capped so a long-lived
+    // tab can't grow it without bound.
+    var terminalHistory = [];
+    var TERMINAL_HISTORY_MAX = 100;
+
+    // The Konami code (typed while the prompt is focused) toggles party mode.
+    // Keys are compared lowercased, so ArrowUp → "arrowup", B → "b".
+    var KONAMI_SEQUENCE = [
+      "arrowup",
+      "arrowup",
+      "arrowdown",
+      "arrowdown",
+      "arrowleft",
+      "arrowright",
+      "arrowleft",
+      "arrowright",
+      "b",
+      "a",
+    ];
+    var konamiProgress = 0;
+
     // Kept narrow (a ~12-char command column + short descriptions) so every
     // line fits a phone's ~36-char terminal width without wrapping mid-column.
     const TERMINAL_HELP = [
@@ -2232,6 +2256,7 @@
       "  whoami    who's asking",
       "  date      date & time",
       "  pwd       working dir",
+      "  ls        list pages",
       "  cd <page> change page",
       "  lang [sv|en]  language",
       "  echo      print text",
@@ -2259,6 +2284,38 @@
         invert: true,
       },
     };
+
+    // `cat`-able pseudo-files. A leading dot and a trailing .txt/.md are
+    // stripped before lookup, so `cat colophon`, `cat colophon.txt` and
+    // `cat .secret` all resolve.
+    const TERMINAL_FILES = {
+      readme: [
+        "it's a portfolio. poke around.",
+        "type 'help' for the command list.",
+      ],
+      about: ["designer & developer.", "type 'cd about' for the long version."],
+      colophon: [
+        "Hugo · vanilla JS · no frameworks.",
+        "hand-rolled design tokens.",
+        "no trackers, no cookies.",
+      ],
+      secret: [
+        "there are no secrets here.",
+        "(the source is right there — view-source:)",
+      ],
+    };
+
+    // `fortune` cookies — design & typography aphorisms, printed at random.
+    const TERMINAL_FORTUNES = [
+      "Less, but better. — Dieter Rams",
+      "Good design is as little design as possible. — Dieter Rams",
+      "Design is not just what it looks like — design is how it works. — Steve Jobs",
+      "The details are not the details. They make the design. — Charles Eames",
+      "White space is to be regarded as an active element. — Jan Tschichold",
+      "Simplicity is the ultimate sophistication. — Leonardo da Vinci",
+      "Perfection is reached when there is nothing left to take away. — Antoine de Saint-Exupéry",
+      "Type is a beautiful group of letters, not a group of beautiful letters. — Matthew Carter",
+    ];
 
     function terminalHost() {
       return (window.location && window.location.hostname) || "tor-bjorn.com";
@@ -2303,6 +2360,126 @@
         return "off";
       }
       return "toggle";
+    }
+
+    // "1h 2m 3s", dropping leading zero units, for `uptime`.
+    function formatUptime(totalSeconds) {
+      var s = Math.max(0, Math.floor(totalSeconds));
+      var h = Math.floor(s / 3600);
+      var m = Math.floor((s % 3600) / 60);
+      s = s % 60;
+      var parts = [];
+      if (h) {
+        parts.push(h + "h");
+      }
+      if (h || m) {
+        parts.push(m + "m");
+      }
+      parts.push(s + "s");
+      return parts.join(" ");
+    }
+
+    function uptimeLine() {
+      var secs = (Date.now() - terminalSessionStart) / 1000;
+      return "up " + formatUptime(secs) + " · load 0.00 (it's a static site)";
+    }
+
+    function historyLines() {
+      if (!terminalHistory.length) {
+        return ["(no history yet)"];
+      }
+      return terminalHistory.map(function (entry, i) {
+        var n = String(i + 1);
+        while (n.length < 3) {
+          n = " " + n;
+        }
+        return n + "  " + entry;
+      });
+    }
+
+    // The nav's page slugs, de-duplicated in nav order — the real directories
+    // `cd` understands, listed by `ls`.
+    function terminalPageSlugs() {
+      var links = document.querySelectorAll(
+        ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href]"
+      );
+      var seen = {};
+      var slugs = [];
+      links.forEach(function (link) {
+        var href = link.getAttribute("href");
+        if (!href || href.charAt(0) === "#") {
+          return;
+        }
+        var path = href.replace(/[?#].*$/, "").replace(/\/+$/, "");
+        var slug = (path.split("/").filter(Boolean).pop() || "").toLowerCase();
+        if (!slug || seen[slug]) {
+          return;
+        }
+        seen[slug] = true;
+        slugs.push(slug);
+      });
+      return slugs;
+    }
+
+    function terminalLsLines() {
+      var slugs = terminalPageSlugs();
+      if (!slugs.length) {
+        return ["(empty)"];
+      }
+      return [
+        slugs
+          .map(function (slug) {
+            return slug + "/";
+          })
+          .join("  "),
+      ];
+    }
+
+    // Resolve a `cat` target to its pseudo-file lines, or null if there's no
+    // such "file".
+    function terminalFile(name) {
+      var key = String(name || "")
+        .toLowerCase()
+        .replace(/^\.+/, "")
+        .replace(/\.(txt|md)$/, "");
+      if (key === "secrets") {
+        key = "secret";
+      }
+      return TERMINAL_FILES[key] || null;
+    }
+
+    // One-line man description, pulled from the help table so the two never
+    // drift apart. Matches the first word of each "  cmd   desc" help row.
+    function terminalManPage(topic) {
+      var want = String(topic || "").toLowerCase();
+      var found = null;
+      TERMINAL_HELP.forEach(function (row) {
+        if (found) {
+          return;
+        }
+        var trimmed = row.trim();
+        var word = trimmed.split(/\s+/)[0];
+        if (word === want) {
+          found = trimmed.slice(word.length).trim() || null;
+        }
+      });
+      return found;
+    }
+
+    // Resolved hex/colour values for a few key palette tokens, for `colour`.
+    function terminalColourLines() {
+      var styles = window.getComputedStyle(document.documentElement);
+      var swatches = [
+        ["paper", "--surface-page"],
+        ["ink", "--surface-ink-strong"],
+        ["accent", "--surface-accent"],
+      ];
+      var lines = ["palette: " + paletteLabel()];
+      swatches.forEach(function (pair) {
+        var value = (styles.getPropertyValue(pair[1]) || "").trim();
+        lines.push("  " + pair[0] + "  " + (value || "—"));
+      });
+      return lines;
     }
 
     // The home link the terminal prompt already points at (falls back to root).
@@ -2669,6 +2846,220 @@
             ],
             action: null,
           };
+        case "ls":
+        case "dir":
+          return { echo: input, lines: terminalLsLines(), action: null };
+        case "cat": {
+          if (!args.length) {
+            return {
+              echo: input,
+              lines: ["usage: cat <file> — try 'cat readme'"],
+              action: null,
+            };
+          }
+          var fileLines = terminalFile(args[0]);
+          if (!fileLines) {
+            return {
+              echo: input,
+              lines: ["cat: " + args[0] + ": No such file or directory"],
+              action: null,
+            };
+          }
+          return { echo: input, lines: fileLines.slice(), action: null };
+        }
+        case "man": {
+          var topic = (args[0] || "").toLowerCase();
+          if (!topic) {
+            return {
+              echo: input,
+              lines: ["what manual page do you want?", "try: man help"],
+              action: null,
+            };
+          }
+          var page = terminalManPage(topic);
+          if (!page) {
+            return {
+              echo: input,
+              lines: ["No manual entry for " + topic],
+              action: null,
+            };
+          }
+          return { echo: input, lines: [topic + " — " + page], action: null };
+        }
+        case "uname":
+          if (args.indexOf("-a") !== -1) {
+            return {
+              echo: input,
+              lines: [
+                "tor-sh 1.0 " +
+                  terminalHost() +
+                  " terminal " +
+                  resolvedModeLabel() +
+                  " " +
+                  currentLang(),
+              ],
+              action: null,
+            };
+          }
+          return { echo: input, lines: ["tor-sh"], action: null };
+        case "colour":
+        case "color":
+          return { echo: input, lines: terminalColourLines(), action: null };
+        case "fortune": {
+          var pick = Math.floor(Math.random() * TERMINAL_FORTUNES.length);
+          return {
+            echo: input,
+            lines: [TERMINAL_FORTUNES[pick]],
+            action: null,
+          };
+        }
+        case "history":
+          return { echo: input, lines: historyLines(), action: null };
+        case "uptime":
+          return { echo: input, lines: [uptimeLine()], action: null };
+        case "top":
+        case "htop":
+          return {
+            echo: input,
+            lines: [
+              "  PID  CPU  MEM  CMD",
+              "    1   0%   ok  tor-sh",
+              "   42   0%   ok  curiosity",
+              "  418   0%    —  coffee (defunct)",
+            ],
+            action: null,
+          };
+        case "vim":
+        case "vi":
+          return {
+            echo: input,
+            lines: [
+              "entering vim… only kidding.",
+              "to leave, type 'exit' — you're safe here.",
+            ],
+            action: null,
+          };
+        case "nano":
+          return {
+            echo: input,
+            lines: ["nano: nothing to edit here.", "type 'exit' to leave."],
+            action: null,
+          };
+        case "emacs":
+          return {
+            echo: input,
+            lines: [
+              "emacs: a fine OS, missing an editor.",
+              "type 'exit' to leave.",
+            ],
+            action: null,
+          };
+        case ":q":
+        case ":q!":
+        case ":wq":
+        case ":wq!":
+        case ":x":
+          return {
+            echo: input,
+            lines: ["(you can just type 'exit')"],
+            action: { type: "exit" },
+          };
+        case "rm": {
+          var rmArgs = args.join(" ");
+          if (
+            /-[a-z]*r/i.test(rmArgs) &&
+            /(^|\s)(\/|~|\*|\/\*|\.)(\s|$)/.test(rmArgs)
+          ) {
+            return {
+              echo: input,
+              lines: ["nice try — it's all in git 😏"],
+              action: null,
+            };
+          }
+          if (!args.length) {
+            return {
+              echo: input,
+              lines: ["rm: missing operand"],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: [
+              "rm: cannot remove '" +
+                args[args.length - 1] +
+                "': read-only site",
+            ],
+            action: null,
+          };
+        }
+        case "git": {
+          var gitSub = (args[0] || "").toLowerCase();
+          var gitReplies = {
+            blame: ["git blame: you — last touched just now 😄"],
+            commit: ["nothing to commit, working tree clean ✨"],
+            push: ["Everything up-to-date."],
+            pull: ["Already up to date."],
+            status: [
+              "On branch main.",
+              "nothing to commit, working tree clean",
+            ],
+            log: ["read the real log: type 'cd writing'"],
+          };
+          if (!gitSub) {
+            return {
+              echo: input,
+              lines: ["usage: git <command> — try 'git status'"],
+              action: null,
+            };
+          }
+          if (gitReplies[gitSub]) {
+            return {
+              echo: input,
+              lines: gitReplies[gitSub].slice(),
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: ["git: '" + gitSub + "' is not a git command."],
+            action: null,
+          };
+        }
+        case "npm":
+        case "yarn":
+        case "pnpm": {
+          var pkgSub = (args[0] || "").toLowerCase();
+          if (pkgSub === "install" || pkgSub === "i" || pkgSub === "add") {
+            return {
+              echo: input,
+              lines: [
+                "resolving 4271 dependencies…",
+                "done. (kidding — it's vanilla JS)",
+              ],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: [cmd + ": this site ships no node_modules."],
+            action: null,
+          };
+        }
+        case "hello":
+        case "hi":
+        case "hey":
+          return {
+            echo: input,
+            lines: ["hey 👋", "type 'help' to see what I can do."],
+            action: null,
+          };
+        case "konami":
+          return {
+            echo: input,
+            lines: ["konami: party mode 🌈"],
+            action: { type: "konami" },
+          };
         default:
           return {
             echo: input,
@@ -2678,11 +3069,25 @@
       }
     }
 
+    // Party mode: a root attribute CSS hangs a playful hue-cycle off. Toggled
+    // by the `konami` command and by the arrow-key Konami code at the prompt.
+    function toggleKonami() {
+      var root = document.documentElement;
+      if (root.getAttribute("data-konami") === "on") {
+        root.removeAttribute("data-konami");
+      } else {
+        root.setAttribute("data-konami", "on");
+      }
+    }
+
     function applyTerminalAction(action) {
       if (!action) {
         return;
       }
       switch (action.type) {
+        case "konami":
+          toggleKonami();
+          break;
         case "exit":
           exitTerminal();
           break;
@@ -2791,6 +3196,15 @@
     }
 
     function runTerminalInput(raw) {
+      // Record the command before running it, so `history` includes itself —
+      // matching a real shell.
+      var trimmed = String(raw === null || raw === undefined ? "" : raw).trim();
+      if (trimmed) {
+        terminalHistory.push(trimmed);
+        if (terminalHistory.length > TERMINAL_HISTORY_MAX) {
+          terminalHistory.shift();
+        }
+      }
       var result = runTerminalCommand(raw);
       if (result.echo) {
         printTerminalLine(result.echo, "terminal-session__cmd");
@@ -3089,9 +3503,32 @@
       }
     }
 
+    // Track the Konami code as it's typed into the prompt. Non-destructive:
+    // it only watches keys, then tidies the stray "b"/"a" once it completes.
+    function advanceKonami(e) {
+      var key = String(e.key || "").toLowerCase();
+      if (key === KONAMI_SEQUENCE[konamiProgress]) {
+        konamiProgress += 1;
+        if (konamiProgress === KONAMI_SEQUENCE.length) {
+          konamiProgress = 0;
+          if (terminalInput) {
+            terminalInput.value = "";
+            syncTerminalInputSize();
+          }
+          toggleKonami();
+          printTerminalLine("konami: party mode 🌈", "terminal-session__out");
+          scrollTerminalToEnd();
+        }
+      } else {
+        // Let a mistyped key restart the sequence if it's the first step.
+        konamiProgress = key === KONAMI_SEQUENCE[0] ? 1 : 0;
+      }
+    }
+
     if (terminalInput) {
       terminalInput.addEventListener("input", syncTerminalInputSize);
       terminalInput.addEventListener("keydown", function (e) {
+        advanceKonami(e);
         if (e.key === "Enter") {
           e.preventDefault();
           var value = terminalInput.value;

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3054,13 +3054,16 @@
         case "pnpm": {
           var pkgSub = (args[0] || "").toLowerCase();
           if (pkgSub === "install" || pkgSub === "i" || pkgSub === "add") {
+            // Print the "working" line now, then reveal the punchline a beat
+            // later so it reads like a job that ran before it fell over.
             return {
               echo: input,
-              lines: [
-                "resolving 4271 dependencies…",
-                "done. (kidding — it's vanilla JS)",
-              ],
-              action: null,
+              lines: ["resolving 4271 dependencies…"],
+              action: {
+                type: "defer",
+                delay: 900,
+                lines: ["done. (kidding — it's vanilla JS)"],
+              },
             };
           }
           return {
@@ -3223,6 +3226,22 @@
           break;
         case "flow":
           startTerminalFlow(action.flow);
+          break;
+        case "defer":
+          // Print follow-up lines after a delay, so a command can fake a job
+          // running before its punchline. Skip if the terminal was left in
+          // the meantime.
+          if (action.lines && action.lines.length) {
+            window.setTimeout(function () {
+              if (!isTerminalLayout()) {
+                return;
+              }
+              action.lines.forEach(function (line) {
+                printTerminalLine(line, "terminal-session__out");
+              });
+              scrollTerminalToEnd();
+            }, action.delay || 600);
+          }
           break;
         default:
           break;

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2248,6 +2248,16 @@
     ];
     var konamiProgress = 0;
 
+    // Where ↑/↓ history recall currently sits (null = the live line). Reset
+    // whenever the user types or runs a command.
+    var terminalHistoryCursor = null;
+
+    // The last printed output line, for `copy` with no argument.
+    var lastTerminalOutput = "";
+
+    // The four selectable layouts, for the `layout`/`theme` command.
+    var TERMINAL_LAYOUTS = ["column", "editorial", "index", "terminal"];
+
     // Kept narrow (a ~12-char command column + short descriptions) so every
     // line fits a phone's ~36-char terminal width without wrapping mid-column.
     const TERMINAL_HELP = [
@@ -2256,8 +2266,9 @@
       "  whoami    who's asking",
       "  date      date & time",
       "  pwd       working dir",
-      "  ls        list pages",
+      "  ls        list dir",
       "  cd <page> change page",
+      "  tree      site map",
       "  lang [sv|en]  language",
       "  echo      print text",
       "  neofetch  session info",
@@ -2265,10 +2276,71 @@
       "  pantone   [on|off|YYYY]",
       "  grain|blend|motion on/off",
       "  grid      layout grid",
+      "  layout <name>  switch layout",
+      "  hire      let's work together",
+      "  social    my links",
+      "  copy <x>  to clipboard",
       "  contact   message me",
       "  subscribe newsletter",
       "  clear     wipe the screen",
       "  exit      leave the terminal",
+      "keys: ↑↓ history · Tab complete · ^L/^C/^U",
+    ];
+
+    // Command words offered by Tab completion (primary spellings only).
+    const TERMINAL_COMMAND_NAMES = [
+      "help",
+      "whoami",
+      "date",
+      "pwd",
+      "ls",
+      "cd",
+      "tree",
+      "lang",
+      "echo",
+      "neofetch",
+      "dark",
+      "light",
+      "system",
+      "pantone",
+      "grain",
+      "blend",
+      "motion",
+      "grid",
+      "layout",
+      "theme",
+      "hire",
+      "social",
+      "links",
+      "email",
+      "resume",
+      "cv",
+      "copy",
+      "cat",
+      "man",
+      "uname",
+      "colour",
+      "fortune",
+      "history",
+      "uptime",
+      "top",
+      "debug",
+      "env",
+      "reset",
+      "contact",
+      "subscribe",
+      "clear",
+      "exit",
+      "sl",
+      "cowsay",
+      "logo",
+      "ascii",
+      "weather",
+      "matrix",
+      "ping",
+      "moo",
+      "xyzzy",
+      "easteregg",
     ];
 
     // Toggleable image effects, keyed by command word. `invert` flags that the
@@ -2302,6 +2374,11 @@
       secret: [
         "there are no secrets here.",
         "(the source is right there — view-source:)",
+      ],
+      config: [
+        "# ~/.config — terminal preferences",
+        "shell   tor-sh 1.0",
+        "prompt  ~$ (edit via the settings panel)",
       ],
     };
 
@@ -2338,6 +2415,17 @@
       "  npm i     fake resolve",
       "  hello     greeting",
       "  konami    party (↑↑↓↓←→←→ba)",
+      "  sl        choo choo",
+      "  cowsay <x> talking cow",
+      "  moo       super cow powers",
+      "  xyzzy     nothing happens",
+      "  42        the answer",
+      "  ping      pong",
+      "  weather   fake forecast",
+      "  logo      brand curl",
+      "  matrix    digital rain",
+      "  debug/env theme state",
+      "  reset     restore defaults",
     ];
 
     function terminalHost() {
@@ -2420,41 +2508,233 @@
       });
     }
 
-    // The nav's page slugs, de-duplicated in nav order — the real directories
-    // `cd` understands, listed by `ls`.
-    function terminalPageSlugs() {
-      var links = document.querySelectorAll(
-        ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href]"
-      );
-      var seen = {};
-      var slugs = [];
-      links.forEach(function (link) {
-        var href = link.getAttribute("href");
-        if (!href || href.charAt(0) === "#") {
-          return;
-        }
-        var path = href.replace(/[?#].*$/, "").replace(/\/+$/, "");
-        var slug = (path.split("/").filter(Boolean).pop() || "").toLowerCase();
-        if (!slug || seen[slug]) {
-          return;
-        }
-        seen[slug] = true;
-        slugs.push(slug);
+    // Full path segments for an internal href, lang prefix stripped (like
+    // hrefToCwd but keeping every segment). Only root-relative "/..." links
+    // count — that cleanly drops mailto:, tel:, external, and hash links.
+    function terminalHrefSegments(href) {
+      var raw = String(href || "");
+      if (raw.charAt(0) !== "/") {
+        return null;
+      }
+      var path = raw.replace(/[?#].*$/, "").replace(/^\/+|\/+$/g, "");
+      var lang = (
+        document.documentElement.getAttribute("lang") || ""
+      ).toLowerCase();
+      var parts = path.split("/").filter(Boolean);
+      if (parts.length && parts[0].toLowerCase() === lang) {
+        parts.shift();
+      }
+      return parts.map(function (p) {
+        return p.toLowerCase();
       });
-      return slugs;
     }
 
-    function terminalLsLines() {
-      var slugs = terminalPageSlugs();
-      if (!slugs.length) {
-        return ["(empty)"];
+    // A small nested directory tree built from every nav + footer link path,
+    // so `ls`, `tree`, `cd` and Tab completion share one data-driven model of
+    // the "filesystem". Cached like terminalNavTargets — the links are static.
+    var terminalDirTreeCache = null;
+    function terminalDirTree() {
+      if (terminalDirTreeCache) {
+        return terminalDirTreeCache;
       }
+      var root = { name: "~", href: terminalHomeUrl(), children: {} };
+      var links = document.querySelectorAll(
+        ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href], footer a[href]"
+      );
+      links.forEach(function (link) {
+        var segs = terminalHrefSegments(link.getAttribute("href"));
+        if (!segs || !segs.length) {
+          return;
+        }
+        var node = root;
+        segs.forEach(function (seg) {
+          if (!node.children[seg]) {
+            node.children[seg] = { name: seg, href: null, children: {} };
+          }
+          node = node.children[seg];
+        });
+        if (!node.href) {
+          node.href = link.getAttribute("href");
+        }
+      });
+      terminalDirTreeCache = root;
+      return root;
+    }
+
+    // The current working directory as lowercased path segments ("~" → []).
+    function terminalCwdSegments() {
+      var rest = currentTerminalCwd().replace(/^~\/?/, "");
+      return rest
+        ? rest
+            .split("/")
+            .filter(Boolean)
+            .map(function (s) {
+              return s.toLowerCase();
+            })
+        : [];
+    }
+
+    // Resolve a path argument to absolute segments, relative to the cwd unless
+    // it starts with "~" or "/". Supports "." and "..".
+    function terminalResolveSegments(pathArg) {
+      var arg = String(pathArg || "").trim();
+      var segs;
+      if (arg.charAt(0) === "~" || arg.charAt(0) === "/") {
+        segs = [];
+        arg = arg.replace(/^~/, "").replace(/^\/+/, "");
+      } else {
+        segs = terminalCwdSegments();
+      }
+      arg
+        .split("/")
+        .filter(Boolean)
+        .forEach(function (part) {
+          var p = part.toLowerCase();
+          if (p === ".") {
+            return;
+          }
+          if (p === "..") {
+            segs.pop();
+            return;
+          }
+          segs.push(p);
+        });
+      return segs;
+    }
+
+    function terminalNodeAt(segments) {
+      var node = terminalDirTree();
+      for (var i = 0; i < segments.length; i++) {
+        node = node.children[segments[i]];
+        if (!node) {
+          return null;
+        }
+      }
+      return node;
+    }
+
+    // Slugs of the current page's own content links (article / summary cards)
+    // that live under the given section — so `ls` inside e.g. ~/writing lists
+    // the actual posts, which the nav tree can't know about.
+    function terminalPageContentSlugs(sectionSegments) {
+      if (!sectionSegments.length) {
+        return [];
+      }
+      var section = sectionSegments[0];
+      var out = [];
+      var seen = {};
+      document
+        .querySelectorAll(".article-card a[href], .summary-card a[href]")
+        .forEach(function (link) {
+          var segs = terminalHrefSegments(link.getAttribute("href"));
+          if (!segs || segs.length < 2 || segs[0] !== section) {
+            return;
+          }
+          var slug = segs[segs.length - 1];
+          if (seen[slug]) {
+            return;
+          }
+          seen[slug] = true;
+          out.push(slug);
+        });
+      return out;
+    }
+
+    // `ls [path]`: list a directory's children. Structural children come from
+    // the nav/footer tree; for the current directory, the page's own content
+    // links are merged in. Unknown path → an ls-style error.
+    function terminalLsLines(pathArg, showHidden) {
+      var targetSegs = terminalResolveSegments(pathArg);
+      var node = terminalNodeAt(targetSegs);
+      if (!node) {
+        return [
+          "ls: cannot access '" + pathArg + "': No such file or directory",
+        ];
+      }
+      var entries = Object.keys(node.children)
+        .sort()
+        .map(function (k) {
+          return node.children[k].name + "/";
+        });
+      if (targetSegs.join("/") === terminalCwdSegments().join("/")) {
+        terminalPageContentSlugs(targetSegs).forEach(function (slug) {
+          var entry = slug + "/";
+          if (entries.indexOf(entry) === -1) {
+            entries.push(entry);
+          }
+        });
+      }
+      if (showHidden) {
+        entries = [".secret", ".config"].concat(entries);
+      }
+      if (!entries.length) {
+        return []; // empty directory — real `ls` prints nothing
+      }
+      var MAX = 40;
+      var lines = [entries.slice(0, MAX).join("  ")];
+      if (entries.length > MAX) {
+        lines.push("… (" + (entries.length - MAX) + " more)");
+      }
+      return lines;
+    }
+
+    // Whole-tree view for `tree`, drawn with ├──/└── connectors.
+    function terminalTreeLines() {
+      var root = terminalDirTree();
+      var lines = ["~"];
+      function walk(node, prefix) {
+        var keys = Object.keys(node.children).sort();
+        keys.forEach(function (key, i) {
+          var last = i === keys.length - 1;
+          lines.push(
+            prefix + (last ? "└── " : "├── ") + node.children[key].name + "/"
+          );
+          walk(node.children[key], prefix + (last ? "    " : "│   "));
+        });
+      }
+      walk(root, "");
+      return lines;
+    }
+
+    // Contact links harvested from the footer (mailto + LinkedIn), so the
+    // `social`/`email`/`copy email` commands always match the real footer and
+    // the current language.
+    function terminalContactLinks() {
+      var out = [];
+      document
+        .querySelectorAll(".footer-contact a[href]")
+        .forEach(function (link) {
+          var href = link.getAttribute("href");
+          if (!href) {
+            return;
+          }
+          var kind =
+            href.indexOf("mailto:") === 0
+              ? "email"
+              : /linkedin/i.test(href)
+              ? "linkedin"
+              : "link";
+          out.push({ kind: kind, href: href });
+        });
+      return out;
+    }
+
+    // A speech bubble + cow for `cowsay`, text clamped to the phone width.
+    function terminalCowsay(text) {
+      var msg = String(text || "").trim() || "moo";
+      if (msg.length > 30) {
+        msg = msg.slice(0, 29) + "…";
+      }
+      var bar = new Array(msg.length + 3).join("-");
       return [
-        slugs
-          .map(function (slug) {
-            return slug + "/";
-          })
-          .join("  "),
+        " " + bar,
+        "< " + msg + " >",
+        " " + bar,
+        "        \\   ^__^",
+        "         \\  (oo)\\_______",
+        "            (__)\\       )\\/\\",
+        "                ||----w |",
+        "                ||     ||",
       ];
     }
 
@@ -2839,6 +3119,9 @@
             action: { type: "art" },
           };
         case "sudo":
+          if (args.join(" ").toLowerCase() === "make me a sandwich") {
+            return { echo: input, lines: ["okay. 🥪"], action: null };
+          }
           return {
             echo: input,
             lines: [
@@ -2862,6 +3145,13 @@
               action: null,
             };
           }
+          if (args.join(" ").toLowerCase() === "me a sandwich") {
+            return {
+              echo: input,
+              lines: ["what? make it yourself."],
+              action: null,
+            };
+          }
           return {
             echo: input,
             lines: [
@@ -2870,8 +3160,22 @@
             action: null,
           };
         case "ls":
-        case "dir":
-          return { echo: input, lines: terminalLsLines(), action: null };
+        case "dir": {
+          var lsShowHidden = args.some(function (a) {
+            return a.charAt(0) === "-" && /a/.test(a);
+          });
+          var lsPath =
+            args.filter(function (a) {
+              return a.charAt(0) !== "-";
+            })[0] || "";
+          return {
+            echo: input,
+            lines: terminalLsLines(lsPath, lsShowHidden),
+            action: null,
+          };
+        }
+        case "tree":
+          return { echo: input, lines: terminalTreeLines(), action: null };
         case "cat": {
           if (!args.length) {
             return {
@@ -3086,6 +3390,241 @@
             lines: ["konami: party mode 🌈"],
             action: { type: "konami" },
           };
+        // ---- Group A: visitor utilities ----------------------------------
+        case "hire":
+          return {
+            echo: input,
+            lines: ["let's build something. starting a message…"],
+            action: { type: "flow", flow: "contact" },
+          };
+        case "social":
+        case "links": {
+          var contacts = terminalContactLinks();
+          if (!contacts.length) {
+            return {
+              echo: input,
+              lines: ["no links here — try 'contact'"],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: contacts.map(function (c) {
+              return c.kind + ": " + c.href.replace(/^mailto:/, "");
+            }),
+            action: null,
+          };
+        }
+        case "email": {
+          var mail = terminalContactLinks().filter(function (c) {
+            return c.kind === "email";
+          })[0];
+          return {
+            echo: input,
+            lines: [
+              mail
+                ? mail.href.replace(/^mailto:/, "")
+                : "no email on file — try 'contact'",
+            ],
+            action: null,
+          };
+        }
+        case "resume":
+        case "cv": {
+          var aboutUrl = resolveCdTarget("about");
+          if (!aboutUrl) {
+            return {
+              echo: input,
+              lines: ["resume: about page not found"],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: ["opening about → CV…"],
+            action: { type: "navigate", url: aboutUrl },
+          };
+        }
+        // ---- Group B: builder tools --------------------------------------
+        case "layout":
+        case "theme": {
+          var wantedLayout = (args[0] || "").toLowerCase();
+          var nowLayout =
+            document.documentElement.getAttribute("data-layout") || "column";
+          if (!wantedLayout) {
+            return {
+              echo: input,
+              lines: [
+                "layout: " + nowLayout,
+                "available: " + TERMINAL_LAYOUTS.join(", "),
+              ],
+              action: null,
+            };
+          }
+          if (TERMINAL_LAYOUTS.indexOf(wantedLayout) === -1) {
+            return {
+              echo: input,
+              lines: [
+                "layout: unknown '" +
+                  wantedLayout +
+                  "' — try: " +
+                  TERMINAL_LAYOUTS.join(", "),
+              ],
+              action: null,
+            };
+          }
+          if (wantedLayout === nowLayout) {
+            return {
+              echo: input,
+              lines: ["layout: already " + wantedLayout],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: ["layout → " + wantedLayout],
+            action: { type: "layout", layout: wantedLayout },
+          };
+        }
+        case "debug":
+        case "env": {
+          var root = document.documentElement;
+          var effectState = function (attr) {
+            return root.getAttribute(attr) === "on" ? "on" : "off";
+          };
+          return {
+            echo: input,
+            lines: [
+              "mode       " +
+                (localStorage.getItem("theme-mode") || "system") +
+                " (" +
+                resolvedModeLabel() +
+                ")",
+              "palette    " + paletteLabel(),
+              "layout     " + (root.getAttribute("data-layout") || "column"),
+              "typography " +
+                (localStorage.getItem("theme-typography") || "editorial"),
+              "grain      " + effectState("data-effect-grain"),
+              "blend      " + effectState("data-effect-blend"),
+              "motion     " +
+                (effectState("data-effect-reduced-motion") === "on"
+                  ? "reduced"
+                  : "full"),
+              "lang       " + currentLang(),
+              "pantone    " + getCurrentCotyYear(),
+            ],
+            action: null,
+          };
+        }
+        case "reset":
+          return {
+            echo: input,
+            lines: ["reset: theme restored to defaults"],
+            action: { type: "reset" },
+          };
+        case "copy": {
+          var copyWhat = (args[0] || "").toLowerCase();
+          var copyText = "";
+          if (copyWhat === "email") {
+            var copyMail = terminalContactLinks().filter(function (c) {
+              return c.kind === "email";
+            })[0];
+            copyText = copyMail ? copyMail.href.replace(/^mailto:/, "") : "";
+          } else if (copyWhat === "url" || copyWhat === "link") {
+            copyText = (window.location && window.location.href) || "";
+          } else if (copyWhat) {
+            copyText = rest;
+          } else {
+            copyText = lastTerminalOutput || "";
+          }
+          if (!copyText) {
+            return {
+              echo: input,
+              lines: ["copy: nothing to copy — try 'copy email' or 'copy url'"],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: [
+              "copied: " +
+                (copyText.length > 30 ? copyText.slice(0, 29) + "…" : copyText),
+            ],
+            action: { type: "copy", text: copyText },
+          };
+        }
+        // ---- Group C: classic unix eggs ----------------------------------
+        case "sl":
+          return {
+            echo: input,
+            lines: [
+              "        _____      . . .",
+              "   ____/ tor \\_______________",
+              "  |___________________________|",
+              "   (O)   (O)   (O)   (O)   (O) ",
+              "  choo choo — you typed ls wrong",
+            ],
+            action: null,
+          };
+        case "xyzzy":
+          return { echo: input, lines: ["Nothing happens."], action: null };
+        case "42":
+        case "answer":
+          return {
+            echo: input,
+            lines: ["the answer to life, the universe & everything: 42"],
+            action: null,
+          };
+        case "moo":
+          return {
+            echo: input,
+            lines: [
+              "         (__)",
+              "         (oo)",
+              "   /------\\/ ",
+              "  / |    ||  ",
+              " *  /\\---/\\  ",
+              "    ~~   ~~  ",
+              "…has this terminal mooed today?",
+            ],
+            action: null,
+          };
+        case "ping": {
+          var pingHost = args[0] || terminalHost();
+          return {
+            echo: input,
+            lines: [
+              "PING " + pingHost + " — pong 🏓",
+              "1 packet transmitted, 1 received, 0.42 ms",
+            ],
+            action: null,
+          };
+        }
+        // ---- Group D: design / ASCII eggs --------------------------------
+        case "cowsay":
+          return { echo: input, lines: terminalCowsay(rest), action: null };
+        case "logo":
+        case "ascii": {
+          var logoLines = terminalArtLines();
+          return {
+            echo: input,
+            lines: logoLines.length ? logoLines : ["(no logo art here)"],
+            action: null,
+          };
+        }
+        case "weather": {
+          var weatherLoc = rest || "Göteborg";
+          return {
+            echo: input,
+            lines: [
+              weatherLoc + ": ⛅ +17°C, light breeze",
+              "(source: vibes, not a real API)",
+            ],
+            action: null,
+          };
+        }
+        case "matrix":
+          return { echo: input, lines: [], action: { type: "matrix" } };
         case "easteregg":
         case "eastereggs":
           return {
@@ -3134,6 +3673,49 @@
       switch (action.type) {
         case "konami":
           toggleKonami();
+          break;
+        case "layout":
+          // Leaving the terminal for another layout wipes the scrollback so it
+          // doesn't leak into the destination (same as exitTerminal).
+          if (
+            action.layout &&
+            action.layout !== "terminal" &&
+            isTerminalLayout() &&
+            terminalSession
+          ) {
+            terminalSession.textContent = "";
+          }
+          setLayout(action.layout);
+          break;
+        case "reset":
+          if (
+            typeof isPantoneModeActive === "function" &&
+            isPantoneModeActive()
+          ) {
+            stopPantone();
+          }
+          setMode("system");
+          commitPaletteSelection("standard", { toast: false });
+          setTypography("editorial");
+          setGrainEnabled(false, { silent: true });
+          setBlendEnabled(false, { silent: true });
+          setReducedMotionEnabled(false, { silent: true });
+          break;
+        case "copy":
+          try {
+            if (
+              window.navigator &&
+              window.navigator.clipboard &&
+              typeof window.navigator.clipboard.writeText === "function"
+            ) {
+              window.navigator.clipboard.writeText(action.text);
+            }
+          } catch (err) {
+            /* clipboard unavailable — the confirmation line already printed */
+          }
+          break;
+        case "matrix":
+          runTerminalMatrix();
           break;
         case "exit":
           exitTerminal();
@@ -3256,11 +3838,53 @@
       line.className = "terminal-session__line " + className;
       line.textContent = text;
       terminalSession.appendChild(line);
+      // Remember the last *output* row, so `copy` with no argument grabs it.
+      if (className.indexOf("terminal-session__out") !== -1) {
+        lastTerminalOutput = text;
+      }
+    }
+
+    // A short, bounded "digital rain" burst for `matrix` — a few deferred
+    // frames of random glyph rows, then it stops. No persistent interval, so
+    // nothing outlives the terminal or fights reduced motion.
+    function runTerminalMatrix() {
+      var GLYPHS = "01ﾊﾋﾎｱｲｳｴｵｶｷｸ日ﾘｦ";
+      var FRAMES = 3;
+      var step = 0;
+      function row() {
+        var s = "";
+        for (var i = 0; i < 30; i++) {
+          s += GLYPHS.charAt(Math.floor(Math.random() * GLYPHS.length));
+        }
+        return s;
+      }
+      function frame() {
+        if (!isTerminalLayout()) {
+          return;
+        }
+        for (var r = 0; r < 4; r++) {
+          printTerminalLine(row(), "terminal-session__out");
+        }
+        scrollTerminalToEnd();
+        step += 1;
+        if (step < FRAMES) {
+          window.setTimeout(frame, 220);
+        } else {
+          window.setTimeout(function () {
+            if (isTerminalLayout()) {
+              printTerminalLine("wake up… 🟢", "terminal-session__out");
+              scrollTerminalToEnd();
+            }
+          }, 220);
+        }
+      }
+      frame();
     }
 
     function runTerminalInput(raw) {
       // Record the command before running it, so `history` includes itself —
-      // matching a real shell.
+      // matching a real shell. Reset the ↑/↓ recall cursor to the live line.
+      terminalHistoryCursor = null;
       var trimmed = String(raw === null || raw === undefined ? "" : raw).trim();
       if (trimmed) {
         terminalHistory.push(trimmed);
@@ -3588,10 +4212,120 @@
       }
     }
 
+    // ↑/↓ history recall: walk terminalHistory, oldest→newest, restoring an
+    // empty line past the newest entry. `dir` is -1 for ↑ (older), +1 for ↓.
+    function terminalRecallHistory(dir) {
+      if (!terminalInput || !terminalHistory.length) {
+        return;
+      }
+      if (terminalHistoryCursor === null) {
+        terminalHistoryCursor = terminalHistory.length;
+      }
+      terminalHistoryCursor = Math.max(
+        0,
+        Math.min(terminalHistory.length, terminalHistoryCursor + dir)
+      );
+      terminalInput.value = terminalHistory[terminalHistoryCursor] || "";
+      syncTerminalInputSize();
+      var end = terminalInput.value.length;
+      try {
+        terminalInput.setSelectionRange(end, end);
+      } catch (err) {
+        /* selection API unavailable — value is still set */
+      }
+    }
+
+    // Tab completion: complete the command word, or a cd/ls/open path fragment
+    // against the current directory's children. Single match fills; multiple
+    // print the candidates.
+    function terminalCompleteInput() {
+      if (!terminalInput) {
+        return;
+      }
+      var value = terminalInput.value;
+      var parts = value.split(/\s+/);
+      var candidates;
+      var frag;
+      if (parts.length <= 1) {
+        frag = (parts[0] || "").toLowerCase();
+        candidates = TERMINAL_COMMAND_NAMES.filter(function (name) {
+          return name.indexOf(frag) === 0;
+        });
+      } else {
+        var verb = parts[0].toLowerCase();
+        if (verb !== "cd" && verb !== "ls" && verb !== "open") {
+          return;
+        }
+        frag = (parts[parts.length - 1] || "").toLowerCase();
+        var node = terminalNodeAt(terminalCwdSegments());
+        candidates = node
+          ? Object.keys(node.children).filter(function (name) {
+              return name.indexOf(frag) === 0;
+            })
+          : [];
+      }
+      if (candidates.length === 1) {
+        parts[parts.length - 1] = candidates[0];
+        terminalInput.value = parts.join(" ") + (parts.length === 1 ? " " : "");
+        syncTerminalInputSize();
+      } else if (candidates.length > 1) {
+        printTerminalLine(candidates.join("  "), "terminal-session__out");
+        scrollTerminalToEnd();
+      }
+    }
+
     if (terminalInput) {
-      terminalInput.addEventListener("input", syncTerminalInputSize);
+      // Typing invalidates the history-recall position.
+      terminalInput.addEventListener("input", function () {
+        terminalHistoryCursor = null;
+        syncTerminalInputSize();
+      });
       terminalInput.addEventListener("keydown", function (e) {
         advanceKonami(e);
+        // Ctrl shortcuts: ^L clear screen, ^U clear line, ^C cancel line.
+        if (e.ctrlKey && !e.altKey && !e.metaKey) {
+          var ctrlKey = (e.key || "").toLowerCase();
+          if (ctrlKey === "l") {
+            e.preventDefault();
+            if (terminalSession) {
+              terminalSession.textContent = "";
+            }
+            return;
+          }
+          if (ctrlKey === "u") {
+            e.preventDefault();
+            terminalInput.value = "";
+            terminalHistoryCursor = null;
+            syncTerminalInputSize();
+            return;
+          }
+          if (ctrlKey === "c") {
+            e.preventDefault();
+            printTerminalLine("^C", "terminal-session__out");
+            if (terminalFlow) {
+              endTerminalFlow();
+            }
+            terminalInput.value = "";
+            terminalHistoryCursor = null;
+            syncTerminalInputSize();
+            scrollTerminalToEnd();
+            return;
+          }
+        }
+        if (e.key === "Tab") {
+          e.preventDefault();
+          if (!terminalFlow) {
+            terminalCompleteInput();
+          }
+          return;
+        }
+        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+          if (!terminalFlow && terminalHistory.length) {
+            e.preventDefault();
+            terminalRecallHistory(e.key === "ArrowUp" ? -1 : 1);
+          }
+          return;
+        }
         if (e.key === "Enter") {
           e.preventDefault();
           var value = terminalInput.value;

--- a/docs/features/terminal-followups-plan.md
+++ b/docs/features/terminal-followups-plan.md
@@ -1,0 +1,155 @@
+# Terminal follow-ups — plan
+
+> **Status:** working draft, source of truth for two deferred terminal features.
+> Both are their own PR. Built on top of the terminal command engine in
+> `assets/js/darkmode.js` (rounds 4–5, PR #226). Edit freely — decisions live
+> here, not in chat.
+
+Two follow-ups, in priority order:
+
+1. **Mobile key bar** — make the round-4 keyboard fundamentals reachable on iOS.
+2. **Terminal in-place navigation** — let a typed `cd` change page without a full
+   reload, keeping the scrollback alive.
+
+---
+
+## 1. Mobile key bar (accessory row)
+
+### Why
+
+The round-4 fundamentals (↑/↓ history recall, Tab completion) rely on keys the
+**default iOS keyboard doesn't have** — so on mobile, the primary context,
+they're unreachable. Standard fix in web/mobile terminals (Termux, Blink, iSH):
+a small on-screen accessory row of keys pinned above the keyboard.
+
+### Design
+
+- A compact toolbar shown **only in terminal layout while the prompt is
+  focused**, pinned just above the on-screen keyboard.
+- Buttons map to the handlers already built in `darkmode.js`:
+  - `↑` / `↓` → `terminalRecallHistory(-1 | +1)`
+  - `Tab` → `terminalCompleteInput()`
+  - `^C` → cancel the current line
+  - `⌄` → scroll to the prompt (folds in the separately-parked scroll idea)
+- iOS specifics:
+  - Position with the **`visualViewport` API** so it tracks the keyboard
+    open/close — plain `position: fixed` mis-places on iOS Safari.
+  - Buttons must **not steal focus** — `preventDefault` on `pointerdown` so the
+    keyboard stays up.
+  - Hidden on desktop (real keys exist), or shown harmlessly.
+- Progressive enhancement: no bar → the commands still work, there's just no
+  recall/completion on mobile (as today).
+
+### Files
+
+- Terminal chrome markup: `layouts/partials/footer.html` (near `.terminal-tail`)
+  or a small new partial.
+- `assets/css/dimensions/layout/terminal.css` for the bar styling.
+- `assets/js/darkmode.js` to wire buttons to the existing handlers + a
+  `visualViewport` listener.
+
+---
+
+## 2. Terminal in-place navigation (SPA-style, typed-only)
+
+### Goal
+
+Today a nav click / typed `cd` does a **full page reload**; the destination
+reprints the stashed `cd` as scrollback (`stashTerminalCd` /
+`printPendingTerminalCd` in `darkmode.js`). Deliberate: simple, robust, good for
+non-technical visitors. Add a second mode: let the **prompt** navigate without
+reloading, so the scrollback survives a `cd` — closer to a real shell (a `cd`
+doesn't reboot the machine).
+
+### Decided design (owner)
+
+**Two modes, split by input type** — this scopes the change tightly and leaves
+the common path untouched:
+
+- **Clicks stay exactly as today.** Nav-link and in-content link clicks keep the
+  current behavior: full reload + `stashTerminalCd` + `printPendingTerminalCd`
+  (the top cd-echo). The gentle mode for the visitor who just clicks around —
+  **untouched, battle-tested, zero risk.** So `printPendingTerminalCd` and the
+  sessionStorage stash are **kept**, not retired.
+- **Typed commands get the new in-place nav.** Only the command-engine
+  `navigate` action (typed `cd`, `resume`, home, …) changes: navigation becomes
+  **just another command** — print the echo at the **bottom prompt** exactly
+  like `ls`/`cat`/`neofetch` already do (reuse `printTerminalLine` → scrollback →
+  `scrollTerminalToEnd`; the viewport stays at the prompt), then `fetch` the URL,
+  swap `#main`, patch the head fields + `--terminal-cwd`, and `pushState`. No
+  reload, no top-injection, no `scrollTo(0,0)`.
+
+Because only the typed path changes, a bug there never reaches ordinary
+click-through visitors. Trade-off noted and accepted: a terminal user who
+_sometimes clicks, sometimes types_ sees the `cd` echo land in different spots
+(click → top after reload; typed → bottom) — which mirrors "mouse way vs shell
+way," so it reads as logical rather than confusing.
+
+**Fallbacks — the typed path still full-reloads for:** terminal-exempt / special
+pages (home, contact, ui-library, palette-generator — per-page CSS/JS bundles +
+inline JSON data islands), **language switches** (`lang` changes i18n site-wide,
+not just `#main`), cross-origin targets, and any `fetch`/parse failure
+(progressive enhancement — links keep working).
+
+### Why it's feasible (research findings)
+
+- **DOM is ideal.** No `baseof.html`; the shell is a partial sandwich —
+  `header.html` opens `<body><div id="layout">` + `#topmenu` + `<main id="main">`,
+  `footer.html` closes `</main>` then renders `<footer>` with `.terminal-session`
+  (scrollback) and `.terminal-tail`/`#terminal-input`. **All terminal chrome is
+  OUTSIDE `<main>`** (nav/boot/prompt above, session/input below). The only
+  per-page DOM is a single `div.content` inside `#main`. **`#main` is a clean,
+  stable swap target** — scrollback, prompt and nav stay untouched.
+- **CSS needs nothing on a swap.** One global fingerprinted bundle contains every
+  layout incl. `terminal.css`; layout is pure `data-layout` CSS. Ordinary
+  content/list/single pages need no new CSS when `#main` swaps.
+- **Hand-roll, don't add a library.** No router exists (greenfield); scripts are
+  plain IIFEs concatenated by Hugo (no JS module bundler wired in), and there's
+  prior `history.pushState` use in `smooth-scroll.js`. Swup/Turbo would need a
+  bundler step or a vendored UMD build — awkward, and wouldn't cut the real cost.
+- **The real cost is re-init, not routing.** Page init lives in
+  `DOMContentLoaded`/IIFE closures with no external init seam (only
+  `CotyScaleActions.init` is callable + idempotent).
+  - **Must re-run on a swap (content-dependent):** `reveal-on-scroll.js` (else
+    new content stays invisible — important), `lightbox.js`
+    `makeFiguresFocusable()` for new `figure[data-lightbox]`, `darkmode.js` cd
+    echo, `role-swapper.js` (home only), `CotyScaleActions.init()` (cheap).
+  - **Must NOT re-run (double-binding hazards):** the whole `darkmode.js`
+    DOMContentLoaded (duplicate `document` click/keydown incl. the nav handler,
+    re-set `window.ThemeActions`), `settings-dropdown.js`, `theme-share.js`,
+    `lightbox.js` overlay creation, `progressbar.js` window listeners.
+  - So the work is: **refactor the content-dependent init out of those closures
+    into named, idempotent functions**, and keep document/window binders
+    bind-once.
+- **Head/meta to patch from the fetched document:** `<title>`, meta description,
+  og/twitter tags, canonical, hreflang set, robots, and the inline
+  `:root { --terminal-cwd }` block (`head.html:~537`). Without patching
+  `--terminal-cwd`, the prompt shows the wrong working directory.
+
+### Build shape (own PR)
+
+1. Refactor content-dependent init (reveal, lightbox focusability, cd echo,
+   optional role-swapper/coty) into named idempotent `initX()` functions; ensure
+   document/window binders are bind-once.
+2. A small IIFE (`assets/js/terminal-nav.js`, ~150–250 lines) that the `navigate`
+   action calls **only in terminal layout & non-exempt targets**: print the
+   bottom echo, `fetch` the URL, swap `#main`, patch head + `--terminal-cwd`,
+   `pushState` (+ `popstate` handler), then call the init functions. Fall back to
+   `location.assign` for the fallback cases above.
+3. Optional polish: wrap the swap in `document.startViewTransition` for a
+   cross-fade.
+
+### Synergy bonus
+
+With a swap, `cd writing` updates `--terminal-cwd` and the new page's cards are
+in the DOM, so the round-4 `ls` content-harvest "just works" right after `cd`.
+
+### Verification (when built)
+
+- Jest: unit-test the swap orchestrator's URL/skip logic and the head/cwd patcher
+  against fetched-HTML fixtures; keep the existing nav/`cd` tests green.
+- Browser (Playwright, Chromium preinstalled): in terminal layout, typed
+  `cd writing` → URL + `--terminal-cwd` + prompt update, scrollback persists,
+  `ls` lists the new page's posts; back button restores; a click still
+  full-reloads as today; a `data-terminal-exempt` page full-reloads; JS-off links
+  still navigate.


### PR DESCRIPTION
Extends the terminal command engine with a set of hidden/utility commands that build on the existing unix metaphor (`cd`/`pwd`/`neofetch`) and the existing easter eggs (`sudo`, `coffee`, `whoami`).

## New commands

**Utility (fit the filesystem metaphor):**
- `ls` / `dir` — list the nav pages as directories (also added to `help`)
- `cat <file>` — `readme` / `about` / `colophon` / `secret` pseudo-files (strips a leading dot and `.txt`/`.md`)
- `man <cmd>` — one-line help pulled from the help table, so the two never drift
- `uname` / `uname -a` — shell / session summary
- `colour` / `color` — the active palette's resolved swatches
- `history` — command scrollback (includes itself, capped at 100)
- `uptime` — session age since the prompt booted

**Jokes:**
- `top` / `htop` — tongue-in-cheek process list
- `vim` / `vi` / `nano` / `emacs`, and `:q` / `:wq` / `:x` — editor jokes (the vim-quit variants leave the terminal)
- `rm -rf /` — "it's all in git" refusal
- `git blame|commit|push|pull|status|log` — answers in character
- `npm` / `yarn` / `pnpm install` — fake dependency resolve
- `hello` / `hi` / `hey` — greeting
- `fortune` — random design & typography aphorism
- `konami` — party mode, also triggered by the arrow-key Konami code (↑↑↓↓←→←→ B A) at the prompt

## Implementation notes
- Party mode sets `data-konami` on the root; `terminal.css` hangs a motion-gated hue-cycle off it, falling back to a static tint under `prefers-reduced-motion` and the site's own `motion off` toggle.
- `runTerminalCommand()` stays free of DOM mutation — new state (history, session start, Konami progress) lives at module scope, matching the existing structure. Side effects stay in `applyTerminalAction()` / the input handler.
- The Konami key sequence is tracked non-destructively in the prompt's keydown handler and tidies the stray `b`/`a` on completion.

## Testing
- 18 new tests in `terminal-commands.test.js` cover every new command, including the arrow-key sequence.
- Full suite green (518 passing), ESLint and Prettier clean, pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gasg2HLcsdryKih3NSoWg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gasg2HLcsdryKih3NSoWg2)_