### PR TITLE
Terminal: mobile key bar for keyboard fundamentals

### DIFF
--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1333,6 +1333,70 @@
   margin-top: var(--spacing-8);
 }
 
+/* ============================================================================
+   Mobile key bar (accessory row)
+   The round-4 keyboard fundamentals (↑/↓ history recall, Tab completion, ^C)
+   ride keys the on-screen keyboard lacks, plus a ⌄ jump-to-prompt. This bar
+   surfaces them just above the keyboard while the prompt is focused. It's a
+   coarse-pointer affordance only — desktop has the real keys, so the bar stays
+   display:none there. darkmode.js toggles .is-visible on focus and translates
+   the bar up over the keyboard via the visualViewport API (plain fixed sits
+   behind it on iOS Safari); the fixed bottom anchor here is the base it starts
+   from. The keys read as bracketed mono words, matching the terminal's chrome.
+   ============================================================================ */
+
+.terminal-keybar {
+  display: none;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  :root[data-layout="terminal"] .terminal-keybar.is-visible {
+    display: flex;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 60;
+    gap: var(--spacing-4);
+    padding: var(--spacing-4) var(--size-page-margins);
+    background: var(--surface-page);
+    border-top: 1px solid var(--border-subtle);
+    /* darkmode.js sets translateY to clear the keyboard; hint the compositor. */
+    will-change: transform;
+  }
+}
+
+:root[data-layout="terminal"] .terminal-keybar__key {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 2.75em;
+  padding: 0 var(--spacing-8);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  font-family: var(--font-mono);
+  font-size: var(--terminal-font-size);
+  line-height: 1;
+  color: var(--text-link, var(--text-default));
+  cursor: pointer;
+  /* No tap flash / double-tap zoom — this is a key, not a link. */
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+/* Bracketed like every other actionable word in the buffer. */
+:root[data-layout="terminal"] .terminal-keybar__key::before {
+  content: "[";
+}
+
+:root[data-layout="terminal"] .terminal-keybar__key::after {
+  content: "]";
+}
+
+:root[data-layout="terminal"] .terminal-keybar__key:active {
+  color: var(--text-accent, currentColor);
+}
+
 /* Party mode — the Konami code (or `konami`) sets data-konami, and the whole
    terminal cycles hue. Motion-gated: reduced-motion visitors get a single
    colourful tint instead of the animation. */

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -132,6 +132,13 @@ describe("terminal command line", () => {
           ><span class="terminal-tail__caret"></span
           ><input id="terminal-input" class="terminal-tail__input" data-js="terminal-input" type="text" size="1" />
         </p>
+        <div class="terminal-keybar" data-js="terminal-keybar">
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="prev" aria-label="Previous command">↑</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="next" aria-label="Next command">↓</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="tab" aria-label="Complete">Tab</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="cancel" aria-label="Cancel line">^C</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="bottom" aria-label="Jump to prompt">⌄</button>
+        </div>
       </body>
     `;
 
@@ -596,6 +603,57 @@ describe("terminal command line", () => {
     keydown({ key: "c", ctrlKey: true });
     expect(input.value).toBe("");
     expect(sessionText()).toContain("^C");
+  });
+
+  function tapKeybar(action) {
+    const button = document.querySelector('[data-keybar="' + action + '"]');
+    button.dispatchEvent(
+      new window.Event("pointerdown", { bubbles: true, cancelable: true })
+    );
+    button.dispatchEvent(new window.Event("click", { bubbles: true }));
+  }
+
+  test("key bar ↑ recalls the previous command (mobile has no arrow keys)", () => {
+    loadModule();
+    typeCommand("whoami");
+    tapKeybar("prev");
+    expect(document.querySelector('[data-js="terminal-input"]').value).toBe(
+      "whoami"
+    );
+  });
+
+  test("key bar Tab completes a command, ^C cancels the line", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "wea";
+    tapKeybar("tab");
+    expect(input.value).toBe("weather ");
+    input.value = "half typed";
+    tapKeybar("cancel");
+    expect(input.value).toBe("");
+    expect(sessionText()).toContain("^C");
+  });
+
+  test("key bar is shown only while the prompt is focused", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    const bar = document.querySelector('[data-js="terminal-keybar"]');
+    expect(bar.classList.contains("is-visible")).toBe(false);
+    input.dispatchEvent(new window.Event("focus"));
+    expect(bar.classList.contains("is-visible")).toBe(true);
+    input.dispatchEvent(new window.Event("blur"));
+    expect(bar.classList.contains("is-visible")).toBe(false);
+  });
+
+  test("key bar pointerdown keeps focus on the input (keyboard stays up)", () => {
+    loadModule();
+    const button = document.querySelector('[data-keybar="prev"]');
+    const event = new window.Event("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    button.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
   });
 
   test("konami command toggles party mode", async () => {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -4301,6 +4301,23 @@
       }
     }
 
+    // ^C: abort the current line — echo the caret marker, end any running flow,
+    // clear the input and the history cursor. Shared by the keydown handler and
+    // the mobile key bar (the on-screen keyboard has no Ctrl key).
+    function terminalCancelLine() {
+      if (!terminalInput) {
+        return;
+      }
+      printTerminalLine("^C", "terminal-session__out");
+      if (terminalFlow) {
+        endTerminalFlow();
+      }
+      terminalInput.value = "";
+      terminalHistoryCursor = null;
+      syncTerminalInputSize();
+      scrollTerminalToEnd();
+    }
+
     if (terminalInput) {
       // Typing invalidates the history-recall position.
       terminalInput.addEventListener("input", function () {
@@ -4328,14 +4345,7 @@
           }
           if (ctrlKey === "c") {
             e.preventDefault();
-            printTerminalLine("^C", "terminal-session__out");
-            if (terminalFlow) {
-              endTerminalFlow();
-            }
-            terminalInput.value = "";
-            terminalHistoryCursor = null;
-            syncTerminalInputSize();
-            scrollTerminalToEnd();
+            terminalCancelLine();
             return;
           }
         }
@@ -4391,6 +4401,91 @@
         }
       });
       syncTerminalInputSize();
+    }
+
+    // ----------------------------------------------------------------------
+    // Mobile key bar (accessory row)
+    // The round-4 keyboard fundamentals — ↑/↓ history recall, Tab completion,
+    // ^C — ride keys the on-screen keyboard doesn't have, so on touch (the
+    // primary context) they're unreachable. This bar surfaces them as tappable
+    // buttons while the prompt is focused, pinned just above the keyboard, plus
+    // a ⌄ jump-to-prompt. Purely additive: with no bar (or no JS) the terminal
+    // works exactly as before, just without recall/completion on mobile.
+    // ----------------------------------------------------------------------
+    var terminalKeybar = document.querySelector('[data-js="terminal-keybar"]');
+    if (terminalKeybar && terminalInput) {
+      // Each button reuses a handler already built above — the bar is only a
+      // touch surface for them, never a second implementation.
+      var KEYBAR_ACTIONS = {
+        prev: function () {
+          terminalRecallHistory(-1);
+        },
+        next: function () {
+          terminalRecallHistory(1);
+        },
+        tab: function () {
+          if (!terminalFlow) {
+            terminalCompleteInput();
+          }
+        },
+        cancel: terminalCancelLine,
+        bottom: scrollTerminalToEnd,
+      };
+
+      // Track the on-screen keyboard: with position:fixed;bottom:0 the bar sits
+      // BEHIND the keyboard on iOS Safari (plain fixed positions against the
+      // layout viewport, which the keyboard doesn't shrink). Translate it up by
+      // the overlap — layout viewport minus the visual viewport — so it rides on
+      // top of the keyboard. No visualViewport API → leave it pinned to the
+      // bottom (still usable, just possibly overlapped).
+      function positionKeybar() {
+        var vv = window.visualViewport;
+        if (!vv) {
+          return;
+        }
+        var overlap = window.innerHeight - vv.height - vv.offsetTop;
+        terminalKeybar.style.transform =
+          "translateY(" + -Math.max(0, overlap) + "px)";
+      }
+
+      // Keep focus on the input: a button that stole focus would close the
+      // keyboard. preventDefault on pointerdown stops the field from blurring,
+      // so the tap runs its action with the keyboard still up (and the bar,
+      // which hides on blur, still on screen to receive the click).
+      terminalKeybar.addEventListener("pointerdown", function (e) {
+        if (e.target.closest("[data-keybar]")) {
+          e.preventDefault();
+        }
+      });
+
+      terminalKeybar.addEventListener("click", function (e) {
+        var button = e.target.closest("[data-keybar]");
+        if (!button) {
+          return;
+        }
+        var action = KEYBAR_ACTIONS[button.getAttribute("data-keybar")];
+        if (action) {
+          action();
+          // Belt-and-braces: keep the keyboard up even if a browser dropped
+          // focus despite the pointerdown guard above.
+          terminalInput.focus();
+        }
+      });
+
+      // Shown only while the prompt is focused; CSS gates it to coarse pointers
+      // so desktop (which has the real keys) never sees it.
+      terminalInput.addEventListener("focus", function () {
+        terminalKeybar.classList.add("is-visible");
+        positionKeybar();
+      });
+      terminalInput.addEventListener("blur", function () {
+        terminalKeybar.classList.remove("is-visible");
+      });
+
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", positionKeybar);
+        window.visualViewport.addEventListener("scroll", positionKeybar);
+      }
     }
 
     // ----------------------------------------------------------------------

--- a/docs/features/terminal-followups-plan.md
+++ b/docs/features/terminal-followups-plan.md
@@ -13,7 +13,14 @@ Two follow-ups, in priority order:
 
 ---
 
-## 1. Mobile key bar (accessory row)
+## 1. Mobile key bar (accessory row) — ✅ shipped
+
+> Built as designed below: a `.terminal-keybar` in `footer.html`, styled in
+> `terminal.css` (coarse-pointer only, bracketed mono keys), wired in
+> `darkmode.js` (buttons reuse the existing handlers; `^C` factored into a
+> shared `terminalCancelLine()`; `visualViewport` tracks the keyboard;
+> `pointerdown` preventDefault keeps focus). Covered by four new Jest tests in
+> `terminal-commands.test.js`.
 
 ### Why
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -456,3 +456,18 @@ other = "type exit or press esc to leave the terminal"
 
 [terminal_input_label]
 other = "Terminal command input — type a command and press Enter (try 'help')"
+
+[terminal_key_prev]
+other = "Previous command"
+
+[terminal_key_next]
+other = "Next command"
+
+[terminal_key_tab]
+other = "Complete"
+
+[terminal_key_cancel]
+other = "Cancel line"
+
+[terminal_key_bottom]
+other = "Jump to prompt"

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -450,3 +450,18 @@ other = "skriv exit eller tryck esc för att lämna terminalen"
 
 [terminal_input_label]
 other = "Terminalens kommandorad — skriv ett kommando och tryck Enter (testa 'help')"
+
+[terminal_key_prev]
+other = "Föregående kommando"
+
+[terminal_key_next]
+other = "Nästa kommando"
+
+[terminal_key_tab]
+other = "Komplettera"
+
+[terminal_key_cancel]
+other = "Avbryt raden"
+
+[terminal_key_bottom]
+other = "Hoppa till prompten"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -187,6 +187,21 @@
         enterkeyhint="go"
       />
     </p>
+    {{/* Mobile key bar: the round-4 keyboard fundamentals (history recall, Tab
+         completion, ^C) ride keys the on-screen keyboard lacks. This accessory
+         row — shown only in terminal layout while the prompt is focused and
+         pinned above the keyboard via the visualViewport API in darkmode.js —
+         surfaces them on touch, plus a ⌄ jump-to-prompt. Buttons carry the
+         glyph for sighted users and an i18n label for assistive tech; the wiring
+         (which preventDefaults so a tap never drops the keyboard) is in
+         darkmode.js. Hidden on desktop via a coarse-pointer media query. */}}
+    <div class="terminal-keybar" data-js="terminal-keybar">
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="prev" aria-label="{{ i18n "terminal_key_prev" }}">↑</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="next" aria-label="{{ i18n "terminal_key_next" }}">↓</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="tab" aria-label="{{ i18n "terminal_key_tab" }}">Tab</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="cancel" aria-label="{{ i18n "terminal_key_cancel" }}">^C</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="bottom" aria-label="{{ i18n "terminal_key_bottom" }}">⌄</button>
+    </div>
   </div>
 </footer>
 <!-- Toast category labels (read by toast.js for title line) -->


### PR DESCRIPTION
The round-4 fundamentals (↑/↓ history recall, Tab completion, ^C) ride
keys the iOS on-screen keyboard doesn't have, so on touch — the primary
context — they were unreachable. Add an accessory row of tappable keys,
pinned above the keyboard while the prompt is focused.

- footer.html: a `.terminal-keybar` of five keys (↑ ↓ Tab ^C ⌄), each
  with a glyph and an i18n aria-label.
- terminal.css: coarse-pointer-only styling; bracketed mono keys matching
  the buffer's chrome; fixed to the viewport bottom as the base the JS
  translates up over the keyboard.
- darkmode.js: buttons reuse the existing handlers (recall/complete/scroll)
  — never a second implementation; `^C` is factored into a shared
  `terminalCancelLine()` used by both the keydown handler and the bar.
  `visualViewport` tracks the keyboard so the bar rides on top of it on
  iOS Safari; `pointerdown` preventDefault keeps focus so a tap never
  drops the keyboard. Purely additive: no bar / no JS → terminal behaves
  exactly as before.
- i18n: five aria-label strings (en + sv).
- Tests: four new cases covering recall, completion, cancel, focus
  visibility, and focus retention.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D4zTzBqNu7qwhF5BhQPPgJ