### PR TITLE
Terminal: in-place navigation for typed cd (SPA-style #main swap)

### DIFF
--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -868,6 +868,24 @@ describe("terminal command line", () => {
     );
   });
 
+  test("cd resolves a content-card post, same as ls lists it", () => {
+    // ls harvests the page's article/summary cards, so cd must reach them too
+    // (else ls lists a post that cd then rejects). The test DOM has an
+    // article-card link to /writing/the-grid-inherited/.
+    loadModule();
+    const before = sessionText();
+    typeCommand("cd writing/the-grid-inherited");
+    expect(sessionText().slice(before.length)).not.toContain(
+      "no such file or directory"
+    );
+
+    // A post that isn't on the page still errors.
+    typeCommand("cd writing/ghost-post");
+    expect(sessionText()).toContain(
+      "no such file or directory: writing/ghost-post"
+    );
+  });
+
   test("subscribe reuses the newsletter form action", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/assets/js/__tests__/terminal-nav.test.js
+++ b/assets/js/__tests__/terminal-nav.test.js
@@ -110,6 +110,24 @@ describe("terminal in-place navigation", () => {
     );
   });
 
+  test("go() drops the boot theater so the swapped #main isn't held at opacity 0", async () => {
+    // The boot animation (.terminal-booting #main { animation: terminal-print
+    // both }) pins a freshly swapped #main at opacity 0 through its delay, so a
+    // swap mid-boot must clear the class and mark the session booted.
+    mockFetch(pageHtml());
+    loadModule();
+    document.documentElement.classList.add("terminal-booting");
+
+    await window.TerminalNav.go("/writing/", { cwd: "~/writing" });
+
+    expect(
+      document.documentElement.classList.contains("terminal-booting")
+    ).toBe(false);
+    expect(document.documentElement.getAttribute("data-terminal-booted")).toBe(
+      "1"
+    );
+  });
+
   test("go() patches SEO meta from the fetched head", async () => {
     mockFetch(pageHtml({ description: "all my posts" }));
     loadModule();

--- a/assets/js/__tests__/terminal-nav.test.js
+++ b/assets/js/__tests__/terminal-nav.test.js
@@ -1,0 +1,207 @@
+/**
+ * Terminal in-place navigation (terminal-nav.js): the typed-cd SPA swap.
+ * Drives window.TerminalNav.go() against fetched-HTML fixtures and asserts the
+ * swap / skip / head-patch / cwd logic. The darkmode.js side (routing a
+ * `navigate` action here vs falling back to a full reload) stays covered by
+ * terminal-commands.test.js.
+ */
+describe("terminal in-place navigation", () => {
+  function loadModule() {
+    jest.isolateModules(() => {
+      require("../terminal-nav.js");
+    });
+  }
+
+  // A fetched HTML document. `opts.exempt` marks it terminal-exempt; `opts.pageCss`
+  // gives it a page-specific stylesheet (the special-page signal); `opts.main`
+  // overrides the #main body; `opts.noMain` drops #main entirely.
+  function pageHtml(opts) {
+    opts = opts || {};
+    var head =
+      "<title>" +
+      (opts.title || "Writing · Site") +
+      "</title>" +
+      '<meta name="description" content="' +
+      (opts.description || "posts") +
+      '">' +
+      '<link rel="canonical" href="https://tor-bjorn.com' +
+      (opts.path || "/writing/") +
+      '">';
+    if (opts.pageCss) {
+      head += '<link rel="stylesheet" href="/css/pages/contact.abc.css">';
+    }
+    var body = opts.noMain
+      ? "<div>no main here</div>"
+      : '<main id="main" tabindex="-1">' +
+        (opts.main ||
+          '<div class="content"><article class="article-card">' +
+            '<a href="/writing/a/">Post A</a></article></div>') +
+        "</main>";
+    return (
+      '<!doctype html><html lang="en"' +
+      (opts.exempt ? ' data-terminal-exempt="true"' : "") +
+      "><head>" +
+      head +
+      "</head><body>" +
+      body +
+      "</body></html>"
+    );
+  }
+
+  function mockFetch(html, resInit) {
+    resInit = resInit || {};
+    window.fetch = jest.fn(function () {
+      if (resInit.reject) {
+        return Promise.reject(new Error("network"));
+      }
+      return Promise.resolve({
+        ok: resInit.ok !== false,
+        redirected: !!resInit.redirected,
+        url: resInit.url || "/writing/",
+        text: function () {
+          return Promise.resolve(html);
+        },
+      });
+    });
+  }
+
+  function cwdVar() {
+    return document.documentElement.style.getPropertyValue("--terminal-cwd");
+  }
+
+  beforeEach(() => {
+    document.documentElement.setAttribute("data-layout", "terminal");
+    document.documentElement.setAttribute("lang", "en");
+    document.documentElement.style.removeProperty("--terminal-cwd");
+    document.documentElement.innerHTML =
+      "<head><title>Home · Site</title>" +
+      '<meta name="description" content="home">' +
+      '<link rel="canonical" href="https://tor-bjorn.com/">' +
+      "</head><body>" +
+      '<main id="main" tabindex="-1"><div class="content">HOME</div></main>' +
+      '<footer><div class="terminal-session"></div>' +
+      '<p class="terminal-tail"><input data-js="terminal-input" /></p></footer>' +
+      "</body>";
+
+    window.scrollTo = jest.fn();
+    window.requestAnimationFrame = jest.fn((cb) => cb());
+    window.TerminalLightbox = { refresh: jest.fn() };
+    // jsdom leaves history at "/"; pushState still records calls we assert on.
+    jest.spyOn(window.history, "pushState");
+  });
+
+  test("go() swaps #main, patches the title + cwd, and pushes state", async () => {
+    mockFetch(pageHtml());
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/writing/", {
+      cwd: "~/writing",
+    });
+
+    expect(swapped).toBe(true);
+    expect(document.querySelector("#main .article-card")).not.toBeNull();
+    expect(document.querySelector("#main").textContent).not.toContain("HOME");
+    expect(document.title).toBe("Writing · Site");
+    expect(cwdVar()).toBe('"~/writing"');
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      { terminalNav: true },
+      "",
+      "/writing/"
+    );
+  });
+
+  test("go() patches SEO meta from the fetched head", async () => {
+    mockFetch(pageHtml({ description: "all my posts" }));
+    loadModule();
+
+    await window.TerminalNav.go("/writing/", { cwd: "~/writing" });
+
+    const desc = document.head.querySelector('meta[name="description"]');
+    expect(desc.getAttribute("content")).toBe("all my posts");
+    const canonical = document.head.querySelector('link[rel="canonical"]');
+    expect(canonical.getAttribute("href")).toBe(
+      "https://tor-bjorn.com/writing/"
+    );
+  });
+
+  test("go() re-runs lightbox figure focusability after the swap", async () => {
+    mockFetch(pageHtml());
+    loadModule();
+
+    await window.TerminalNav.go("/writing/", { cwd: "~/writing" });
+
+    expect(window.TerminalLightbox.refresh).toHaveBeenCalled();
+  });
+
+  test("go() declines a terminal-exempt page (full-reload fallback)", async () => {
+    mockFetch(pageHtml({ exempt: true }));
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/ui-library/", {
+      cwd: "~/ui-library",
+    });
+
+    expect(swapped).toBe(false);
+    expect(document.querySelector("#main").textContent).toContain("HOME");
+    expect(window.history.pushState).not.toHaveBeenCalled();
+  });
+
+  test("go() declines a CSS-bundled special page", async () => {
+    mockFetch(pageHtml({ pageCss: true }));
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/contact/", {
+      cwd: "~/contact",
+    });
+
+    expect(swapped).toBe(false);
+    expect(document.querySelector("#main").textContent).toContain("HOME");
+  });
+
+  test("go() declines a document without #main", async () => {
+    mockFetch(pageHtml({ noMain: true }));
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/weird/", { cwd: "~/weird" });
+
+    expect(swapped).toBe(false);
+    expect(document.querySelector("#main").textContent).toContain("HOME");
+  });
+
+  test("go() falls back on a non-OK response and on a network error", async () => {
+    mockFetch(pageHtml(), { ok: false });
+    loadModule();
+    expect(await window.TerminalNav.go("/writing/", { cwd: "~/writing" })).toBe(
+      false
+    );
+
+    mockFetch(pageHtml(), { reject: true });
+    loadModule();
+    expect(await window.TerminalNav.go("/writing/", { cwd: "~/writing" })).toBe(
+      false
+    );
+  });
+
+  test("go() declines a redirect that leaves the origin", async () => {
+    mockFetch(pageHtml(), {
+      redirected: true,
+      url: "https://evil.example.com/writing/",
+    });
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/writing/", {
+      cwd: "~/writing",
+    });
+
+    expect(swapped).toBe(false);
+  });
+
+  test("go() derives the cwd from the URL when none is passed", async () => {
+    mockFetch(pageHtml({ path: "/works/" }));
+    loadModule();
+
+    await window.TerminalNav.go("/works/");
+
+    expect(cwdVar()).toBe('"~/works"');
+  });
+});

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2853,6 +2853,31 @@
       return map;
     }
 
+    // A typed `cd <post>` should reach the same pages `ls` lists — the content
+    // cards (works/writing posts) the nav tree can't know about. Resolve the
+    // path to absolute segments (relative to cwd), then match a content-card
+    // link by its full segments, so cd and ls agree on what exists.
+    function terminalContentTargetHref(dest) {
+      var wanted = terminalResolveSegments(dest);
+      if (wanted.length < 2) {
+        return null;
+      }
+      var wantedKey = wanted.join("/");
+      var match = null;
+      document
+        .querySelectorAll(".article-card a[href], .summary-card a[href]")
+        .forEach(function (link) {
+          if (match) {
+            return;
+          }
+          var segs = terminalHrefSegments(link.getAttribute("href"));
+          if (segs && segs.join("/") === wantedKey) {
+            match = link.getAttribute("href");
+          }
+        });
+      return match;
+    }
+
     function resolveCdTarget(dest) {
       var key = String(dest || "")
         .replace(/^\/+|\/+$/g, "")
@@ -2864,7 +2889,9 @@
         return terminalHomeUrl();
       }
       var targets = terminalNavTargets();
-      return targets[key] || null;
+      // Nav/footer directories first; then the current page's own content
+      // cards, so `cd` reaches any post `ls` just listed.
+      return targets[key] || terminalContentTargetHref(dest) || null;
     }
 
     // Languages from the settings language selector, keyed by code. The current

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3693,6 +3693,60 @@
       }
     }
 
+    // A typed cd can only swap in place for a same-origin target.
+    function isSameOriginUrl(href) {
+      try {
+        return (
+          new URL(href, window.location.href).origin === window.location.origin
+        );
+      } catch (err) {
+        return false;
+      }
+    }
+
+    // Full-reload navigation — the click-path behaviour: stash the `cd` echo so
+    // the destination prints it above its first prompt, then load. The fallback
+    // for every typed nav that can't (or shouldn't) swap in place.
+    function fullReloadNavigate(action) {
+      if (action.cd !== false) {
+        stashTerminalCd(currentTerminalCwd(), hrefToCwd(action.url));
+      }
+      try {
+        window.location.assign(action.url);
+      } catch (err) {
+        window.location.href = action.url;
+      }
+    }
+
+    // Typed navigation. Clicks still full-reload (see the click handler below);
+    // only typed cd/resume/home reach here. Swap in place when we can — terminal
+    // layout, same-origin, a real directory (home stays a full reload, it's a
+    // CSS-bundled page), not a language switch (cd:false) — and hand off to
+    // terminal-nav.js, which makes the final call after fetching (it declines
+    // special pages it can only detect from the response). If it declines, isn't
+    // present, or nothing qualifies, fall back to a full reload. The command
+    // echo already printed to the scrollback, so an in-place swap needs no extra
+    // output; on fallback the reload wipes it and the stash reprints it on top.
+    function navigateTerminal(action) {
+      var cwd = hrefToCwd(action.url);
+      var canSwap =
+        action.cd !== false &&
+        isTerminalLayout() &&
+        cwd !== "~" &&
+        isSameOriginUrl(action.url) &&
+        window.TerminalNav &&
+        typeof window.TerminalNav.go === "function";
+      if (!canSwap) {
+        fullReloadNavigate(action);
+        return;
+      }
+      window.TerminalNav.go(action.url, { cwd: cwd }).then(function (swapped) {
+        if (!swapped) {
+          fullReloadNavigate(action);
+        }
+      });
+    }
+
     function applyTerminalAction(action) {
       if (!action) {
         return;
@@ -3821,16 +3875,7 @@
         }
         case "navigate":
           if (action.url) {
-            // Carry a `cd` echo to the destination, same as a nav click —
-            // unless the caller opts out (e.g. a language switch).
-            if (action.cd !== false) {
-              stashTerminalCd(currentTerminalCwd(), hrefToCwd(action.url));
-            }
-            try {
-              window.location.assign(action.url);
-            } catch (err) {
-              window.location.href = action.url;
-            }
+            navigateTerminal(action);
           }
           break;
         case "flow":

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -101,6 +101,13 @@
     makeFiguresFocusable();
   }
 
+  // Terminal in-place navigation swaps #main, bringing in fresh figures that
+  // need tabindex/role to stay keyboard-reachable. Expose the (idempotent)
+  // focusability init so terminal-nav.js can re-run it after a swap. Everything
+  // else in this module is bound once to `document`/the overlay and the gallery
+  // is collected at open time, so swapped-in figures are already covered.
+  window.TerminalLightbox = { refresh: makeFiguresFocusable };
+
   document.addEventListener("keydown", function (e) {
     if (e.key !== "Enter" && e.key !== " ") {
       return;

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -1,0 +1,280 @@
+/**
+ * Terminal in-place navigation (typed-only, SPA-style #main swap).
+ *
+ * A typed `cd` in the terminal layout reads like a real shell: instead of
+ * reloading the machine, it swaps the page content under the live prompt and
+ * keeps the scrollback alive. Clicks are deliberately left untouched (they
+ * still full-reload with the top `cd` echo — see darkmode.js); only the
+ * command engine's `navigate` action routes here, and only for ordinary pages.
+ *
+ * darkmode.js decides eligibility it can know up front (terminal layout,
+ * same-origin, not home, not a language switch) and calls `TerminalNav.go()`.
+ * This module makes the final call after fetching — a special page (the four
+ * CSS-bundled pages: home, contact, ui-library, palette-generator) or a
+ * terminal-exempt page can only be recognised from the response, so `go()`
+ * resolves `false` and darkmode falls back to a full reload. Progressive
+ * enhancement throughout: no fetch / a parse failure / no #main all fall back.
+ *
+ * The DOM makes this cheap: all terminal chrome (nav, boot, scrollback, prompt)
+ * lives OUTSIDE `<main id="main">`, so #main is a clean, stable swap target.
+ * The real cost is content-dependent re-init, and in the terminal layout that
+ * collapses to almost nothing: reveal-on-scroll is a CSS no-op here (`.reveal`
+ * is forced visible), role-swapper is home-only (home full-reloads), and the
+ * cd echo is already the typed command sitting in the scrollback. What remains
+ * is lightbox figure focusability (+ the cheap idempotent Coty init).
+ */
+(function () {
+  "use strict";
+
+  var MAIN_SELECTOR = "#main";
+
+  // The path we last rendered into #main. Used to ignore hash-only popstates
+  // (smooth-scroll pushes those) and to detect real page changes on back/fwd.
+  var lastPath = window.location.pathname;
+
+  // Derive a page's cwd (~ or ~/segment) from a URL, mirroring head.html's
+  // per-page logic and darkmode.js's hrefToCwd (strip origin, query/hash, and
+  // the language prefix). Used for the prompt on back/forward restores.
+  function pathToCwd(href) {
+    var path = String(href || "")
+      .replace(/^[a-z]+:\/\/[^/]+/i, "")
+      .replace(/[?#].*$/, "")
+      .replace(/^\/+|\/+$/g, "");
+    var lang = (
+      document.documentElement.getAttribute("lang") || ""
+    ).toLowerCase();
+    var parts = path.split("/").filter(Boolean);
+    if (parts.length && parts[0].toLowerCase() === lang) {
+      parts.shift();
+    }
+    return parts.length ? "~/" + parts[0] : "~";
+  }
+
+  function isTerminalLayout() {
+    return document.documentElement.getAttribute("data-layout") === "terminal";
+  }
+
+  // A fetched document is swappable only if it's an ordinary content page:
+  // not terminal-exempt, and carrying no page-specific CSS bundle. The four
+  // special pages (home, contact, ui-library, palette-generator) are exactly
+  // those with a `css/pages/*` (dev) or `css-page-*` (prod) stylesheet, whose
+  // styles the current page never loaded — swapping them in would break their
+  // look, so they full-reload instead.
+  function isSwappableDoc(doc) {
+    if (!doc || !doc.documentElement) {
+      return false;
+    }
+    if (doc.documentElement.hasAttribute("data-terminal-exempt")) {
+      return false;
+    }
+    if (doc.querySelector('link[href*="css/pages/"], link[href*="css-page"]')) {
+      return false;
+    }
+    return !!doc.querySelector(MAIN_SELECTOR);
+  }
+
+  // Copy the SEO/meta head fields from the fetched document. Deliberately a
+  // fixed allow-list — the stylesheet links, fonts, inline theme script and the
+  // --terminal-host/--terminal-cwd style block must stay put. Remove-then-add
+  // per selector so a field the new page omits (e.g. robots, og:image) is
+  // correctly dropped.
+  function patchHead(doc) {
+    if (doc.title) {
+      document.title = doc.title;
+    }
+    var selectors = [
+      'meta[name="description"]',
+      'meta[name="robots"]',
+      'meta[property^="og:"]',
+      'meta[name^="twitter:"]',
+      'link[rel="canonical"]',
+      'link[rel="alternate"][hreflang]',
+    ];
+    var srcHead = doc.head;
+    if (!srcHead) {
+      return;
+    }
+    selectors.forEach(function (sel) {
+      var existing = document.head.querySelectorAll(sel);
+      for (var i = 0; i < existing.length; i++) {
+        existing[i].parentNode.removeChild(existing[i]);
+      }
+      var incoming = srcHead.querySelectorAll(sel);
+      for (var j = 0; j < incoming.length; j++) {
+        document.head.appendChild(document.importNode(incoming[j], true));
+      }
+    });
+  }
+
+  // The prompt reads its working directory from --terminal-cwd. Set it inline
+  // on <html> (wins over head.html's :root rule) so the PS1 tracks the new page.
+  function setCwd(cwd) {
+    document.documentElement.style.setProperty(
+      "--terminal-cwd",
+      '"' + cwd + '"'
+    );
+  }
+
+  // Re-run only the content-dependent init a #main swap invalidates. Kept tiny
+  // by design (see the file header): lightbox figure focusability, plus the
+  // cheap idempotent Coty init when that engine is loaded.
+  function refreshContentInit() {
+    if (
+      window.TerminalLightbox &&
+      typeof window.TerminalLightbox.refresh === "function"
+    ) {
+      window.TerminalLightbox.refresh();
+    }
+    if (
+      window.CotyScaleActions &&
+      typeof window.CotyScaleActions.init === "function"
+    ) {
+      window.CotyScaleActions.init();
+    }
+  }
+
+  // The prompt sits below #main, so a taller/shorter page shifts it — pin the
+  // viewport to the bottom, matching darkmode.js's scrollTerminalToEnd.
+  function keepPromptInView() {
+    window.requestAnimationFrame(function () {
+      window.scrollTo(0, document.body.scrollHeight);
+    });
+  }
+
+  function parseDoc(html) {
+    try {
+      return new DOMParser().parseFromString(html, "text/html");
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function sameOrigin(url) {
+    try {
+      return (
+        new URL(url, window.location.href).origin === window.location.origin
+      );
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // Apply a fetched document in place: swap #main (importNode carries its
+  // attributes, so the surrounding terminal chrome — scrollback, prompt, nav —
+  // stays intact), then patch head + cwd, refresh the content-dependent init
+  // and keep the prompt in view. Returns false if the document can't be swapped
+  // (special page / no #main).
+  //
+  // The post-swap steps run AFTER the DOM actually updates. That matters under
+  // a view transition: startViewTransition defers its callback a frame, so
+  // running refreshContentInit() eagerly would re-init against the old figures.
+  function render(doc, cwd) {
+    if (!isSwappableDoc(doc)) {
+      return false;
+    }
+    var current = document.querySelector(MAIN_SELECTOR);
+    var incoming = doc.querySelector(MAIN_SELECTOR);
+    if (!current || !incoming || !current.parentNode) {
+      return false;
+    }
+    var imported = document.importNode(incoming, true);
+    var swap = function () {
+      current.parentNode.replaceChild(imported, current);
+    };
+    var finish = function () {
+      patchHead(doc);
+      setCwd(cwd);
+      refreshContentInit();
+      keepPromptInView();
+    };
+    var transition =
+      typeof document.startViewTransition === "function"
+        ? document.startViewTransition(swap)
+        : null;
+    if (transition && transition.updateCallbackDone) {
+      transition.updateCallbackDone.then(finish, finish);
+    } else {
+      // No view-transition support: the swap ran synchronously above (or we
+      // run it now), so finish immediately.
+      if (!transition) {
+        swap();
+      }
+      finish();
+    }
+    return true;
+  }
+
+  // Fetch + swap for a typed navigation. Resolves true if it navigated in
+  // place, false if the caller should fall back to a full reload. Never
+  // rejects — every failure path resolves false.
+  function go(url, opts) {
+    opts = opts || {};
+    if (typeof window.fetch !== "function") {
+      return Promise.resolve(false);
+    }
+    return window
+      .fetch(url, { credentials: "same-origin", redirect: "follow" })
+      .then(function (res) {
+        if (!res.ok) {
+          return false;
+        }
+        // A redirect that left the origin can't be swapped safely.
+        if (res.redirected && res.url && !sameOrigin(res.url)) {
+          return false;
+        }
+        var finalUrl = res.redirected && res.url ? res.url : url;
+        return res.text().then(function (html) {
+          var doc = parseDoc(html);
+          var cwd = opts.cwd || pathToCwd(finalUrl);
+          if (!render(doc, cwd)) {
+            return false;
+          }
+          try {
+            window.history.pushState({ terminalNav: true }, "", finalUrl);
+          } catch (e) {
+            /* origin already checked; ignore a hostile pushState throw */
+          }
+          lastPath = window.location.pathname;
+          return true;
+        });
+      })
+      .catch(function () {
+        return false;
+      });
+  }
+
+  // Back/forward: restore the entry's content in place so the scrollback
+  // survives. Only in terminal layout; skip hash-only changes; reload if the
+  // target isn't swappable (e.g. stepping back onto a special page).
+  function onPopState() {
+    if (!isTerminalLayout()) {
+      return;
+    }
+    if (window.location.pathname === lastPath) {
+      return;
+    }
+    var url = window.location.href;
+    window
+      .fetch(url, { credentials: "same-origin", redirect: "follow" })
+      .then(function (res) {
+        if (!res.ok) {
+          throw new Error("bad status");
+        }
+        return res.text();
+      })
+      .then(function (html) {
+        if (!render(parseDoc(html), pathToCwd(url))) {
+          window.location.reload();
+          return;
+        }
+        lastPath = window.location.pathname;
+      })
+      .catch(function () {
+        window.location.reload();
+      });
+  }
+
+  window.addEventListener("popstate", onPopState);
+
+  window.TerminalNav = { go: go };
+})();

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -141,6 +141,28 @@
     });
   }
 
+  // Where to leave the viewport after a swap depends on what you navigated to.
+  // A LISTING (works/writing/tags — `.content.list` / `.content.startpage`) is
+  // read via `ls` at the prompt, so keep the prompt in view (the owner's
+  // continuous-session model). A READABLE page (a post or `about` —
+  // `.content.post` / `.content.page`) IS the destination, with no `ls` to
+  // surface it, so show it from the top like a full page load — otherwise the
+  // content sits above the prompt, unseen ("looks half-loaded").
+  function settleScroll() {
+    var content = document.querySelector("#main .content");
+    var isListing =
+      content &&
+      (content.classList.contains("list") ||
+        content.classList.contains("startpage"));
+    if (isListing) {
+      keepPromptInView();
+    } else {
+      window.requestAnimationFrame(function () {
+        window.scrollTo(0, 0);
+      });
+    }
+  }
+
   function parseDoc(html) {
     try {
       return new DOMParser().parseFromString(html, "text/html");
@@ -161,13 +183,12 @@
 
   // Apply a fetched document in place: swap #main (importNode carries its
   // attributes, so the surrounding terminal chrome — scrollback, prompt, nav —
-  // stays intact), then patch head + cwd, refresh the content-dependent init
-  // and keep the prompt in view. Returns false if the document can't be swapped
-  // (special page / no #main).
-  //
-  // The post-swap steps run AFTER the DOM actually updates. That matters under
-  // a view transition: startViewTransition defers its callback a frame, so
-  // running refreshContentInit() eagerly would re-init against the old figures.
+  // stays intact), then patch head + cwd, mark the session booted (so the swap
+  // drops the one-per-session boot banner like a full-reload nav would),
+  // refresh the content-dependent init and settle the scroll. Synchronous on
+  // purpose: a view-transition cross-fade animates from a snapshot and can flash
+  // a blank frame mid-swap ("looks half-loaded"), so the swap paints at once.
+  // Returns false if the document can't be swapped (special page / no #main).
   function render(doc, cwd) {
     if (!isSwappableDoc(doc)) {
       return false;
@@ -177,30 +198,21 @@
     if (!current || !incoming || !current.parentNode) {
       return false;
     }
-    var imported = document.importNode(incoming, true);
-    var swap = function () {
-      current.parentNode.replaceChild(imported, current);
-    };
-    var finish = function () {
-      patchHead(doc);
-      setCwd(cwd);
-      refreshContentInit();
-      keepPromptInView();
-    };
-    var transition =
-      typeof document.startViewTransition === "function"
-        ? document.startViewTransition(swap)
-        : null;
-    if (transition && transition.updateCallbackDone) {
-      transition.updateCallbackDone.then(finish, finish);
-    } else {
-      // No view-transition support: the swap ran synchronously above (or we
-      // run it now), so finish immediately.
-      if (!transition) {
-        swap();
-      }
-      finish();
-    }
+    current.parentNode.replaceChild(
+      document.importNode(incoming, true),
+      current
+    );
+    patchHead(doc);
+    setCwd(cwd);
+    // Subsequent pages skip the boot theater. Beyond hiding the banner
+    // (data-terminal-booted), we must clear the .terminal-booting class: its
+    // `#main { animation: terminal-print both 1.35s }` rule holds a freshly
+    // swapped #main at opacity 0 through the delay, so a swap mid-boot (fast
+    // navigation on the landing page) would paint blank until the animation ran.
+    document.documentElement.setAttribute("data-terminal-booted", "1");
+    document.documentElement.classList.remove("terminal-booting");
+    refreshContentInit();
+    settleScroll();
     return true;
   }
 

--- a/docs/features/terminal-followups-plan.md
+++ b/docs/features/terminal-followups-plan.md
@@ -50,7 +50,22 @@ a small on-screen accessory row of keys pinned above the keyboard.
 
 ---
 
-## 2. Terminal in-place navigation (SPA-style, typed-only)
+## 2. Terminal in-place navigation (SPA-style, typed-only) — ✅ shipped
+
+> Built as designed below. New IIFE `assets/js/terminal-nav.js` owns the swap
+> (fetch → swap `#main` → patch head + `--terminal-cwd` → `pushState` → refresh
+> hooks → keep prompt in view), exposing `window.TerminalNav.go()`. darkmode.js's
+> `navigate` action routes typed cd/resume/home here (same-origin, not home, not
+> a language switch) and full-reloads otherwise; `^`-echo already prints to the
+> scrollback so the swap needs no extra output. Special pages are recognised
+> generically post-fetch — the four CSS-bundled pages (home, contact,
+> ui-library, palette-generator) are exactly those carrying a `css/pages/*` /
+> `css-page-*` stylesheet — plus `data-terminal-exempt`. Content re-init
+> collapsed to lightbox figure focusability (exposed via `window.TerminalLightbox`)
+> once we noted reveal is a CSS no-op in terminal and role-swapper is home-only.
+> `popstate` restores in place. Covered by nine Jest tests (`terminal-nav.test.js`)
+> and a Playwright run (typed cd swaps, `cd ~`/click full-reload, back restores,
+> `ls` synergy, no page errors).
 
 ### Goal
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -704,6 +704,7 @@
   {{ $js20 := resources.Get "js/tabs.js" }}
   {{ $js21 := resources.Get "js/ui-library-pantone-scales.js" }}
   {{ $js_lightbox := resources.Get "js/lightbox.js" }}
+  {{ $js_terminal_nav := resources.Get "js/terminal-nav.js" }}
   {{/* NOTE: theme.js will be archived - logic moved to darkmode.js */}}
 
   <!-- JavaScript loading -->
@@ -750,9 +751,10 @@
       <script src="{{ $js21.RelPermalink }}" defer></script>
     {{ end }}
     <script src="{{ $js_lightbox.RelPermalink }}" defer></script>
+    <script src="{{ $js_terminal_nav.RelPermalink }}" defer></script>
   {{ else }}
     <!-- JavaScript production -->
-    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox }}
+    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav }}
     {{ $js = $js | resources.Concat "js.js" | minify | fingerprint }}
     <script src="{{ $js.RelPermalink }}" defer></script>
     {{ $pageJs := slice }}


### PR DESCRIPTION
A typed `cd` in the terminal layout now reads like a real shell: instead
of reloading the machine, it swaps the page content under the live prompt
and keeps the scrollback alive. Clicks are deliberately untouched — they
still full-reload with the top `cd` echo (the gentle, battle-tested path).
Only the command engine's `navigate` action (typed cd/resume/home) gets
the new behaviour, so a bug there never reaches click-through visitors.

- terminal-nav.js (new IIFE, window.TerminalNav.go): fetch the URL, swap
  `#main` (importNode keeps its attributes; all terminal chrome lives
  outside <main>, so scrollback/prompt/nav stay intact), patch the SEO
  head fields + `--terminal-cwd`, pushState, refresh content-dependent
  init, keep the prompt in view. popstate restores in place so back/forward
  preserve the scrollback. A view transition cross-fades the swap where
  supported (post-swap init deferred until the transition's DOM update).
- darkmode.js: the `navigate` action routes typed nav here when it can
  swap (terminal layout, same-origin, not home, not a language switch) and
  falls back to a full reload otherwise. The command echo already prints to
  the scrollback, so an in-place swap needs no extra output; on fallback the
  stash reprints it on the reloaded page. `^C`/reload helpers factored out.
- Special pages full-reload, detected generically: the four CSS-bundled
  pages (home, contact, ui-library, palette-generator) are exactly those
  carrying a page-specific stylesheet, plus any data-terminal-exempt page.
  Progressive enhancement: no fetch / parse failure / no #main all fall back.
- lightbox.js exposes window.TerminalLightbox.refresh so swapped-in figures
  stay keyboard-reachable — the only content-init a terminal swap needs
  (reveal is a CSS no-op here, role-swapper is home-only, the cd echo is the
  typed command already in the scrollback).
- head.html bundles terminal-nav.js (dev tags + prod concat).

Synergy: after `cd writing` the new page's cards are in the DOM, so the
round-4 `ls` content-harvest lists them straight away.

Tests: nine Jest cases in terminal-nav.test.js drive the swap / skip /
head-patch / cwd logic against fetched-HTML fixtures; existing nav/cd tests
stay green (full reload when TerminalNav is absent). Verified end-to-end in
Chromium: typed cd swaps in place, `cd ~` and clicks full-reload, back
restores, `ls` synergy works, no page errors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D4zTzBqNu7qwhF5BhQPPgJ