### PR TITLE
Terminal: in-place navigation for typed cd (SPA-style #main swap)

### DIFF
--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -506,6 +506,55 @@
   content: none;
 }
 
+/* ============================================================================
+   The about page is ONE file too — like a post. A single `cat about.md` prints
+   it; its inner headings render as markdown inside that output, not as their
+   own `cat '…'` commands (which read as many prompts you can't actually type).
+   The page has no h1 title to carry the command, so a top ::before does.
+   ============================================================================ */
+:root[data-layout="terminal"] .content.page.about::before {
+  content: var(--terminal-ps1) "cat about.md";
+  display: block;
+  font-family: var(--font-mono);
+  font-weight: 400;
+  color: var(--text-muted, inherit);
+  margin-bottom: var(--spacing-16);
+}
+
+:root[data-layout="terminal"] .content.page.about h2::before,
+:root[data-layout="terminal"] .content.page.about .section-heading::before {
+  content: "## ";
+}
+
+:root[data-layout="terminal"] .content.page.about h3::before,
+:root[data-layout="terminal"] .content.page.about .about-main__headline::before,
+:root[data-layout="terminal"] .content.page.about .about-cv__title::before {
+  content: "### ";
+}
+
+:root[data-layout="terminal"] .content.page.about .about-cv__heading::before {
+  content: "#### ";
+  font-family: var(--font-mono);
+  font-weight: 400;
+  color: var(--text-muted, inherit);
+}
+
+:root[data-layout="terminal"] .content.page.about h2::after,
+:root[data-layout="terminal"] .content.page.about h3::after,
+:root[data-layout="terminal"] .content.page.about .section-heading::after,
+:root[data-layout="terminal"] .content.page.about .about-main__headline::after,
+:root[data-layout="terminal"] .content.page.about .about-cv__title::after {
+  content: none;
+}
+
+:root[data-layout="terminal"] .content.page.about h2,
+:root[data-layout="terminal"] .content.page.about h3,
+:root[data-layout="terminal"] .content.page.about .section-heading,
+:root[data-layout="terminal"] .content.page.about .about-main__headline,
+:root[data-layout="terminal"] .content.page.about .about-cv__title {
+  text-transform: none;
+}
+
 /* Related is a section after the file — it keeps its ls command. */
 :root[data-layout="terminal"] .content.post .related-items__title {
   text-transform: lowercase;

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1454,7 +1454,23 @@
   display: block;
 }
 
-/* Echoed command lines carry the real prompt string, like scrollback. */
+/* Echoed command lines carry the real prompt string, like scrollback.
+   Append-only history: darkmode.js pins an inline --terminal-cwd on each echo
+   (the cwd it ran at). The :root --terminal-ps1 composite would resolve its
+   inner var(--terminal-cwd) back at :root (the LIVE cwd), so re-declare the
+   PS1 chain HERE — on the echo element — where the inner var resolves against
+   the element's frozen --terminal-cwd. The live input prompt keeps the :root
+   composite, so it alone tracks the working directory. */
+:root[data-layout="terminal"] .terminal-session__cmd {
+  --terminal-ps1-short: var(--terminal-cwd, "~") "$ ";
+  --terminal-ps1: "visitor@" var(--terminal-host, "tor-bjorn.com") ":"
+    var(--terminal-ps1-short);
+}
+@media (max-width: 47.9375em) {
+  :root[data-layout="terminal"] .terminal-session__cmd {
+    --terminal-ps1: var(--terminal-ps1-short);
+  }
+}
 :root[data-layout="terminal"] .terminal-session__cmd::before {
   content: var(--terminal-ps1);
   color: var(--text-muted, inherit);

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1478,6 +1478,70 @@
   margin-top: var(--spacing-8);
 }
 
+/* ============================================================================
+   Mobile key bar (accessory row)
+   The round-4 keyboard fundamentals (↑/↓ history recall, Tab completion, ^C)
+   ride keys the on-screen keyboard lacks, plus a ⌄ jump-to-prompt. This bar
+   surfaces them just above the keyboard while the prompt is focused. It's a
+   coarse-pointer affordance only — desktop has the real keys, so the bar stays
+   display:none there. darkmode.js toggles .is-visible on focus and translates
+   the bar up over the keyboard via the visualViewport API (plain fixed sits
+   behind it on iOS Safari); the fixed bottom anchor here is the base it starts
+   from. The keys read as bracketed mono words, matching the terminal's chrome.
+   ============================================================================ */
+
+.terminal-keybar {
+  display: none;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  :root[data-layout="terminal"] .terminal-keybar.is-visible {
+    display: flex;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 60;
+    gap: var(--spacing-4);
+    padding: var(--spacing-4) var(--size-page-margins);
+    background: var(--surface-page);
+    border-top: 1px solid var(--border-subtle);
+    /* darkmode.js sets translateY to clear the keyboard; hint the compositor. */
+    will-change: transform;
+  }
+}
+
+:root[data-layout="terminal"] .terminal-keybar__key {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 2.75em;
+  padding: 0 var(--spacing-8);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  font-family: var(--font-mono);
+  font-size: var(--terminal-font-size);
+  line-height: 1;
+  color: var(--text-link, var(--text-default));
+  cursor: pointer;
+  /* No tap flash / double-tap zoom — this is a key, not a link. */
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+/* Bracketed like every other actionable word in the buffer. */
+:root[data-layout="terminal"] .terminal-keybar__key::before {
+  content: "[";
+}
+
+:root[data-layout="terminal"] .terminal-keybar__key::after {
+  content: "]";
+}
+
+:root[data-layout="terminal"] .terminal-keybar__key:active {
+  color: var(--text-accent, currentColor);
+}
+
 /* Party mode — the Konami code (or `konami`) sets data-konami, and the whole
    terminal cycles hue. Motion-gated: reduced-motion visitors get a single
    colourful tint instead of the animation. */

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -556,7 +556,7 @@
   .content.post
   .project-info
   + .post-content:has(figure)::before {
-  content: var(--terminal-ps1) "ls " var(--terminal-gallery-arg) "/";
+  content: var(--terminal-ps1) "ls --images";
   display: block;
   font-size: var(--terminal-font-size);
   margin-top: var(--spacing-16);

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1099,6 +1099,17 @@
    Footer: stacked text rows inside the same window
    ============================================================================ */
 
+/* The footer's command blocks (ls -R ~/, cat 'newsletter.txt', subscribe
+   --email, env) belong to the home login tour — otherwise they repeat under
+   every content page as if run from ~/writing, ~/works, … On any non-home page
+   they're hidden; the scrollback and live prompt (also in the footer) stay.
+   The home flag is server-set on <html> and synced across in-place nav. */
+:root[data-layout="terminal"]:not([data-terminal-home]) .footer-grid--primary,
+:root[data-layout="terminal"]:not([data-terminal-home]) .footer-newsletter,
+:root[data-layout="terminal"]:not([data-terminal-home]) .footer-meta {
+  display: none;
+}
+
 :root[data-layout="terminal"] .footer-grid--primary {
   display: flex;
   flex-direction: column;

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -189,6 +189,17 @@
   color: var(--text-accent);
 }
 
+/* The hero is the first line of the login tour: `cat welcome.txt` prints the
+   intro. (Home-only — the hero section exists only there. Typeable: `welcome`
+   is a pseudo-file in darkmode.js.) */
+:root[data-layout="terminal"] .hero-section::before {
+  content: var(--terminal-ps1) "cat welcome.txt";
+  display: block;
+  font-family: var(--font-mono);
+  color: var(--text-muted, inherit);
+  margin-bottom: var(--spacing-16);
+}
+
 /* ============================================================================
    Shared text chrome — the primitives every terminal component composes from.
    Individual sections below only pick content strings and layout on top.
@@ -358,6 +369,7 @@
    screen readers and every other layout; here font-size:0 hides it and the
    ::after prints the filename. */
 :root[data-layout="terminal"] .summary-card__title a[data-slug],
+:root[data-layout="terminal"] .summary-card__title a[data-dir],
 :root[data-layout="terminal"] .article-card__title a[data-slug],
 :root[data-layout="terminal"]
   .related-items__item
@@ -373,6 +385,13 @@
   .type-headline-4
   a[data-slug]::after {
   content: attr(data-slug) ".md";
+  font-size: var(--terminal-font-size);
+  font-family: var(--font-mono);
+}
+
+/* A taxonomy/section card (works' "tags") is a directory — slug/, not slug.md. */
+:root[data-layout="terminal"] .summary-card__title a[data-dir]::after {
+  content: attr(data-dir) "/";
   font-size: var(--terminal-font-size);
   font-family: var(--font-mono);
 }
@@ -417,6 +436,25 @@
   content: "'/";
 }
 
+/* Home's featured section is a filtered view, not a directory: print the exact
+   typeable command. The localized "Featured"/"Utvalda" heading text is hidden
+   (font-size:0) and the command injected, so it stays language-independent. */
+/* #main in the selector so it outweighs the id-specificity "one type size"
+   rule (#main :is(h1..h6)) — otherwise the localized heading text leaks in
+   after the injected command. */
+:root[data-layout="terminal"] #main .works-section .post-header h2 {
+  font-size: 0;
+}
+
+:root[data-layout="terminal"] #main .works-section .post-header h2::before {
+  content: var(--terminal-ps1) "ls works/ --featured";
+  font-size: var(--terminal-font-size);
+}
+
+:root[data-layout="terminal"] .works-section .post-header h2::after {
+  content: "";
+}
+
 /* ============================================================================
    Post pages are ONE file: a single cat on the title prints everything.
    Inner headings render as markdown inside the output, not as new commands.
@@ -459,18 +497,27 @@
   text-transform: lowercase;
 }
 
-:root[data-layout="terminal"] .content.post .related-items__title::before {
-  content: var(--terminal-ps1) "ls '";
+:root[data-layout="terminal"] #main .content.post .related-items__title {
+  font-size: 0;
+}
+
+:root[data-layout="terminal"]
+  #main
+  .content.post
+  .related-items__title::before {
+  content: var(--terminal-ps1) "ls --related";
+  font-size: var(--terminal-font-size);
 }
 
 :root[data-layout="terminal"] .content.post .related-items__title::after {
-  content: "'/";
+  content: "";
 }
 
-/* Project info is the directory next to the file: ls 'info'/, one column,
-   one size. */
+/* A post is a file; its info/related are the file's own sections, listed with
+   filter flags — `ls --info`, `ls --related` (relative to the post you're in),
+   the same commands you'd type. One column, one size. */
 :root[data-layout="terminal"] .content.post > .project-info::before {
-  content: var(--terminal-ps1) "ls 'info'/";
+  content: var(--terminal-ps1) "ls --info";
   display: block;
   margin-bottom: var(--spacing-8);
 }

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -80,10 +80,22 @@
   --terminal-line-height: 1.7;
 
   /* The PS1 strings — every prompt in the buffer composes from these.
-     The short form (cwd only) is what small screens collapse to. */
+     The short form (cwd only) is what small screens collapse to.
+
+     --terminal-cwd is the page's FROZEN load cwd (server-set, never changed by
+     an append-only `cd`), so every server-rendered history prompt — the header
+     nav, the hero/featured/footer tour lines, a post's `cat` header — stays put
+     as scrollback. Only the live input prompt tracks the working directory, via
+     the parallel --terminal-live-cwd chain below (darkmode.js's `chdir` moves
+     that one alone). Scrollback echoes freeze their own inline --terminal-cwd. */
   --terminal-ps1-short: var(--terminal-cwd, "~") "$ ";
   --terminal-ps1: "visitor@" var(--terminal-host, "tor-bjorn.com") ":"
     var(--terminal-ps1-short);
+
+  --terminal-live-cwd: var(--terminal-cwd, "~");
+  --terminal-ps1-live-short: var(--terminal-live-cwd, "~") "$ ";
+  --terminal-ps1-live: "visitor@" var(--terminal-host, "tor-bjorn.com") ":"
+    var(--terminal-ps1-live-short);
 
   /* Figure tokens and the gallery listing argument. */
   --terminal-image-label: "[image ";
@@ -103,6 +115,7 @@
 @media (max-width: 47.9375em) {
   :root[data-layout="terminal"] {
     --terminal-ps1: var(--terminal-ps1-short);
+    --terminal-ps1-live: var(--terminal-ps1-live-short);
   }
 }
 
@@ -1319,7 +1332,7 @@
 }
 
 :root[data-layout="terminal"] .terminal-tail__prompt::before {
-  content: var(--terminal-ps1);
+  content: var(--terminal-ps1-live);
   color: var(--text-muted, inherit);
 }
 

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -346,12 +346,34 @@
   font-family: var(--font-mono);
 }
 
-/* Links that are directories carry the trailing slash. */
+/* Links that are directories carry the trailing slash — the nav sections. */
 :root[data-layout="terminal"] .top-menu__item--nav .top-menu__link::after,
-:root[data-layout="terminal"] .top-menu__label--long::after,
-:root[data-layout="terminal"] .summary-card__title a::after,
-:root[data-layout="terminal"] .related-items__item .type-headline-4 a::after {
+:root[data-layout="terminal"] .top-menu__label--long::after {
   content: "/";
+  font-family: var(--font-mono);
+}
+
+/* Posts are files: an ls-row shows the slug as a .md filename (stamped onto the
+   link by darkmode.js), not the human title. The title stays in the DOM for
+   screen readers and every other layout; here font-size:0 hides it and the
+   ::after prints the filename. */
+:root[data-layout="terminal"] .summary-card__title a[data-slug],
+:root[data-layout="terminal"] .article-card__title a[data-slug],
+:root[data-layout="terminal"]
+  .related-items__item
+  .type-headline-4
+  a[data-slug] {
+  font-size: 0;
+}
+
+:root[data-layout="terminal"] .summary-card__title a[data-slug]::after,
+:root[data-layout="terminal"] .article-card__title a[data-slug]::after,
+:root[data-layout="terminal"]
+  .related-items__item
+  .type-headline-4
+  a[data-slug]::after {
+  content: attr(data-slug) ".md";
+  font-size: var(--terminal-font-size);
   font-family: var(--font-mono);
 }
 

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -27,7 +27,8 @@
      themselves via data-toast-title/aria-label.
    - summary templates: .summary-card__year spans (hidden in other layouts)
      become the ls-row year column.
-   - footer.html: .footer-meta__item [data-category] becomes the env var name.
+   - footer.html: .footer-meta__item [data-category] becomes the colophon's
+     KEY=value status name.
    - DOM order on work posts: the gallery prompt needs .project-info followed
      by .gallery / .post-content containing figures.
    - Pages that cannot adapt opt out with data-terminal-exempt on <html>
@@ -1181,7 +1182,9 @@
   content: ".txt'";
 }
 
-/* The legal/status row is an executed env — flat rows, never centred.
+/* The legal/status row is the site's colophon (©, status, legal links) — an
+   executed `cat colophon`, reproduced verbatim when typed (see darkmode.js's
+   terminalColophonLines). `env` is the separate live state-dump command.
    display:block kills the subgrid so the prompt doesn't wrap in a track. */
 :root[data-layout="terminal"] .footer-meta {
   display: block;
@@ -1189,7 +1192,7 @@
 }
 
 :root[data-layout="terminal"] .footer-meta::before {
-  content: var(--terminal-ps1-short) "env";
+  content: var(--terminal-ps1-short) "cat colophon";
   display: block;
 }
 
@@ -1209,7 +1212,7 @@
 }
 
 /* The label spans hold icons only — gone; the value spans carry their
-   category name, which becomes the env variable: LÄGE=Mörkt. */
+   category name, rendered as a KEY=value status pair: LÄGE=Mörkt. */
 :root[data-layout="terminal"] .footer-meta__label {
   display: none;
 }

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1484,6 +1484,31 @@
   color: inherit;
 }
 
+/* A cat'd [image N] token is a real button (opens the picture in the lightbox)
+   but must read as inline terminal text: strip the native chrome, inherit the
+   font, and mark it interactive with an underline + pointer. */
+:root[data-layout="terminal"] .terminal-session__image {
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: var(--text-muted, inherit);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+  cursor: pointer;
+}
+
+:root[data-layout="terminal"] .terminal-session__image:hover,
+:root[data-layout="terminal"] .terminal-session__image:focus-visible {
+  color: var(--text-default, inherit);
+  text-decoration-color: currentColor;
+  outline: none;
+}
+
 /* Echoed answers inside an interactive flow (contact / subscribe) read like
    what the user typed at the field prompt. */
 :root[data-layout="terminal"] .terminal-session__flow {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -57,7 +57,7 @@ describe("terminal command line", () => {
 
     document.documentElement.innerHTML = `
       <head><meta name="theme-color" content="#ffffff">
-        <script type="application/json" data-js="terminal-manifest">{"works":"dir","writing":"dir","about":"file","contact":"action","ui-library":"exempt","palette-generator":"exempt"}</script>
+        <script type="application/json" data-js="terminal-manifest">{"works":{"kind":"dir","url":"/works/"},"writing":{"kind":"dir","url":"/writing/"},"about":{"kind":"file","url":"/about/"},"contact":{"kind":"action","url":"/contact/"},"legal":{"kind":"dir","url":"/legal/"},"ui-library":{"kind":"exempt","url":"/ui-library/"},"palette-generator":{"kind":"exempt","url":"/palette-generator/"}}</script>
       </head>
       <body>
         <div class="terminal-boot">

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -258,6 +258,26 @@ describe("terminal command line", () => {
     expect(sessionText().toLowerCase()).toContain("no secrets");
   });
 
+  test("a quoted argument parses as one token (spaces and all)", () => {
+    loadModule();
+    // The chrome prints `cat 'name.txt'`; typed verbatim it must not split on
+    // the quotes or an inner space into "'name" — the whole quoted string is one
+    // argument, quotes stripped.
+    typeCommand("cat 'no such thing.md'");
+    // The error names the whole filename with quotes stripped — proof it was
+    // one token, not split on the space into "'no".
+    expect(sessionText()).toContain(
+      "cat: no such thing.md: No such file or directory"
+    );
+  });
+
+  test("cat 'newsletter.txt' prints the newsletter blurb, not a parse error", () => {
+    loadModule();
+    typeCommand("cat 'newsletter.txt'");
+    expect(sessionText()).not.toContain("No such file");
+    expect(sessionText().toLowerCase()).toContain("subscribe");
+  });
+
   test("man pulls a one-line description from help", () => {
     loadModule();
     typeCommand("man whoami");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -56,7 +56,9 @@ describe("terminal command line", () => {
     document.documentElement.setAttribute("data-layout", "terminal");
 
     document.documentElement.innerHTML = `
-      <head><meta name="theme-color" content="#ffffff"></head>
+      <head><meta name="theme-color" content="#ffffff">
+        <script type="application/json" data-js="terminal-manifest">{"works":"dir","writing":"dir","about":"file","contact":"action","ui-library":"exempt","palette-generator":"exempt"}</script>
+      </head>
       <body>
         <div class="terminal-boot">
           <pre class="terminal-boot__art terminal-boot__art--sm">  ██\n ████</pre>
@@ -237,11 +239,26 @@ describe("terminal command line", () => {
 
   // ---- Additional commands & easter eggs --------------------------------
 
-  test("ls lists the nav pages as directories", () => {
+  test("ls renders entries by kind: sections as dirs, pages as files", () => {
     loadModule();
     typeCommand("ls");
+    // From the manifest: works/writing are dirs, about is a file, contact an
+    // action — so the top level reads honestly, no hardcoded guess.
     expect(sessionText()).toContain("writing/");
-    expect(sessionText()).toContain("about/");
+    expect(sessionText()).toContain("about.md");
+    expect(sessionText()).not.toContain("about/");
+  });
+
+  test("cd classifies by kind: file → cat, action → run", () => {
+    loadModule();
+    typeCommand("cd about");
+    expect(sessionText()).toContain(
+      "not a directory: about — try: cat about.md"
+    );
+    typeCommand("cd contact");
+    expect(sessionText()).toContain(
+      "contact is a command, not a directory — just run: contact"
+    );
   });
 
   test("cat prints a known pseudo-file and 404s unknown ones", () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -922,6 +922,14 @@ describe("terminal command line", () => {
     );
   });
 
+  test("ls --featured lists the page's cards as files (not misread as -a)", () => {
+    loadModule();
+    typeCommand("ls works/ --featured");
+    // The article-card link → a .md file; the long flag must not trip -a.
+    expect(sessionText()).toContain("the-grid-inherited.md");
+    expect(sessionText()).not.toContain(".secret");
+  });
+
   test("subscribe reuses the newsletter form action", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -261,6 +261,19 @@ describe("terminal command line", () => {
     );
   });
 
+  test("cd walks a section's tags/ hierarchy; a tagged post is a file", () => {
+    loadModule();
+    // works is a dir in the manifest, so its tags index and a term are dirs you
+    // cd into (no error); a post reached through a tag is a file → cat it.
+    typeCommand("cd works/tags");
+    typeCommand("cd works/tags/experimental");
+    expect(sessionText()).not.toContain("no such file");
+    typeCommand("cd works/tags/experimental/a-cut-up-world");
+    expect(sessionText()).toContain(
+      "not a directory: works/tags/experimental/a-cut-up-world — try: cat a-cut-up-world.md"
+    );
+  });
+
   test("cat prints a known pseudo-file and 404s unknown ones", () => {
     loadModule();
     typeCommand("cat readme");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -134,6 +134,13 @@ describe("terminal command line", () => {
           ><span class="terminal-tail__caret"></span
           ><input id="terminal-input" class="terminal-tail__input" data-js="terminal-input" type="text" size="1" />
         </p>
+        <div class="terminal-keybar" data-js="terminal-keybar">
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="prev" aria-label="Previous command">↑</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="next" aria-label="Next command">↓</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="tab" aria-label="Complete">Tab</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="cancel" aria-label="Cancel line">^C</button>
+          <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="bottom" aria-label="Jump to prompt">⌄</button>
+        </div>
       </body>
     `;
 
@@ -664,6 +671,57 @@ describe("terminal command line", () => {
     keydown({ key: "c", ctrlKey: true });
     expect(input.value).toBe("");
     expect(sessionText()).toContain("^C");
+  });
+
+  function tapKeybar(action) {
+    const button = document.querySelector('[data-keybar="' + action + '"]');
+    button.dispatchEvent(
+      new window.Event("pointerdown", { bubbles: true, cancelable: true })
+    );
+    button.dispatchEvent(new window.Event("click", { bubbles: true }));
+  }
+
+  test("key bar ↑ recalls the previous command (mobile has no arrow keys)", () => {
+    loadModule();
+    typeCommand("whoami");
+    tapKeybar("prev");
+    expect(document.querySelector('[data-js="terminal-input"]').value).toBe(
+      "whoami"
+    );
+  });
+
+  test("key bar Tab completes a command, ^C cancels the line", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "wea";
+    tapKeybar("tab");
+    expect(input.value).toBe("weather ");
+    input.value = "half typed";
+    tapKeybar("cancel");
+    expect(input.value).toBe("");
+    expect(sessionText()).toContain("^C");
+  });
+
+  test("key bar is shown only while the prompt is focused", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    const bar = document.querySelector('[data-js="terminal-keybar"]');
+    expect(bar.classList.contains("is-visible")).toBe(false);
+    input.dispatchEvent(new window.Event("focus"));
+    expect(bar.classList.contains("is-visible")).toBe(true);
+    input.dispatchEvent(new window.Event("blur"));
+    expect(bar.classList.contains("is-visible")).toBe(false);
+  });
+
+  test("key bar pointerdown keeps focus on the input (keyboard stays up)", () => {
+    loadModule();
+    const button = document.querySelector('[data-keybar="prev"]');
+    const event = new window.Event("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    button.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
   });
 
   test("konami command toggles party mode", async () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -873,7 +873,8 @@ describe("terminal command line", () => {
   test("a post is a file: cd rejects it, cat opens it", () => {
     // The test DOM has an article-card link to /writing/the-grid-inherited/.
     // Posts are files, so `cd` into one is "not a directory" and points at cat;
-    // `cat <post>.md` navigates (its page renders as the cat output).
+    // `cat <post>.md` resolves to a remote-cat action (append-only: the post's
+    // text prints into the scrollback — exercised for real in the browser check).
     loadModule();
     typeCommand("cd writing/the-grid-inherited");
     expect(sessionText()).toContain(
@@ -883,7 +884,7 @@ describe("terminal command line", () => {
 
     const before = sessionText();
     typeCommand("cat writing/the-grid-inherited.md");
-    // Resolves (produces a navigate action) — no cat error.
+    // Resolves (produces a remote-cat action) — no cat error line.
     expect(sessionText().slice(before.length)).not.toContain(
       "No such file or directory"
     );

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -868,6 +868,24 @@ describe("terminal command line", () => {
     );
   });
 
+  test("cd resolves a content-card post, same as ls lists it", () => {
+    // ls harvests the page's article/summary cards, so cd must reach them too
+    // (else ls lists a post that cd then rejects). The test DOM has an
+    // article-card link to /writing/the-grid-inherited/.
+    loadModule();
+    const before = sessionText();
+    typeCommand("cd writing/the-grid-inherited");
+    expect(sessionText().slice(before.length)).not.toContain(
+      "no such file or directory"
+    );
+
+    // A post that isn't on the page still errors.
+    typeCommand("cd writing/ghost-post");
+    expect(sessionText()).toContain(
+      "no such file or directory: writing/ghost-post"
+    );
+  });
+
   test("subscribe reuses the newsletter form action", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -933,6 +933,13 @@ describe("terminal command line", () => {
     );
   });
 
+  test("ls <file> --info points at cat (a post's info lives in the file)", () => {
+    loadModule();
+    typeCommand("ls a-cut-up-world.md --info");
+    // --info is a lens on the loaded page; for an unopened post it hints at cat.
+    expect(sessionText()).toContain("try: cat a-cut-up-world.md");
+  });
+
   test("ls --featured lists the page's cards as files (not misread as -a)", () => {
     loadModule();
     typeCommand("ls works/ --featured");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -475,6 +475,16 @@ describe("terminal command line", () => {
     expect(text).toMatch(/[├└]/);
   });
 
+  test("ls -R is recursive — per-directory blocks, not a flat list", () => {
+    loadModule();
+    typeCommand("ls -R ~/");
+    const text = sessionText();
+    // A recursive listing has sub-directory headers (e.g. "~/works:"), which a
+    // flat single-level ls never prints.
+    expect(text).toContain("~/works:");
+    expect(text).toContain("~/works/tags:");
+  });
+
   test("hire starts the contact flow", () => {
     loadModule();
     typeCommand("hire");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -870,7 +870,7 @@ describe("terminal command line", () => {
     );
   });
 
-  test("a post is a file: cd rejects it, cat opens it", () => {
+  test("a post is a file: cd rejects it, cat opens it", async () => {
     // The test DOM has an article-card link to /writing/the-grid-inherited/.
     // Posts are files, so `cd` into one is "not a directory" and points at cat;
     // `cat <post>.md` resolves to a remote-cat action (append-only: the post's
@@ -889,9 +889,19 @@ describe("terminal command line", () => {
       "No such file or directory"
     );
 
-    // A post that isn't on the page still errors.
+    // A post that isn't loaded resolves cwd-relatively and is fetched to
+    // verify — a 404 reports No such file (append-only cat's remote path, so
+    // a file `ls` printed from a fetched section can still be cat'd, and a
+    // typo still errors). Mock a 404 and let the async handler settle.
+    const before404 = sessionText();
+    window.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
     typeCommand("cat writing/ghost-post.md");
-    expect(sessionText()).toContain(
+    // Fake timers are active, so flush the remote-cat promise chain by hand
+    // (fetch → then throws notFound → catch prints) via microtask ticks.
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    expect(sessionText().slice(before404.length)).toContain(
       "cat: writing/ghost-post.md: No such file or directory"
     );
   });

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -142,7 +142,9 @@ describe("terminal command line", () => {
     }));
     window.getComputedStyle = jest.fn(() => ({
       getPropertyValue: jest.fn((prop) =>
-        prop === "--terminal-cwd" ? "~" : "#ffffff"
+        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
+          ? "~"
+          : "#ffffff"
       ),
     }));
     window.Toast = { show: jest.fn() };
@@ -410,7 +412,9 @@ describe("terminal command line", () => {
     // Pretend the page is /writing/ so the cwd is ~/writing.
     window.getComputedStyle = jest.fn(() => ({
       getPropertyValue: jest.fn((prop) =>
-        prop === "--terminal-cwd" ? "~/writing" : "#ffffff"
+        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
+          ? "~/writing"
+          : "#ffffff"
       ),
     }));
     typeCommand("ls");
@@ -424,7 +428,9 @@ describe("terminal command line", () => {
     // Sitting on /works/, ask for a different section's contents.
     window.getComputedStyle = jest.fn(() => ({
       getPropertyValue: jest.fn((prop) =>
-        prop === "--terminal-cwd" ? "~/works" : "#ffffff"
+        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
+          ? "~/works"
+          : "#ffffff"
       ),
     }));
     typeCommand("ls ~/writing");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -414,7 +414,9 @@ describe("terminal command line", () => {
       ),
     }));
     typeCommand("ls");
-    expect(sessionText()).toContain("the-grid-inherited/");
+    // Posts are files, not directories: listed as .md (no trailing slash).
+    expect(sessionText()).toContain("the-grid-inherited.md");
+    expect(sessionText()).not.toContain("the-grid-inherited/");
   });
 
   test("ls of another section hints at cd instead of printing nothing", () => {
@@ -868,21 +870,55 @@ describe("terminal command line", () => {
     );
   });
 
-  test("cd resolves a content-card post, same as ls lists it", () => {
-    // ls harvests the page's article/summary cards, so cd must reach them too
-    // (else ls lists a post that cd then rejects). The test DOM has an
-    // article-card link to /writing/the-grid-inherited/.
+  test("a post is a file: cd rejects it, cat opens it", () => {
+    // The test DOM has an article-card link to /writing/the-grid-inherited/.
+    // Posts are files, so `cd` into one is "not a directory" and points at cat;
+    // `cat <post>.md` navigates (its page renders as the cat output).
     loadModule();
-    const before = sessionText();
     typeCommand("cd writing/the-grid-inherited");
+    expect(sessionText()).toContain(
+      "not a directory: writing/the-grid-inherited"
+    );
+    expect(sessionText()).toContain("cat writing/the-grid-inherited.md");
+
+    const before = sessionText();
+    typeCommand("cat writing/the-grid-inherited.md");
+    // Resolves (produces a navigate action) — no cat error.
     expect(sessionText().slice(before.length)).not.toContain(
-      "no such file or directory"
+      "No such file or directory"
     );
 
     // A post that isn't on the page still errors.
-    typeCommand("cd writing/ghost-post");
+    typeCommand("cat writing/ghost-post.md");
     expect(sessionText()).toContain(
-      "no such file or directory: writing/ghost-post"
+      "cat: writing/ghost-post.md: No such file or directory"
+    );
+  });
+
+  test("ls nav/ and ls settings/ list the menus (as the header prints them)", () => {
+    loadModule();
+    typeCommand("ls nav/");
+    expect(sessionText()).toContain("works/"); // a section is a directory
+    expect(sessionText()).toContain("about"); // a standalone page is a leaf
+    const before = sessionText();
+    typeCommand("ls settings/");
+    const added = sessionText().slice(before.length);
+    expect(added).toContain("theme");
+    expect(added).toContain("language");
+  });
+
+  test("nav and settings are menus, not places: cd lists instead of entering", () => {
+    loadModule();
+    typeCommand("cd settings");
+    expect(sessionText()).toContain("menu, not a directory");
+  });
+
+  test("open navigates to a post file", () => {
+    loadModule();
+    const before = sessionText();
+    typeCommand("open writing/the-grid-inherited.md");
+    expect(sessionText().slice(before.length)).not.toContain(
+      "no such file or directory"
     );
   });
 

--- a/assets/js/__tests__/terminal-nav.test.js
+++ b/assets/js/__tests__/terminal-nav.test.js
@@ -110,6 +110,24 @@ describe("terminal in-place navigation", () => {
     );
   });
 
+  test("go() drops the boot theater so the swapped #main isn't held at opacity 0", async () => {
+    // The boot animation (.terminal-booting #main { animation: terminal-print
+    // both }) pins a freshly swapped #main at opacity 0 through its delay, so a
+    // swap mid-boot must clear the class and mark the session booted.
+    mockFetch(pageHtml());
+    loadModule();
+    document.documentElement.classList.add("terminal-booting");
+
+    await window.TerminalNav.go("/writing/", { cwd: "~/writing" });
+
+    expect(
+      document.documentElement.classList.contains("terminal-booting")
+    ).toBe(false);
+    expect(document.documentElement.getAttribute("data-terminal-booted")).toBe(
+      "1"
+    );
+  });
+
   test("go() patches SEO meta from the fetched head", async () => {
     mockFetch(pageHtml({ description: "all my posts" }));
     loadModule();

--- a/assets/js/__tests__/terminal-nav.test.js
+++ b/assets/js/__tests__/terminal-nav.test.js
@@ -1,0 +1,207 @@
+/**
+ * Terminal in-place navigation (terminal-nav.js): the typed-cd SPA swap.
+ * Drives window.TerminalNav.go() against fetched-HTML fixtures and asserts the
+ * swap / skip / head-patch / cwd logic. The darkmode.js side (routing a
+ * `navigate` action here vs falling back to a full reload) stays covered by
+ * terminal-commands.test.js.
+ */
+describe("terminal in-place navigation", () => {
+  function loadModule() {
+    jest.isolateModules(() => {
+      require("../terminal-nav.js");
+    });
+  }
+
+  // A fetched HTML document. `opts.exempt` marks it terminal-exempt; `opts.pageCss`
+  // gives it a page-specific stylesheet (the special-page signal); `opts.main`
+  // overrides the #main body; `opts.noMain` drops #main entirely.
+  function pageHtml(opts) {
+    opts = opts || {};
+    var head =
+      "<title>" +
+      (opts.title || "Writing · Site") +
+      "</title>" +
+      '<meta name="description" content="' +
+      (opts.description || "posts") +
+      '">' +
+      '<link rel="canonical" href="https://tor-bjorn.com' +
+      (opts.path || "/writing/") +
+      '">';
+    if (opts.pageCss) {
+      head += '<link rel="stylesheet" href="/css/pages/contact.abc.css">';
+    }
+    var body = opts.noMain
+      ? "<div>no main here</div>"
+      : '<main id="main" tabindex="-1">' +
+        (opts.main ||
+          '<div class="content"><article class="article-card">' +
+            '<a href="/writing/a/">Post A</a></article></div>') +
+        "</main>";
+    return (
+      '<!doctype html><html lang="en"' +
+      (opts.exempt ? ' data-terminal-exempt="true"' : "") +
+      "><head>" +
+      head +
+      "</head><body>" +
+      body +
+      "</body></html>"
+    );
+  }
+
+  function mockFetch(html, resInit) {
+    resInit = resInit || {};
+    window.fetch = jest.fn(function () {
+      if (resInit.reject) {
+        return Promise.reject(new Error("network"));
+      }
+      return Promise.resolve({
+        ok: resInit.ok !== false,
+        redirected: !!resInit.redirected,
+        url: resInit.url || "/writing/",
+        text: function () {
+          return Promise.resolve(html);
+        },
+      });
+    });
+  }
+
+  function cwdVar() {
+    return document.documentElement.style.getPropertyValue("--terminal-cwd");
+  }
+
+  beforeEach(() => {
+    document.documentElement.setAttribute("data-layout", "terminal");
+    document.documentElement.setAttribute("lang", "en");
+    document.documentElement.style.removeProperty("--terminal-cwd");
+    document.documentElement.innerHTML =
+      "<head><title>Home · Site</title>" +
+      '<meta name="description" content="home">' +
+      '<link rel="canonical" href="https://tor-bjorn.com/">' +
+      "</head><body>" +
+      '<main id="main" tabindex="-1"><div class="content">HOME</div></main>' +
+      '<footer><div class="terminal-session"></div>' +
+      '<p class="terminal-tail"><input data-js="terminal-input" /></p></footer>' +
+      "</body>";
+
+    window.scrollTo = jest.fn();
+    window.requestAnimationFrame = jest.fn((cb) => cb());
+    window.TerminalLightbox = { refresh: jest.fn() };
+    // jsdom leaves history at "/"; pushState still records calls we assert on.
+    jest.spyOn(window.history, "pushState");
+  });
+
+  test("go() swaps #main, patches the title + cwd, and pushes state", async () => {
+    mockFetch(pageHtml());
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/writing/", {
+      cwd: "~/writing",
+    });
+
+    expect(swapped).toBe(true);
+    expect(document.querySelector("#main .article-card")).not.toBeNull();
+    expect(document.querySelector("#main").textContent).not.toContain("HOME");
+    expect(document.title).toBe("Writing · Site");
+    expect(cwdVar()).toBe('"~/writing"');
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      { terminalNav: true },
+      "",
+      "/writing/"
+    );
+  });
+
+  test("go() patches SEO meta from the fetched head", async () => {
+    mockFetch(pageHtml({ description: "all my posts" }));
+    loadModule();
+
+    await window.TerminalNav.go("/writing/", { cwd: "~/writing" });
+
+    const desc = document.head.querySelector('meta[name="description"]');
+    expect(desc.getAttribute("content")).toBe("all my posts");
+    const canonical = document.head.querySelector('link[rel="canonical"]');
+    expect(canonical.getAttribute("href")).toBe(
+      "https://tor-bjorn.com/writing/"
+    );
+  });
+
+  test("go() re-runs lightbox figure focusability after the swap", async () => {
+    mockFetch(pageHtml());
+    loadModule();
+
+    await window.TerminalNav.go("/writing/", { cwd: "~/writing" });
+
+    expect(window.TerminalLightbox.refresh).toHaveBeenCalled();
+  });
+
+  test("go() declines a terminal-exempt page (full-reload fallback)", async () => {
+    mockFetch(pageHtml({ exempt: true }));
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/ui-library/", {
+      cwd: "~/ui-library",
+    });
+
+    expect(swapped).toBe(false);
+    expect(document.querySelector("#main").textContent).toContain("HOME");
+    expect(window.history.pushState).not.toHaveBeenCalled();
+  });
+
+  test("go() declines a CSS-bundled special page", async () => {
+    mockFetch(pageHtml({ pageCss: true }));
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/contact/", {
+      cwd: "~/contact",
+    });
+
+    expect(swapped).toBe(false);
+    expect(document.querySelector("#main").textContent).toContain("HOME");
+  });
+
+  test("go() declines a document without #main", async () => {
+    mockFetch(pageHtml({ noMain: true }));
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/weird/", { cwd: "~/weird" });
+
+    expect(swapped).toBe(false);
+    expect(document.querySelector("#main").textContent).toContain("HOME");
+  });
+
+  test("go() falls back on a non-OK response and on a network error", async () => {
+    mockFetch(pageHtml(), { ok: false });
+    loadModule();
+    expect(await window.TerminalNav.go("/writing/", { cwd: "~/writing" })).toBe(
+      false
+    );
+
+    mockFetch(pageHtml(), { reject: true });
+    loadModule();
+    expect(await window.TerminalNav.go("/writing/", { cwd: "~/writing" })).toBe(
+      false
+    );
+  });
+
+  test("go() declines a redirect that leaves the origin", async () => {
+    mockFetch(pageHtml(), {
+      redirected: true,
+      url: "https://evil.example.com/writing/",
+    });
+    loadModule();
+
+    const swapped = await window.TerminalNav.go("/writing/", {
+      cwd: "~/writing",
+    });
+
+    expect(swapped).toBe(false);
+  });
+
+  test("go() derives the cwd from the URL when none is passed", async () => {
+    mockFetch(pageHtml({ path: "/works/" }));
+    loadModule();
+
+    await window.TerminalNav.go("/works/");
+
+    expect(cwdVar()).toBe('"~/works"');
+  });
+});

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2224,6 +2224,23 @@
       '[data-js="terminal-session"]'
     );
 
+    // Append-only history: the header's login prompts (`ls ~`, `ls settings/`)
+    // are the session's opening lines. Freeze them at the load-time cwd — pin
+    // each an inline --terminal-cwd — so a later append-only `cd` moves only the
+    // live prompt below, never this history above. The live input prompt keeps
+    // reading the global var, so it alone tracks the working directory.
+    if (isTerminalLayout()) {
+      var terminalLoadCwd = currentTerminalCwd();
+      document
+        .querySelectorAll("#topmenu .terminal-prompt:not(.terminal-prompt--cd)")
+        .forEach(function (headerPrompt) {
+          headerPrompt.style.setProperty(
+            "--terminal-cwd",
+            '"' + terminalLoadCwd + '"'
+          );
+        });
+    }
+
     // Session start, for `uptime` — captured when the command engine boots.
     var terminalSessionStart = Date.now();
 
@@ -2735,6 +2752,70 @@
           }
         });
       return out.length ? out : ["(no info here)"];
+    }
+
+    // Extract a cat'able rendering of a fetched post/page: the title, the
+    // preamble, then the body prose as text lines, with images collapsed to
+    // `[image N]` tokens (a terminal can't paint them). Walks the readable
+    // content root in document order and skips the chrome a `cat` shouldn't
+    // dump — breadcrumbs, tags, project-info (that's `ls --info`), related
+    // items. Returns [] if there's no content root to read.
+    function terminalExtractPostLines(doc) {
+      var root =
+        doc.querySelector("#main .content.post") ||
+        doc.querySelector("#main .content.page") ||
+        doc.querySelector("#main .content");
+      if (!root) {
+        return [];
+      }
+      // Related items and post tags have no wrapping container — they're
+      // BEM-classed siblings inside .content.post — so match by class prefix.
+      var SKIP =
+        ".application-breadcrumb, .project-info, [class*='related-'], " +
+        ".works-section, .works-post__tags, .post-tags-wrap, .lang-notice, nav";
+      var lines = [];
+      var imageN = 0;
+      var nodes = root.querySelectorAll(
+        "h1, h2, h3, h4, p, blockquote, li, figure, img"
+      );
+      for (var i = 0; i < nodes.length; i++) {
+        var el = nodes[i];
+        if (el.closest(SKIP)) {
+          continue;
+        }
+        var tag = el.tagName.toLowerCase();
+        if (tag === "figure" || tag === "img") {
+          // A bare img inside a figure is already counted by the figure.
+          if (tag === "img" && el.closest("figure")) {
+            continue;
+          }
+          imageN += 1;
+          var img = tag === "img" ? el : el.querySelector("img");
+          var cap = el.querySelector && el.querySelector("figcaption");
+          var label =
+            (img && img.getAttribute("alt")) ||
+            (cap ? cap.textContent.trim() : "");
+          lines.push(
+            label
+              ? "[image " + imageN + ": " + label + "]"
+              : "[image " + imageN + "]"
+          );
+          continue;
+        }
+        // A caption's text is carried by its figure token above; a paragraph
+        // nested in a blockquote/li is carried by that container's text.
+        if (
+          el.closest("figure") ||
+          (tag === "p" && el.closest("blockquote, li"))
+        ) {
+          continue;
+        }
+        var text = (el.textContent || "").replace(/\s+/g, " ").trim();
+        if (text) {
+          lines.push(text);
+        }
+      }
+      return lines;
     }
 
     function terminalLsOne(pathArg, showHidden) {
@@ -3474,15 +3555,16 @@
             };
           }
           // Real page first: a content post, or a readable page (about.md,
-          // newsletter.md) the home tour prints as `cat`. The page IS the file's
-          // output, so navigating there prints it.
+          // newsletter.md). Append-only: cat PRINTS the file into the buffer
+          // (fetch + extract text) — nothing above changes. (`open` still loads
+          // the real page, as the escape hatch.)
           var catHref =
             terminalContentTargetHref(catName) || resolveCdTarget(catName);
           if (catHref) {
             return {
               echo: input,
               lines: [],
-              action: { type: "navigate", url: catHref },
+              action: { type: "remote-cat", url: catHref },
             };
           }
           // Otherwise a pseudo-file (readme, colophon, secret, config, …).
@@ -4235,6 +4317,45 @@
               scrollTerminalToEnd();
             });
           break;
+        case "remote-cat":
+          // Append-only cat: fetch the post and print its readable text
+          // (images as [image N] tokens) into the scrollback below — nothing
+          // above the prompt changes. `open` is the escape hatch to the page.
+          if (typeof window.fetch !== "function") {
+            printTerminalLine(
+              "cat: cannot reach " + action.url,
+              "terminal-session__out"
+            );
+            break;
+          }
+          window
+            .fetch(action.url, { credentials: "same-origin" })
+            .then(function (res) {
+              return res.ok ? res.text() : Promise.reject();
+            })
+            .then(function (html) {
+              var doc = new DOMParser().parseFromString(html, "text/html");
+              var catLines = terminalExtractPostLines(doc);
+              if (!catLines.length) {
+                printTerminalLine(
+                  "cat: " + action.url + ": (empty)",
+                  "terminal-session__out"
+                );
+              } else {
+                catLines.forEach(function (line) {
+                  printTerminalLine(line, "terminal-session__out");
+                });
+              }
+              scrollTerminalToEnd();
+            })
+            .catch(function () {
+              printTerminalLine(
+                "cat: cannot reach " + action.url,
+                "terminal-session__out"
+              );
+              scrollTerminalToEnd();
+            });
+          break;
         case "flow":
           startTerminalFlow(action.flow);
           break;
@@ -4259,13 +4380,19 @@
       }
     }
 
-    function printTerminalLine(text, className) {
+    function printTerminalLine(text, className, frozenCwd) {
       if (!terminalSession) {
         return;
       }
       var line = document.createElement("span");
       line.className = "terminal-session__line " + className;
       line.textContent = text;
+      // Freeze the prompt's cwd on an echoed command so the scrollback keeps
+      // the directory it ran at — a later `cd` moves only the live prompt, not
+      // the history above (matching the pending-cd echo's own inline override).
+      if (frozenCwd) {
+        line.style.setProperty("--terminal-cwd", '"' + frozenCwd + '"');
+      }
       terminalSession.appendChild(line);
       // Remember the last *output* row, so `copy` with no argument grabs it.
       if (className.indexOf("terminal-session__out") !== -1) {
@@ -4323,7 +4450,14 @@
       }
       var result = runTerminalCommand(raw);
       if (result.echo) {
-        printTerminalLine(result.echo, "terminal-session__cmd");
+        // Freeze the echo at the cwd it ran at. applyTerminalAction (below)
+        // is what performs an append-only `cd`, so reading the cwd now — before
+        // it runs — captures where the command was actually typed.
+        printTerminalLine(
+          result.echo,
+          "terminal-session__cmd",
+          currentTerminalCwd()
+        );
       }
       var artLines =
         result.action && result.action.type === "art" ? terminalArtLines() : [];

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -5478,6 +5478,23 @@
       }
     }
 
+    // ^C: abort the current line — echo the caret marker, end any running flow,
+    // clear the input and the history cursor. Shared by the keydown handler and
+    // the mobile key bar (the on-screen keyboard has no Ctrl key).
+    function terminalCancelLine() {
+      if (!terminalInput) {
+        return;
+      }
+      printTerminalLine("^C", "terminal-session__out");
+      if (terminalFlow) {
+        endTerminalFlow();
+      }
+      terminalInput.value = "";
+      terminalHistoryCursor = null;
+      syncTerminalInputSize();
+      scrollTerminalToEnd();
+    }
+
     if (terminalInput) {
       // Typing invalidates the history-recall position.
       terminalInput.addEventListener("input", function () {
@@ -5505,14 +5522,7 @@
           }
           if (ctrlKey === "c") {
             e.preventDefault();
-            printTerminalLine("^C", "terminal-session__out");
-            if (terminalFlow) {
-              endTerminalFlow();
-            }
-            terminalInput.value = "";
-            terminalHistoryCursor = null;
-            syncTerminalInputSize();
-            scrollTerminalToEnd();
+            terminalCancelLine();
             return;
           }
         }
@@ -5568,6 +5578,91 @@
         }
       });
       syncTerminalInputSize();
+    }
+
+    // ----------------------------------------------------------------------
+    // Mobile key bar (accessory row)
+    // The round-4 keyboard fundamentals — ↑/↓ history recall, Tab completion,
+    // ^C — ride keys the on-screen keyboard doesn't have, so on touch (the
+    // primary context) they're unreachable. This bar surfaces them as tappable
+    // buttons while the prompt is focused, pinned just above the keyboard, plus
+    // a ⌄ jump-to-prompt. Purely additive: with no bar (or no JS) the terminal
+    // works exactly as before, just without recall/completion on mobile.
+    // ----------------------------------------------------------------------
+    var terminalKeybar = document.querySelector('[data-js="terminal-keybar"]');
+    if (terminalKeybar && terminalInput) {
+      // Each button reuses a handler already built above — the bar is only a
+      // touch surface for them, never a second implementation.
+      var KEYBAR_ACTIONS = {
+        prev: function () {
+          terminalRecallHistory(-1);
+        },
+        next: function () {
+          terminalRecallHistory(1);
+        },
+        tab: function () {
+          if (!terminalFlow) {
+            terminalCompleteInput();
+          }
+        },
+        cancel: terminalCancelLine,
+        bottom: scrollTerminalToEnd,
+      };
+
+      // Track the on-screen keyboard: with position:fixed;bottom:0 the bar sits
+      // BEHIND the keyboard on iOS Safari (plain fixed positions against the
+      // layout viewport, which the keyboard doesn't shrink). Translate it up by
+      // the overlap — layout viewport minus the visual viewport — so it rides on
+      // top of the keyboard. No visualViewport API → leave it pinned to the
+      // bottom (still usable, just possibly overlapped).
+      function positionKeybar() {
+        var vv = window.visualViewport;
+        if (!vv) {
+          return;
+        }
+        var overlap = window.innerHeight - vv.height - vv.offsetTop;
+        terminalKeybar.style.transform =
+          "translateY(" + -Math.max(0, overlap) + "px)";
+      }
+
+      // Keep focus on the input: a button that stole focus would close the
+      // keyboard. preventDefault on pointerdown stops the field from blurring,
+      // so the tap runs its action with the keyboard still up (and the bar,
+      // which hides on blur, still on screen to receive the click).
+      terminalKeybar.addEventListener("pointerdown", function (e) {
+        if (e.target.closest("[data-keybar]")) {
+          e.preventDefault();
+        }
+      });
+
+      terminalKeybar.addEventListener("click", function (e) {
+        var button = e.target.closest("[data-keybar]");
+        if (!button) {
+          return;
+        }
+        var action = KEYBAR_ACTIONS[button.getAttribute("data-keybar")];
+        if (action) {
+          action();
+          // Belt-and-braces: keep the keyboard up even if a browser dropped
+          // focus despite the pointerdown guard above.
+          terminalInput.focus();
+        }
+      });
+
+      // Shown only while the prompt is focused; CSS gates it to coarse pointers
+      // so desktop (which has the real keys) never sees it.
+      terminalInput.addEventListener("focus", function () {
+        terminalKeybar.classList.add("is-visible");
+        positionKeybar();
+      });
+      terminalInput.addEventListener("blur", function () {
+        terminalKeybar.classList.remove("is-visible");
+      });
+
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", positionKeybar);
+        window.visualViewport.addEventListener("scroll", positionKeybar);
+      }
     }
 
     // ----------------------------------------------------------------------

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3076,6 +3076,41 @@
 
     // Resolve a `cat` target to its pseudo-file lines, or null if there's no
     // such "file".
+    // The footer-meta row (©, status, legal links) is the site's colophon — it
+    // prints on the home tour under a `cat colophon` prompt, so typing it must
+    // reproduce it. Harvest the live footer (status items → KEY=value like the
+    // footer's own CSS; everything else → its visible text, sans the sr-only
+    // labels). Falls back to the static colophon when no footer is in the DOM.
+    function terminalColophonLines() {
+      var list = document.querySelector(".footer-meta__list");
+      if (!list) {
+        return TERMINAL_FILES.colophon.slice();
+      }
+      var out = [];
+      list.querySelectorAll(".footer-meta__item").forEach(function (item) {
+        var cat = item.querySelector("[data-category]");
+        if (cat) {
+          out.push(
+            cat.getAttribute("data-category").toUpperCase() +
+              "=" +
+              cat.textContent.replace(/\s+/g, " ").trim()
+          );
+          return;
+        }
+        var clone = item.cloneNode(true);
+        clone
+          .querySelectorAll(".sr-only, .footer-meta__label")
+          .forEach(function (n) {
+            n.parentNode.removeChild(n);
+          });
+        var text = clone.textContent.replace(/\s+/g, " ").trim();
+        if (text) {
+          out.push(text);
+        }
+      });
+      return out.length ? out : TERMINAL_FILES.colophon.slice();
+    }
+
     function terminalFile(name) {
       var key = String(name || "")
         .toLowerCase()
@@ -3083,6 +3118,10 @@
         .replace(/\.(txt|md)$/, "");
       if (key === "secrets") {
         key = "secret";
+      }
+      // colophon is the live footer, reproduced (see terminalColophonLines).
+      if (key === "colophon") {
+        return terminalColophonLines();
       }
       return TERMINAL_FILES[key] || null;
     }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2853,6 +2853,31 @@
       return map;
     }
 
+    // A typed `cd <post>` should reach the same pages `ls` lists — the content
+    // cards (works/writing posts) the nav tree can't know about. Resolve the
+    // path to absolute segments (relative to cwd), then match a content-card
+    // link by its full segments, so cd and ls agree on what exists.
+    function terminalContentTargetHref(dest) {
+      var wanted = terminalResolveSegments(dest);
+      if (wanted.length < 2) {
+        return null;
+      }
+      var wantedKey = wanted.join("/");
+      var match = null;
+      document
+        .querySelectorAll(".article-card a[href], .summary-card a[href]")
+        .forEach(function (link) {
+          if (match) {
+            return;
+          }
+          var segs = terminalHrefSegments(link.getAttribute("href"));
+          if (segs && segs.join("/") === wantedKey) {
+            match = link.getAttribute("href");
+          }
+        });
+      return match;
+    }
+
     function resolveCdTarget(dest) {
       var key = String(dest || "")
         .replace(/^\/+|\/+$/g, "")
@@ -2864,7 +2889,9 @@
         return terminalHomeUrl();
       }
       var targets = terminalNavTargets();
-      return targets[key] || null;
+      // Nav/footer directories first; then the current page's own content
+      // cards, so `cd` reaches any post `ls` just listed.
+      return targets[key] || terminalContentTargetHref(dest) || null;
     }
 
     // Languages from the settings language selector, keyed by code. The current

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2693,16 +2693,47 @@
     // in. Unknown path → an ls-style error; a real page whose contents can't
     // be listed from here (a different section) → a `cd` hint rather than a
     // bare empty result.
-    // The statusbar renders the loaded page as history: `~$ ls nav/` and
-    // `~$ ls settings/`. Make those real so typing them reproduces the header —
-    // the navigation and the settings toggles, listed. Both are menus, not
-    // places, so you `ls` them but don't `cd` into them (see the cd handler).
-    var TERMINAL_SECTION_DIRS = {
-      works: 1,
-      arbeten: 1,
-      writing: 1,
-      texter: 1,
-    };
+    // The terminal presents the site as a filesystem, and Hugo tells it what
+    // each top-level thing IS via the manifest emitted in head.html: a section
+    // is a `dir`, a standalone page a `file`, the contact form an `action`, a
+    // visual tool `exempt`. Parsed once; the client no longer guesses.
+    var terminalManifestCache = null;
+    function terminalManifest() {
+      if (terminalManifestCache) {
+        return terminalManifestCache;
+      }
+      terminalManifestCache = {};
+      var el = document.querySelector('[data-js="terminal-manifest"]');
+      if (el && el.textContent) {
+        try {
+          terminalManifestCache = JSON.parse(el.textContent) || {};
+        } catch (e) {
+          /* malformed manifest — fall back to the dir default below */
+        }
+      }
+      return terminalManifestCache;
+    }
+
+    // A top-level segment's kind. Deeper structural nodes (e.g. a section's
+    // `tags/`) aren't in the manifest and default to `dir` — they list children.
+    function terminalNodeKind(name) {
+      return terminalManifest()[String(name || "").toLowerCase()] || "dir";
+    }
+
+    // How an entry renders in a listing: dir → `name/`, file → `name.md`,
+    // action → `name` (a command), exempt → `name*` (a tool you `open`).
+    function terminalEntryLabel(name) {
+      switch (terminalNodeKind(name)) {
+        case "file":
+          return name + ".md";
+        case "action":
+          return name;
+        case "exempt":
+          return name + "*";
+        default:
+          return name + "/";
+      }
+    }
 
     function terminalNavEntries() {
       var seen = {};
@@ -2722,7 +2753,7 @@
             return;
           }
           seen[name] = true;
-          out.push(TERMINAL_SECTION_DIRS[name] ? name + "/" : name);
+          out.push(name === "home" ? "home" : terminalEntryLabel(name));
         });
       return out;
     }
@@ -2949,11 +2980,13 @@
         ];
       }
       var isCwd = targetSegs.join("/") === terminalCwdSegments().join("/");
-      // Structural children (sections, tags) are directories — trailing slash.
+      // Structural children render by kind (dir → `name/`, file → `name.md`,
+      // action → `name`, exempt → `name*`) — the manifest drives the top level;
+      // deeper nodes (a section's tags/) default to dir.
       var entries = Object.keys(node.children)
         .sort()
         .map(function (k) {
-          return node.children[k].name + "/";
+          return terminalEntryLabel(node.children[k].name);
         });
       if (isCwd) {
         // The page's own content (posts) are FILES: a post is a .md you `cat`,
@@ -3047,7 +3080,9 @@
         keys.forEach(function (key, i) {
           var last = i === keys.length - 1;
           lines.push(
-            prefix + (last ? "└── " : "├── ") + node.children[key].name + "/"
+            prefix +
+              (last ? "└── " : "├── ") +
+              terminalEntryLabel(node.children[key].name)
           );
           walk(node.children[key], prefix + (last ? "    " : "│   "));
         });
@@ -3489,13 +3524,61 @@
               action: null,
             };
           }
-          // Sections are directories — cd moves you into them (prompt only).
-          var sectionTarget = terminalNavTargets()[destKey];
-          if (sectionTarget) {
+          // A known top-level thing — classify by its manifest kind. Only a
+          // `dir` (a section) is somewhere you cd into; a file/action/tool is
+          // reached by cat/run/open, so point there instead of pretending.
+          var navHref = terminalNavTargets()[destKey];
+          var inManifest = Object.prototype.hasOwnProperty.call(
+            terminalManifest(),
+            destKey
+          );
+          if (navHref || inManifest) {
+            var destKind = terminalNodeKind(destKey);
+            if (destKind === "file") {
+              return {
+                echo: input,
+                lines: [
+                  "cd: not a directory: " +
+                    dest +
+                    " — try: cat " +
+                    destKey +
+                    ".md",
+                ],
+                action: null,
+              };
+            }
+            if (destKind === "action") {
+              return {
+                echo: input,
+                lines: [
+                  "cd: " +
+                    destKey +
+                    " is a command, not a directory — just run: " +
+                    destKey,
+                ],
+                action: null,
+              };
+            }
+            if (destKind === "exempt") {
+              return {
+                echo: input,
+                lines: [
+                  "cd: " +
+                    destKey +
+                    " is a visual tool — open it: open " +
+                    destKey,
+                ],
+                action: null,
+              };
+            }
+            // A directory — cd moves you into it (prompt only).
             return {
               echo: input,
               lines: [],
-              action: { type: "chdir", cwd: hrefToCwd(sectionTarget) },
+              action: {
+                type: "chdir",
+                cwd: hrefToCwd(navHref || "/" + destKey),
+              },
             };
           }
           // A post is a file — you cat it, you don't cd into it.
@@ -3820,7 +3903,10 @@
             }
           }
           // A section is a directory — you ls it, you don't cat it.
-          if (TERMINAL_SECTION_DIRS[catName]) {
+          if (
+            terminalNodeKind(catName) === "dir" &&
+            terminalManifest()[catName]
+          ) {
             return {
               echo: input,
               lines: [
@@ -5457,8 +5543,9 @@
           }
           var slug = segs[segs.length - 1];
           // A taxonomy/section card (e.g. works' "tags") is a directory, not a
-          // file — render it slug/ instead of slug.md.
-          if (slug === "tags" || TERMINAL_SECTION_DIRS[slug]) {
+          // file — render it slug/ instead of slug.md. A post isn't in the
+          // manifest, so it correctly falls through to a .md file.
+          if (slug === "tags" || terminalManifest()[slug] === "dir") {
             link.setAttribute("data-dir", slug);
           } else {
             link.setAttribute("data-slug", slug);

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3008,6 +3008,36 @@
       return out;
     }
 
+    // Recursive `ls -R`: per-directory blocks (a `path:` header, then that
+    // directory's children), walked depth-first from the given node. This is
+    // what the footer sitemap prints under its `ls -R ~/` prompt, so typing it
+    // reproduces the map (the flat, single-level `ls` only ever shows one dir).
+    function terminalLsRecursiveLines(node, path) {
+      var out = [];
+      function walk(n, p) {
+        var keys = Object.keys(n.children).sort();
+        out.push(p + ":");
+        if (keys.length) {
+          out.push(
+            keys
+              .map(function (k) {
+                return n.children[k].name + "/";
+              })
+              .join("  ")
+          );
+        }
+        out.push("");
+        keys.forEach(function (k) {
+          walk(n.children[k], p + "/" + n.children[k].name);
+        });
+      }
+      walk(node, path);
+      if (out.length && out[out.length - 1] === "") {
+        out.pop();
+      }
+      return out;
+    }
+
     // Whole-tree view for `tree`, drawn with ├──/└── connectors.
     function terminalTreeLines() {
       var root = terminalDirTree();
@@ -3636,9 +3666,39 @@
           var lsShowHidden = args.some(function (a) {
             return a.charAt(0) === "-" && a.charAt(1) !== "-" && /a/.test(a);
           });
+          var lsRecursive = args.some(function (a) {
+            return a.charAt(0) === "-" && a.charAt(1) !== "-" && /R/.test(a);
+          });
           var lsPaths = args.filter(function (a) {
             return a.charAt(0) !== "-";
           });
+          // `ls -R` walks the whole tree from the given dir (default ~), the
+          // recursive listing the footer sitemap is labelled with.
+          if (lsRecursive) {
+            var lsRSegs = lsPaths.length
+              ? terminalResolveSegments(lsPaths[0])
+              : [];
+            var lsRNode = terminalNodeAt(lsRSegs);
+            if (!lsRNode) {
+              return {
+                echo: input,
+                lines: [
+                  "ls: cannot access '" +
+                    lsPaths[0] +
+                    "': No such file or directory",
+                ],
+                action: null,
+              };
+            }
+            return {
+              echo: input,
+              lines: terminalLsRecursiveLines(
+                lsRNode,
+                lsRSegs.length ? "~/" + lsRSegs.join("/") : "~"
+              ),
+              action: null,
+            };
+          }
           if (lsLong.indexOf("--featured") !== -1) {
             return {
               echo: input,

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2259,6 +2259,13 @@
           "terminal-session__cmd",
           currentTerminalCwd()
         );
+        // Opening a fullscreen image should dismiss the mobile keyboard, so
+        // blur the prompt and DON'T call scrollTerminalToEnd (it would refocus
+        // the input and pop the keyboard straight back up). Scroll without
+        // refocusing; the lightbox itself moves focus to its close button.
+        if (terminalInput) {
+          terminalInput.blur();
+        }
         if (
           src &&
           window.TerminalLightbox &&
@@ -2266,7 +2273,9 @@
         ) {
           window.TerminalLightbox.openSrc(src, alt);
         }
-        scrollTerminalToEnd();
+        window.requestAnimationFrame(function () {
+          window.scrollTo(0, document.body.scrollHeight);
+        });
       });
     }
 

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2241,6 +2241,35 @@
         });
     }
 
+    // Clicking a cat'd [image N] token is a shortcut for a command you could
+    // have typed: it echoes `open <file>` into the scrollback (frozen at the
+    // current cwd, like any command) and opens the picture in the lightbox.
+    // Delegated, so it covers every image printed into the append-only buffer.
+    if (terminalSession) {
+      terminalSession.addEventListener("click", function (e) {
+        var btn = e.target.closest(".terminal-session__image");
+        if (!btn) {
+          return;
+        }
+        var file = btn.getAttribute("data-image-file") || "image";
+        var src = btn.getAttribute("data-image-src");
+        var alt = btn.getAttribute("data-image-alt");
+        printTerminalLine(
+          "open " + file,
+          "terminal-session__cmd",
+          currentTerminalCwd()
+        );
+        if (
+          src &&
+          window.TerminalLightbox &&
+          typeof window.TerminalLightbox.openSrc === "function"
+        ) {
+          window.TerminalLightbox.openSrc(src, alt);
+        }
+        scrollTerminalToEnd();
+      });
+    }
+
     // Session start, for `uptime` — captured when the command engine boots.
     var terminalSessionStart = Date.now();
 
@@ -2734,33 +2763,66 @@
       return out.length ? [out.join("  ")] : [emptyMsg];
     }
 
-    function terminalInfoLines() {
+    // The project meta (role / details / client) as "label: value" lines,
+    // read from any root (the live page for `ls --info`, or a fetched post for
+    // `cat`). Details is a <dl> of pairs → one line each ("year: 2016"); role
+    // and client are text paragraphs → joined onto their section's line.
+    function terminalInfoLinesFrom(root) {
       var out = [];
-      document
+      (root || document)
         .querySelectorAll(".project-info__section")
         .forEach(function (sec) {
           var title = sec.querySelector(".project-info__title");
-          var val = sec.querySelector(
-            ".project-info__text, .project-info__value"
-          );
-          if (title && val) {
-            out.push(
-              title.textContent.trim().toLowerCase() +
-                ": " +
-                val.textContent.trim()
-            );
+          if (!title) {
+            return;
+          }
+          var label = title.textContent.trim().toLowerCase();
+          var items = sec.querySelectorAll(".project-info__item");
+          if (items.length) {
+            items.forEach(function (item) {
+              var dt = item.querySelector(".project-info__label");
+              var dd = item.querySelector(".project-info__value");
+              if (dt && dd) {
+                out.push(
+                  dt.textContent.trim().toLowerCase() +
+                    ": " +
+                    dd.textContent.trim().replace(/\s+/g, " ")
+                );
+              }
+            });
+            return;
+          }
+          var texts = sec.querySelectorAll(".project-info__text");
+          if (texts.length) {
+            var joined = Array.prototype.map
+              .call(texts, function (t) {
+                return t.textContent.trim().replace(/\s+/g, " ");
+              })
+              .filter(Boolean)
+              .join(" — ");
+            if (joined) {
+              out.push(label + ": " + joined);
+            }
           }
         });
+      return out;
+    }
+
+    function terminalInfoLines() {
+      var out = terminalInfoLinesFrom(document);
       return out.length ? out : ["(no info here)"];
     }
 
-    // Extract a cat'able rendering of a fetched post/page: the title, the
-    // preamble, then the body prose as text lines, with images collapsed to
-    // `[image N]` tokens (a terminal can't paint them). Walks the readable
-    // content root in document order and skips the chrome a `cat` shouldn't
-    // dump — breadcrumbs, tags, project-info (that's `ls --info`), related
-    // items. Returns [] if there's no content root to read.
-    function terminalExtractPostLines(doc) {
+    // Extract a cat'able rendering of a fetched post/page as an ordered list of
+    // TOKENS — {text} for a prose line, {image, n, file, src, alt} for a figure
+    // (a terminal can't paint an image, so it prints a clickable [image N] token
+    // that opens the real picture). Walks the readable content root in document
+    // order, skipping the chrome a `cat` shouldn't dump (breadcrumbs, tags,
+    // related), then appends the project meta (role/details/client) so `cat`
+    // shows the whole file — the info you can't otherwise reach once a post is a
+    // file you never `cd` into. `base` resolves relative image URLs (the fetch
+    // URL). Returns [] if there's no content root.
+    function terminalExtractPostLines(doc, base) {
       var root =
         doc.querySelector("#main .content.post") ||
         doc.querySelector("#main .content.page") ||
@@ -2768,12 +2830,18 @@
       if (!root) {
         return [];
       }
+      var baseUrl;
+      try {
+        baseUrl = new URL(base || "/", window.location.href);
+      } catch (e) {
+        baseUrl = window.location.href;
+      }
       // Related items and post tags have no wrapping container — they're
       // BEM-classed siblings inside .content.post — so match by class prefix.
       var SKIP =
         ".application-breadcrumb, .project-info, [class*='related-'], " +
         ".works-section, .works-post__tags, .post-tags-wrap, .lang-notice, nav";
-      var lines = [];
+      var tokens = [];
       var imageN = 0;
       var nodes = root.querySelectorAll(
         "h1, h2, h3, h4, p, blockquote, li, figure, img"
@@ -2795,11 +2863,36 @@
           var label =
             (img && img.getAttribute("alt")) ||
             (cap ? cap.textContent.trim() : "");
-          lines.push(
-            label
-              ? "[image " + imageN + ": " + label + "]"
-              : "[image " + imageN + "]"
-          );
+          // Prefer the figure's data-lightbox (the full-res URL the on-page
+          // lightbox uses); fall back to the <img> src. The filename (for the
+          // `open <file>` echo) comes from the img src.
+          var fileSrc = img ? img.getAttribute("src") || "" : "";
+          var lbSrc =
+            (tag === "figure" && el.getAttribute("data-lightbox")) || fileSrc;
+          var file =
+            (fileSrc || lbSrc || "")
+              .split("?")[0]
+              .split("/")
+              .filter(Boolean)
+              .pop() || "image-" + imageN;
+          // Strip Hugo's image-processing suffix (foo_hu_<hash>.jpg → foo.jpg)
+          // so the echoed `open <file>` reads like the source filename.
+          file = file.replace(/_hu[_a-f0-9]*(\.[a-z0-9]+)$/i, "$1");
+          var src = "";
+          if (lbSrc) {
+            try {
+              src = new URL(lbSrc, baseUrl).href;
+            } catch (e) {
+              src = lbSrc;
+            }
+          }
+          tokens.push({
+            image: true,
+            n: imageN,
+            file: file,
+            src: src,
+            alt: label,
+          });
           continue;
         }
         // A caption's text is carried by its figure token above; a paragraph
@@ -2812,10 +2905,15 @@
         }
         var text = (el.textContent || "").replace(/\s+/g, " ").trim();
         if (text) {
-          lines.push(text);
+          tokens.push({ text: text });
         }
       }
-      return lines;
+      // Append the project meta as its own trailing block — cat shows the whole
+      // file, so the role/details/client you set in front matter come along.
+      terminalInfoLinesFrom(root).forEach(function (line) {
+        tokens.push({ text: line });
+      });
+      return tokens;
     }
 
     function terminalLsOne(pathArg, showHidden) {
@@ -3489,6 +3587,21 @@
             };
           }
           if (lsLong.indexOf("--info") !== -1) {
+            // `--info` is a lens on the page you're viewing. For a post you
+            // haven't opened, its meta now lives in the file — point at cat
+            // rather than the misleading "(no info here)".
+            if (lsPaths.length) {
+              return {
+                echo: input,
+                lines: [
+                  "ls: --info reads the current page — for " +
+                    lsPaths[0] +
+                    " try: cat " +
+                    lsPaths[0],
+                ],
+                action: null,
+              };
+            }
             return { echo: input, lines: terminalInfoLines(), action: null };
           }
           if (lsLong.indexOf("--images") !== -1) {
@@ -4367,15 +4480,19 @@
             })
             .then(function (html) {
               var doc = new DOMParser().parseFromString(html, "text/html");
-              var catLines = terminalExtractPostLines(doc);
-              if (!catLines.length) {
+              var catTokens = terminalExtractPostLines(doc, action.url);
+              if (!catTokens.length) {
                 printTerminalLine(
                   "cat: " + catLabel + ": (empty)",
                   "terminal-session__out"
                 );
               } else {
-                catLines.forEach(function (line) {
-                  printTerminalLine(line, "terminal-session__out");
+                catTokens.forEach(function (tok) {
+                  if (tok.image) {
+                    printTerminalImageLine(tok);
+                  } else {
+                    printTerminalLine(tok.text, "terminal-session__out");
+                  }
                 });
               }
               scrollTerminalToEnd();
@@ -4433,6 +4550,28 @@
       if (className.indexOf("terminal-session__out") !== -1) {
         lastTerminalOutput = text;
       }
+    }
+
+    // A cat'd image prints as a clickable [image N] token: a terminal can't
+    // paint the picture, but the token carries the real image URL and filename,
+    // so clicking it echoes `open <file>` and opens the picture in the lightbox
+    // (see the terminalSession click handler). Keyboard-reachable as a button.
+    function printTerminalImageLine(tok) {
+      if (!terminalSession) {
+        return;
+      }
+      var line = document.createElement("span");
+      line.className = "terminal-session__line terminal-session__out";
+      var btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "terminal-session__image";
+      btn.textContent =
+        "[image " + tok.n + (tok.alt ? ": " + tok.alt : "") + "]";
+      btn.setAttribute("data-image-src", tok.src || "");
+      btn.setAttribute("data-image-file", tok.file || "");
+      btn.setAttribute("data-image-alt", tok.alt || "");
+      line.appendChild(btn);
+      terminalSession.appendChild(line);
     }
 
     // A short, bounded "digital rain" burst for `matrix` — a few deferred

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -4841,6 +4841,26 @@
 
     printPendingTerminalCd();
 
+    // Posts are files: stamp each content card's title link with its slug so the
+    // terminal CSS can render it as `slug.md` (an ls-row filename) instead of the
+    // human title. The title stays in the DOM for screen readers + other layouts;
+    // terminal.css just hides it and shows the slug. Re-run after an in-place nav.
+    function terminalStampSlugs() {
+      document
+        .querySelectorAll(
+          ".summary-card__title a[href], .article-card__title a[href], " +
+            ".related-items__item .type-headline-4 a[href]"
+        )
+        .forEach(function (link) {
+          var segs = terminalHrefSegments(link.getAttribute("href"));
+          if (segs && segs.length) {
+            link.setAttribute("data-slug", segs[segs.length - 1]);
+          }
+        });
+    }
+    terminalStampSlugs();
+    window.TerminalSlugs = { refresh: terminalStampSlugs };
+
     // Terminal layout: statusbar quick toggle that shows the resolved mode as
     // a bracketed word; clicking flips light/dark (an explicit choice, so it
     // replaces "system"). The label tracks every mode change via the

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -770,6 +770,10 @@
   // half-finished contact/subscribe flow on the way out.
   var terminalFlowReset = null;
 
+  // Bridge to the command engine (nested in a later scope): it publishes an
+  // `exitTargetUrl()` here so exit can land you where you cd'd to.
+  var terminalNavApi = null;
+
   // Leave the terminal: back to the snapshotted layout, and restore the
   // snapshotted typography if the pairing's choice (technical) is still
   // active — a manual typography change inside the terminal is respected.
@@ -802,6 +806,15 @@
         // storage was cleared): fall back to the site default rather than
         // leaving the pairing's mono behind.
         setTypography("editorial");
+      }
+    }
+    // Exit lands you where you cd'd to: if the live cwd points at a page other
+    // than the one loaded, navigate there in the now-restored layout. (An
+    // append-only `cd` only moved the prompt, so the URL never followed.)
+    if (terminalNavApi && typeof terminalNavApi.exitTargetUrl === "function") {
+      var exitUrl = terminalNavApi.exitTargetUrl();
+      if (exitUrl) {
+        window.location.href = exitUrl;
       }
     }
   }
@@ -5721,6 +5734,21 @@
     }
     terminalStampSlugs();
     window.TerminalSlugs = { refresh: terminalStampSlugs };
+
+    // Publish the exit target for the top-level exitTerminal(): if you've cd'd
+    // away (live cwd ≠ the loaded page's cwd), exit navigates to that page in
+    // the restored layout. An in-place action (open) leaves live === page, so
+    // this returns null and exit just drops back to the current URL.
+    terminalNavApi = {
+      exitTargetUrl: function () {
+        var live = terminalCwdSegments();
+        var page = terminalPageCwdSegments();
+        if (!live.length || live.join("/") === page.join("/")) {
+          return null;
+        }
+        return terminalCwdUrl(live);
+      },
+    };
 
     // Terminal layout: statusbar quick toggle that shows the resolved mode as
     // a bracketed word; clicking flips light/dark (an explicit choice, so it

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2743,6 +2743,15 @@
       if (rawArg === "settings") {
         return [terminalSettingsEntries().join("  ")];
       }
+      // `ls featured` — the curated selection the home page prints — is a view,
+      // harvested from the page's cards (so the header's `ls 'featured'` line is
+      // reproducible by typing it).
+      if (rawArg === "featured") {
+        return terminalHarvestFiles(
+          ".summary-card a[href], .article-card a[href]",
+          "(nothing featured here)"
+        );
+      }
       var targetSegs = terminalResolveSegments(pathArg);
       var node = terminalNodeAt(targetSegs);
       if (!node) {
@@ -3407,22 +3416,37 @@
               action: null,
             };
           }
-          var fileLines = terminalFile(args[0]);
-          if (fileLines) {
-            return { echo: input, lines: fileLines.slice(), action: null };
+          var catName = args[0].replace(/\.(md|txt)$/i, "").toLowerCase();
+          // A section is a directory — you ls it, you don't cat it.
+          if (TERMINAL_SECTION_DIRS[catName]) {
+            return {
+              echo: input,
+              lines: [
+                "cat: " +
+                  catName +
+                  ": Is a directory — try: ls " +
+                  catName +
+                  "/",
+              ],
+              action: null,
+            };
           }
-          // Not a pseudo-file — maybe a content post. `cat`-ing a post opens its
-          // page: the post renders as the cat output (`cat 'title.md'` + body),
-          // so navigating there IS printing the file. Strip the .md first.
-          var catHref = terminalContentTargetHref(
-            args[0].replace(/\.(md|txt)$/i, "")
-          );
+          // Real page first: a content post, or a readable page (about.md,
+          // newsletter.md) the home tour prints as `cat`. The page IS the file's
+          // output, so navigating there prints it.
+          var catHref =
+            terminalContentTargetHref(catName) || resolveCdTarget(catName);
           if (catHref) {
             return {
               echo: input,
               lines: [],
               action: { type: "navigate", url: catHref },
             };
+          }
+          // Otherwise a pseudo-file (readme, colophon, secret, config, …).
+          var fileLines = terminalFile(args[0]);
+          if (fileLines) {
+            return { echo: input, lines: fileLines.slice(), action: null };
           }
           return {
             echo: input,

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2691,6 +2691,45 @@
       ];
     }
 
+    // Filtered `ls` views — the same tool, different lens. `--featured` lists
+    // the curated cards on the current page (home's featured works); `--related`
+    // lists a post's sibling projects; `--info` prints a post's role/details.
+    // All harvested from the current page's DOM — a page's own sequence.
+    function terminalHarvestFiles(selector, emptyMsg) {
+      var out = [];
+      document.querySelectorAll(selector).forEach(function (a) {
+        var segs = terminalHrefSegments(a.getAttribute("href"));
+        if (!segs || segs.length < 2) {
+          return;
+        }
+        var file = segs[segs.length - 1] + ".md";
+        if (out.indexOf(file) === -1) {
+          out.push(file);
+        }
+      });
+      return out.length ? [out.join("  ")] : [emptyMsg];
+    }
+
+    function terminalInfoLines() {
+      var out = [];
+      document
+        .querySelectorAll(".project-info__section")
+        .forEach(function (sec) {
+          var title = sec.querySelector(".project-info__title");
+          var val = sec.querySelector(
+            ".project-info__text, .project-info__value"
+          );
+          if (title && val) {
+            out.push(
+              title.textContent.trim().toLowerCase() +
+                ": " +
+                val.textContent.trim()
+            );
+          }
+        });
+      return out.length ? out : ["(no info here)"];
+    }
+
     function terminalLsOne(pathArg, showHidden) {
       // nav/ and settings/ are global menus, reachable from any cwd — match the
       // raw argument (~/nav, nav/, nav) before resolving relative to the cwd.
@@ -3317,12 +3356,41 @@
           };
         case "ls":
         case "dir": {
+          // Long filter flags (--featured/--related/--info) are separate lenses;
+          // short flags (-a) reveal hidden entries. Keep them apart so "--featured"
+          // (which contains an "a") isn't misread as -a.
+          var lsLong = args.filter(function (a) {
+            return a.indexOf("--") === 0;
+          });
           var lsShowHidden = args.some(function (a) {
-            return a.charAt(0) === "-" && /a/.test(a);
+            return a.charAt(0) === "-" && a.charAt(1) !== "-" && /a/.test(a);
           });
           var lsPaths = args.filter(function (a) {
             return a.charAt(0) !== "-";
           });
+          if (lsLong.indexOf("--featured") !== -1) {
+            return {
+              echo: input,
+              lines: terminalHarvestFiles(
+                ".summary-card a[href], .article-card a[href]",
+                "(nothing featured here)"
+              ),
+              action: null,
+            };
+          }
+          if (lsLong.indexOf("--related") !== -1) {
+            return {
+              echo: input,
+              lines: terminalHarvestFiles(
+                ".related-items__item .type-headline-4 a[href]",
+                "(no related files)"
+              ),
+              action: null,
+            };
+          }
+          if (lsLong.indexOf("--info") !== -1) {
+            return { echo: input, lines: terminalInfoLines(), action: null };
+          }
           return {
             echo: input,
             lines: terminalLsLines(lsPaths, lsShowHidden),

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2586,8 +2586,21 @@
         return terminalDirTreeCache;
       }
       var root = { name: "~", href: terminalHomeUrl(), children: {} };
+      // Seed the top level from the manifest — the authoritative list of what's
+      // in ~ (including footer-only sections like legal that carry no nav link,
+      // and without the noise of harvesting every footer href e.g. index.xml).
+      var manifest = terminalManifest();
+      Object.keys(manifest).forEach(function (seg) {
+        root.children[seg] = {
+          name: seg,
+          href: manifest[seg].url || null,
+          children: {},
+        };
+      });
+      // Then harvest the (relative) nav links for deeper structure — a section's
+      // tags/ and the like.
       var links = document.querySelectorAll(
-        ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href], footer a[href]"
+        ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href]"
       );
       links.forEach(function (link) {
         var segs = terminalHrefSegments(link.getAttribute("href"));
@@ -2733,7 +2746,15 @@
     // A top-level segment's kind. Deeper structural nodes (e.g. a section's
     // `tags/`) aren't in the manifest and default to `dir` — they list children.
     function terminalNodeKind(name) {
-      return terminalManifest()[String(name || "").toLowerCase()] || "dir";
+      var e = terminalManifest()[String(name || "").toLowerCase()];
+      return (e && e.kind) || "dir";
+    }
+
+    // A top-level segment's URL from the manifest — lets the terminal reach a
+    // footer-only section (legal) that has no nav link to resolve against.
+    function terminalManifestUrl(name) {
+      var e = terminalManifest()[String(name || "").toLowerCase()];
+      return (e && e.url) || null;
     }
 
     // How an entry renders in a listing: dir → `name/`, file → `name.md`,
@@ -3329,8 +3350,14 @@
       }
       var targets = terminalNavTargets();
       // Nav/footer directories first; then the current page's own content
-      // cards, so `cd` reaches any post `ls` just listed.
-      return targets[key] || terminalContentTargetHref(dest) || null;
+      // cards (so `cd` reaches any post `ls` just listed); then the manifest URL
+      // (so a footer-only section like legal resolves even without a nav link).
+      return (
+        targets[key] ||
+        terminalContentTargetHref(dest) ||
+        terminalManifestUrl(key) ||
+        null
+      );
     }
 
     // The URL for a cwd's segments — the section's nav href as the base, then
@@ -5684,7 +5711,8 @@
           // A taxonomy/section card (e.g. works' "tags") is a directory, not a
           // file — render it slug/ instead of slug.md. A post isn't in the
           // manifest, so it correctly falls through to a .md file.
-          if (slug === "tags" || terminalManifest()[slug] === "dir") {
+          var slugEntry = terminalManifest()[slug];
+          if (slug === "tags" || (slugEntry && slugEntry.kind === "dir")) {
             link.setAttribute("data-dir", slug);
           } else {
             link.setAttribute("data-slug", slug);

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3184,10 +3184,13 @@
             dest === ".." ||
             destKey === "home"
           ) {
+            // Append-only: cd just moves you (changes the prompt). It doesn't
+            // load a page or print anything — like a real shell. You `ls`/`cat`
+            // to see things, and nothing above the prompt ever changes.
             return {
               echo: input,
               lines: [],
-              action: { type: "navigate", url: terminalHomeUrl() },
+              action: { type: "chdir", cwd: "~" },
             };
           }
           // nav/ and settings/ are menus, not places — list them, don't enter.
@@ -3204,13 +3207,13 @@
               action: null,
             };
           }
-          // Sections are directories — cd enters them.
+          // Sections are directories — cd moves you into them (prompt only).
           var sectionTarget = terminalNavTargets()[destKey];
           if (sectionTarget) {
             return {
               echo: input,
               lines: [],
-              action: { type: "navigate", url: sectionTarget },
+              action: { type: "chdir", cwd: hrefToCwd(sectionTarget) },
             };
           }
           // A post is a file — you cat it, you don't cd into it.
@@ -3416,6 +3419,28 @@
               lines: [figs ? figs + " images" : "(no images here)"],
               action: null,
             };
+          }
+          // Append-only: listing the section you've cd'd into but haven't
+          // loaded (cd only moved the prompt) — fetch it and print the files
+          // below, without touching anything above.
+          if (!lsPaths.length && !lsLong.length) {
+            var lsSegs = terminalCwdSegments();
+            // The current page's DOM has no cards for this cwd (you cd'd here
+            // but haven't loaded it) → fetch the section and print it below.
+            if (lsSegs.length && !terminalPageContentSlugs(lsSegs).length) {
+              var lsUrl = resolveCdTarget(lsSegs[0]);
+              if (lsUrl) {
+                return {
+                  echo: input,
+                  lines: [],
+                  action: {
+                    type: "remote-ls",
+                    url: lsUrl,
+                    cwd: "~/" + lsSegs[0],
+                  },
+                };
+              }
+            }
           }
           return {
             echo: input,
@@ -4152,6 +4177,63 @@
           if (action.url) {
             navigateTerminal(action);
           }
+          break;
+        case "chdir":
+          // Append-only cd: move the prompt only. --terminal-cwd drives the
+          // PS1, so setting it (inline, wins over head.html's :root rule) is the
+          // whole move. No fetch, no swap, no scroll jump — nothing above the
+          // prompt changes.
+          document.documentElement.style.setProperty(
+            "--terminal-cwd",
+            '"' + (action.cwd || "~") + '"'
+          );
+          break;
+        case "remote-ls":
+          // Append-only ls: fetch the section you've cd'd into and print its
+          // files into the scrollback below — nothing above moves.
+          if (typeof window.fetch !== "function") {
+            printTerminalLine(
+              "ls: cannot reach " + action.url,
+              "terminal-session__out"
+            );
+            break;
+          }
+          window
+            .fetch(action.url, { credentials: "same-origin" })
+            .then(function (res) {
+              return res.ok ? res.text() : Promise.reject();
+            })
+            .then(function (html) {
+              var doc = new DOMParser().parseFromString(html, "text/html");
+              var files = [];
+              doc
+                .querySelectorAll(
+                  ".summary-card a[href], .article-card a[href]"
+                )
+                .forEach(function (a) {
+                  var segs = terminalHrefSegments(a.getAttribute("href"));
+                  if (!segs || segs.length < 2) {
+                    return;
+                  }
+                  var slug = segs[segs.length - 1];
+                  var entry = slug === "tags" ? "tags/" : slug + ".md";
+                  if (files.indexOf(entry) === -1) {
+                    files.push(entry);
+                  }
+                });
+              printTerminalLine(
+                files.length ? files.join("  ") : "(empty)",
+                "terminal-session__out"
+              );
+              scrollTerminalToEnd();
+            })
+            .catch(function () {
+              printTerminalLine(
+                "ls: cannot reach " + action.url,
+                "terminal-session__out"
+              );
+              scrollTerminalToEnd();
+            });
           break;
         case "flow":
           startTerminalFlow(action.flow);

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2609,9 +2609,25 @@
       return root;
     }
 
-    // The current working directory as lowercased path segments ("~" → []).
+    // The current (live) working directory as lowercased path segments.
     function terminalCwdSegments() {
-      var rest = currentTerminalCwd().replace(/^~\/?/, "");
+      return terminalSegmentsOf(currentTerminalCwd());
+    }
+
+    // The LOADED page's cwd (the frozen --terminal-cwd the server set), as
+    // segments. It differs from the live cwd once you've cd'd away — which is
+    // how `ls` knows the current DOM can't list here and it must fetch.
+    function terminalPageCwdSegments() {
+      var v = window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue("--terminal-cwd")
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      return terminalSegmentsOf(v || "~");
+    }
+
+    function terminalSegmentsOf(cwd) {
+      var rest = String(cwd || "").replace(/^~\/?/, "");
       return rest
         ? rest
             .split("/")
@@ -3317,6 +3333,25 @@
       return targets[key] || terminalContentTargetHref(dest) || null;
     }
 
+    // The URL for a cwd's segments — the section's nav href as the base, then
+    // the deeper path appended (so ~/works/tags/experimental → /works/tags/
+    // experimental/). Language prefix rides along in the base. Used to fetch a
+    // nested directory the append-only prompt sits in but hasn't loaded.
+    function terminalCwdUrl(segs) {
+      if (!segs || !segs.length) {
+        return terminalHomeUrl();
+      }
+      var base = resolveCdTarget(segs[0]);
+      if (!base) {
+        return null;
+      }
+      return (
+        base.replace(/\/+$/, "") +
+        (segs.length > 1 ? "/" + segs.slice(1).join("/") : "") +
+        "/"
+      );
+    }
+
     // Languages from the settings language selector, keyed by code. The current
     // language's radio has no data-language-href; every other one carries the
     // translated page's URL (or a homepage fallback).
@@ -3520,6 +3555,39 @@
                   " is a menu, not a directory — try: ls " +
                   destKey +
                   "/",
+              ],
+              action: null,
+            };
+          }
+          // A path into a section's tags/ hierarchy. `<section>/tags` (the
+          // index) and `<section>/tags/<tag>` (a term) are directories you cd
+          // into; a post reached through a tag (`…/tags/<tag>/<slug>`) is a file
+          // whose real home is the section — cat it.
+          var cdSegs = terminalResolveSegments(dest);
+          if (
+            cdSegs.length >= 2 &&
+            cdSegs[1] === "tags" &&
+            terminalNodeKind(cdSegs[0]) === "dir"
+          ) {
+            if (cdSegs.length <= 3) {
+              return {
+                echo: input,
+                lines: [],
+                action: { type: "chdir", cwd: "~/" + cdSegs.join("/") },
+              };
+            }
+            var cdTagSlug = cdSegs[cdSegs.length - 1].replace(
+              /\.(md|txt)$/i,
+              ""
+            );
+            return {
+              echo: input,
+              lines: [
+                "cd: not a directory: " +
+                  dest +
+                  " — try: cat " +
+                  cdTagSlug +
+                  ".md",
               ],
               action: null,
             };
@@ -3830,15 +3898,18 @@
               action: null,
             };
           }
-          // Append-only: listing the section you've cd'd into but haven't
-          // loaded (cd only moved the prompt) — fetch it and print the files
-          // below, without touching anything above.
+          // Append-only: listing the section (or a nested tags dir) you've cd'd
+          // into but haven't loaded (cd only moved the prompt) — fetch it and
+          // print below, without touching anything above.
           if (!lsPaths.length && !lsLong.length) {
             var lsSegs = terminalCwdSegments();
-            // The current page's DOM has no cards for this cwd (you cd'd here
-            // but haven't loaded it) → fetch the section and print it below.
-            if (lsSegs.length && !terminalPageContentSlugs(lsSegs).length) {
-              var lsUrl = resolveCdTarget(lsSegs[0]);
+            // You've cd'd away from the loaded page (live cwd ≠ page cwd), so the
+            // current DOM can't list here → fetch that path and print it below.
+            if (
+              lsSegs.length &&
+              lsSegs.join("/") !== terminalPageCwdSegments().join("/")
+            ) {
+              var lsUrl = terminalCwdUrl(lsSegs);
               if (lsUrl) {
                 return {
                   echo: input,
@@ -3846,7 +3917,7 @@
                   action: {
                     type: "remote-ls",
                     url: lsUrl,
-                    cwd: "~/" + lsSegs[0],
+                    cwd: "~/" + lsSegs.join("/"),
                   },
                 };
               }
@@ -3891,7 +3962,12 @@
               action: null,
             };
           }
-          var catName = args[0].replace(/\.(md|txt)$/i, "").toLowerCase();
+          // A trailing @ is the symlink marker `ls` prints in a tag dir — not
+          // part of the name, so drop it before resolving.
+          var catName = args[0]
+            .replace(/@$/, "")
+            .replace(/\.(md|txt)$/i, "")
+            .toLowerCase();
           // An explicit `.txt` is a text blurb (readme, the newsletter/colophon
           // footer blocks) — resolve it as a pseudo-file BEFORE a same-named
           // page (e.g. `cat newsletter.txt` is the blurb; `cat newsletter.md`
@@ -3946,16 +4022,20 @@
           if (catSegs.length >= 2) {
             var catBase = resolveCdTarget(catSegs[0]);
             if (catBase) {
+              // A post reached through a tag path is a symlink — its real file
+              // lives in the section, so cat resolves to <section>/<slug>, not
+              // the literal .../tags/<tag>/<slug> (which 404s).
+              var catRest =
+                catSegs.indexOf("tags") !== -1
+                  ? [catSegs[catSegs.length - 1]]
+                  : catSegs.slice(1);
               return {
                 echo: input,
                 lines: [],
                 action: {
                   type: "remote-cat",
                   url:
-                    catBase.replace(/\/+$/, "") +
-                    "/" +
-                    catSegs.slice(1).join("/") +
-                    "/",
+                    catBase.replace(/\/+$/, "") + "/" + catRest.join("/") + "/",
                   name: args[0],
                 },
               };
@@ -4518,6 +4598,80 @@
       });
     }
 
+    // Render a fetched directory listing by what the cwd IS:
+    //  - a tags index (~/works/tags)     → the tags, as `<tag>/` dirs
+    //  - a tag term (~/works/tags/<tag>)  → the posts, as `<slug>.md@` symlinks
+    //    (their canonical file lives up in the section, not here)
+    //  - a section (~/works)              → the posts as `<slug>.md`, plus a
+    //    `tags/` entry when the page links to a tag index
+    function terminalRemoteLsEntries(doc, cwd) {
+      var segs = String(cwd || "")
+        .replace(/^~\/?/, "")
+        .split("/")
+        .filter(Boolean);
+      var tagsIdx = segs.indexOf("tags");
+      var isTagsIndex = segs.length > 0 && segs[segs.length - 1] === "tags";
+      var isTerm = tagsIdx !== -1 && tagsIdx < segs.length - 1;
+      var out = [];
+      var seen = {};
+      var add = function (entry, key) {
+        if (!seen[key]) {
+          seen[key] = 1;
+          out.push(entry);
+        }
+      };
+
+      if (isTagsIndex) {
+        doc.querySelectorAll('a[href*="/tags/"]').forEach(function (a) {
+          var hs = terminalHrefSegments(a.getAttribute("href"));
+          var ti = hs ? hs.indexOf("tags") : -1;
+          // Only a term link tags/<tag> (the tag the last segment).
+          if (ti === -1 || ti !== hs.length - 2) {
+            return;
+          }
+          var tag = hs[hs.length - 1];
+          if (tag && tag !== "index" && tag !== "page") {
+            add(tag + "/", tag);
+          }
+        });
+        return out;
+      }
+
+      doc
+        .querySelectorAll(".summary-card a[href], .article-card a[href]")
+        .forEach(function (a) {
+          var hs = terminalHrefSegments(a.getAttribute("href"));
+          if (!hs || hs.length < 2) {
+            return;
+          }
+          var slug = hs[hs.length - 1];
+          if (slug === "tags") {
+            return;
+          }
+          // In a tag term the post's real file is up in the section, so it's a
+          // symlink (marked with @), not a copy. In the section it's the file.
+          add(isTerm ? slug + ".md@" : slug + ".md", slug);
+        });
+
+      // A section lists its own `tags/` directory only when it actually has
+      // one — i.e. the page links to `<section>/tags/`. Works has real tag term
+      // pages; writing uses `?tag=` filters, so it correctly gets no tags/.
+      if (!isTerm && segs.length) {
+        var section = segs[0];
+        var hasTags = false;
+        doc.querySelectorAll('a[href*="/tags"]').forEach(function (a) {
+          var hs = terminalHrefSegments(a.getAttribute("href"));
+          if (hs && hs.length === 2 && hs[0] === section && hs[1] === "tags") {
+            hasTags = true;
+          }
+        });
+        if (hasTags) {
+          add("tags/", "tags");
+        }
+      }
+      return out;
+    }
+
     function applyTerminalAction(action) {
       if (!action) {
         return;
@@ -4676,22 +4830,7 @@
             })
             .then(function (html) {
               var doc = new DOMParser().parseFromString(html, "text/html");
-              var files = [];
-              doc
-                .querySelectorAll(
-                  ".summary-card a[href], .article-card a[href]"
-                )
-                .forEach(function (a) {
-                  var segs = terminalHrefSegments(a.getAttribute("href"));
-                  if (!segs || segs.length < 2) {
-                    return;
-                  }
-                  var slug = segs[segs.length - 1];
-                  var entry = slug === "tags" ? "tags/" : slug + ".md";
-                  if (files.indexOf(entry) === -1) {
-                    files.push(entry);
-                  }
-                });
+              var files = terminalRemoteLsEntries(doc, action.cwd);
               if (files.length) {
                 printTerminalLine(files.join("  "), "terminal-session__out");
               } else if (doc.querySelector(".content.post, .content.page")) {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3693,6 +3693,60 @@
       }
     }
 
+    // A typed cd can only swap in place for a same-origin target.
+    function isSameOriginUrl(href) {
+      try {
+        return (
+          new URL(href, window.location.href).origin === window.location.origin
+        );
+      } catch (err) {
+        return false;
+      }
+    }
+
+    // Full-reload navigation — the click-path behaviour: stash the `cd` echo so
+    // the destination prints it above its first prompt, then load. The fallback
+    // for every typed nav that can't (or shouldn't) swap in place.
+    function fullReloadNavigate(action) {
+      if (action.cd !== false) {
+        stashTerminalCd(currentTerminalCwd(), hrefToCwd(action.url));
+      }
+      try {
+        window.location.assign(action.url);
+      } catch (err) {
+        window.location.href = action.url;
+      }
+    }
+
+    // Typed navigation. Clicks still full-reload (see the click handler below);
+    // only typed cd/resume/home reach here. Swap in place when we can — terminal
+    // layout, same-origin, a real directory (home stays a full reload, it's a
+    // CSS-bundled page), not a language switch (cd:false) — and hand off to
+    // terminal-nav.js, which makes the final call after fetching (it declines
+    // special pages it can only detect from the response). If it declines, isn't
+    // present, or nothing qualifies, fall back to a full reload. The command
+    // echo already printed to the scrollback, so an in-place swap needs no extra
+    // output; on fallback the reload wipes it and the stash reprints it on top.
+    function navigateTerminal(action) {
+      var cwd = hrefToCwd(action.url);
+      var canSwap =
+        action.cd !== false &&
+        isTerminalLayout() &&
+        cwd !== "~" &&
+        isSameOriginUrl(action.url) &&
+        window.TerminalNav &&
+        typeof window.TerminalNav.go === "function";
+      if (!canSwap) {
+        fullReloadNavigate(action);
+        return;
+      }
+      window.TerminalNav.go(action.url, { cwd: cwd }).then(function (swapped) {
+        if (!swapped) {
+          fullReloadNavigate(action);
+        }
+      });
+    }
+
     function applyTerminalAction(action) {
       if (!action) {
         return;
@@ -3821,16 +3875,7 @@
         }
         case "navigate":
           if (action.url) {
-            // Carry a `cd` echo to the destination, same as a nav click —
-            // unless the caller opts out (e.g. a language switch).
-            if (action.cd !== false) {
-              stashTerminalCd(currentTerminalCwd(), hrefToCwd(action.url));
-            }
-            try {
-              window.location.assign(action.url);
-            } catch (err) {
-              window.location.href = action.url;
-            }
+            navigateTerminal(action);
           }
           break;
         case "flow":

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3564,13 +3564,37 @@
             return {
               echo: input,
               lines: [],
-              action: { type: "remote-cat", url: catHref },
+              action: { type: "remote-cat", url: catHref, name: args[0] },
             };
           }
           // Otherwise a pseudo-file (readme, colophon, secret, config, …).
           var fileLines = terminalFile(args[0]);
           if (fileLines) {
             return { echo: input, lines: fileLines.slice(), action: null };
+          }
+          // cwd-relative fallback: a file in a section you've cd'd into but not
+          // loaded — its card lives on the remote section page, not this DOM, so
+          // the DOM lookups above miss it (the same file `ls` prints by fetching
+          // the section). Build the URL from the section base + slug, the way
+          // remote-ls does, and let remote-cat fetch it (a 404 → No such file).
+          var catSegs = terminalResolveSegments(catName);
+          if (catSegs.length >= 2) {
+            var catBase = resolveCdTarget(catSegs[0]);
+            if (catBase) {
+              return {
+                echo: input,
+                lines: [],
+                action: {
+                  type: "remote-cat",
+                  url:
+                    catBase.replace(/\/+$/, "") +
+                    "/" +
+                    catSegs.slice(1).join("/") +
+                    "/",
+                  name: args[0],
+                },
+              };
+            }
           }
           return {
             echo: input,
@@ -4317,10 +4341,11 @@
               scrollTerminalToEnd();
             });
           break;
-        case "remote-cat":
+        case "remote-cat": {
           // Append-only cat: fetch the post and print its readable text
           // (images as [image N] tokens) into the scrollback below — nothing
           // above the prompt changes. `open` is the escape hatch to the page.
+          var catLabel = action.name || action.url;
           if (typeof window.fetch !== "function") {
             printTerminalLine(
               "cat: cannot reach " + action.url,
@@ -4331,14 +4356,21 @@
           window
             .fetch(action.url, { credentials: "same-origin" })
             .then(function (res) {
-              return res.ok ? res.text() : Promise.reject();
+              // A 404 means the guessed cwd-relative path doesn't exist — a
+              // genuine "No such file", distinct from a network failure.
+              if (!res.ok) {
+                var notFound = new Error("not found");
+                notFound.notFound = true;
+                throw notFound;
+              }
+              return res.text();
             })
             .then(function (html) {
               var doc = new DOMParser().parseFromString(html, "text/html");
               var catLines = terminalExtractPostLines(doc);
               if (!catLines.length) {
                 printTerminalLine(
-                  "cat: " + action.url + ": (empty)",
+                  "cat: " + catLabel + ": (empty)",
                   "terminal-session__out"
                 );
               } else {
@@ -4348,14 +4380,17 @@
               }
               scrollTerminalToEnd();
             })
-            .catch(function () {
+            .catch(function (err) {
               printTerminalLine(
-                "cat: cannot reach " + action.url,
+                err && err.notFound
+                  ? "cat: " + catLabel + ": No such file or directory"
+                  : "cat: cannot reach " + action.url,
                 "terminal-session__out"
               );
               scrollTerminalToEnd();
             });
           break;
+        }
         case "flow":
           startTerminalFlow(action.flow);
           break;

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2306,6 +2306,7 @@
       "  pwd       working dir",
       "  ls        list dir",
       "  cd <page> change page",
+      "  cv        résumé (about)",
       "  tree      site map",
       "  lang [sv|en]  language",
       "  echo      print text",
@@ -2333,6 +2334,7 @@
       "pwd",
       "ls",
       "cd",
+      "cv",
       "tree",
       "lang",
       "echo",
@@ -2814,11 +2816,12 @@
     // shows the whole file — the info you can't otherwise reach once a post is a
     // file you never `cd` into. `base` resolves relative image URLs (the fetch
     // URL). Returns [] if there's no content root.
-    function terminalExtractPostLines(doc, base) {
-      var root =
-        doc.querySelector("#main .content.post") ||
-        doc.querySelector("#main .content.page") ||
-        doc.querySelector("#main .content");
+    function terminalExtractPostLines(doc, base, rootSelector) {
+      var root = rootSelector
+        ? doc.querySelector(rootSelector)
+        : doc.querySelector("#main .content.post") ||
+          doc.querySelector("#main .content.page") ||
+          doc.querySelector("#main .content");
       if (!root) {
         return [];
       }
@@ -3671,6 +3674,29 @@
             echo: input,
             lines: terminalLsLines(lsPaths, lsShowHidden),
             action: null,
+          };
+        }
+        case "cv": {
+          // A shortcut that prints just the résumé section of the about page —
+          // "part of about" (it's inside about.md), but reachable on its own.
+          // Append-only, like cat: fetch about and print only its .about-cv.
+          var cvUrl = resolveCdTarget("about");
+          if (!cvUrl) {
+            return {
+              echo: input,
+              lines: ["cv: about page not found"],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: [],
+            action: {
+              type: "remote-cat",
+              url: cvUrl,
+              name: "cv.md",
+              root: ".about-cv",
+            },
           };
         }
         case "tree":
@@ -4528,7 +4554,11 @@
             })
             .then(function (html) {
               var doc = new DOMParser().parseFromString(html, "text/html");
-              var catTokens = terminalExtractPostLines(doc, action.url);
+              var catTokens = terminalExtractPostLines(
+                doc,
+                action.url,
+                action.root
+              );
               if (!catTokens.length) {
                 printTerminalLine(
                   "cat: " + catLabel + ": (empty)",

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -4471,10 +4471,27 @@
                     files.push(entry);
                   }
                 });
-              printTerminalLine(
-                files.length ? files.join("  ") : "(empty)",
-                "terminal-session__out"
-              );
+              if (files.length) {
+                printTerminalLine(files.join("  "), "terminal-session__out");
+              } else if (doc.querySelector(".content.post, .content.page")) {
+                // A readable page (about, a post) is a FILE, not a listing —
+                // point at cat instead of a bare "(empty)" that hides how to
+                // reach it.
+                var lsSlug = String(action.cwd || "")
+                  .split("/")
+                  .filter(Boolean)
+                  .pop();
+                printTerminalLine(
+                  "ls: " +
+                    (lsSlug || "this") +
+                    " is a file, not a directory — try: cat " +
+                    (lsSlug || "it") +
+                    ".md",
+                  "terminal-session__out"
+                );
+              } else {
+                printTerminalLine("(empty)", "terminal-session__out");
+              }
               scrollTerminalToEnd();
             })
             .catch(function () {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2362,6 +2362,13 @@
     // stripped before lookup, so `cat colophon`, `cat colophon.txt` and
     // `cat .secret` all resolve.
     const TERMINAL_FILES = {
+      welcome: [
+        "Hi, Torbjörn here — a designer.",
+        "For over a decade I've worked across editorial design,",
+        "brand and digital product. Based in Gothenburg.",
+        "",
+        "you're in the terminal — try 'ls', 'cd works', 'help'.",
+      ],
       readme: [
         "it's a portfolio. poke around.",
         "type 'help' for the command list.",
@@ -4853,8 +4860,16 @@
         )
         .forEach(function (link) {
           var segs = terminalHrefSegments(link.getAttribute("href"));
-          if (segs && segs.length) {
-            link.setAttribute("data-slug", segs[segs.length - 1]);
+          if (!segs || !segs.length) {
+            return;
+          }
+          var slug = segs[segs.length - 1];
+          // A taxonomy/section card (e.g. works' "tags") is a directory, not a
+          // file — render it slug/ instead of slug.md.
+          if (slug === "tags" || TERMINAL_SECTION_DIRS[slug]) {
+            link.setAttribute("data-dir", slug);
+          } else {
+            link.setAttribute("data-slug", slug);
           }
         });
     }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2224,23 +2224,6 @@
       '[data-js="terminal-session"]'
     );
 
-    // Append-only history: the header's login prompts (`ls ~`, `ls settings/`)
-    // are the session's opening lines. Freeze them at the load-time cwd — pin
-    // each an inline --terminal-cwd — so a later append-only `cd` moves only the
-    // live prompt below, never this history above. The live input prompt keeps
-    // reading the global var, so it alone tracks the working directory.
-    if (isTerminalLayout()) {
-      var terminalLoadCwd = currentTerminalCwd();
-      document
-        .querySelectorAll("#topmenu .terminal-prompt:not(.terminal-prompt--cd)")
-        .forEach(function (headerPrompt) {
-          headerPrompt.style.setProperty(
-            "--terminal-cwd",
-            '"' + terminalLoadCwd + '"'
-          );
-        });
-    }
-
     // Clicking a cat'd [image N] token is a shortcut for a command you could
     // have typed: it echoes `open <file>` into the scrollback (frozen at the
     // current cwd, like any command) and opens the picture in the lightbox.
@@ -4446,12 +4429,12 @@
           }
           break;
         case "chdir":
-          // Append-only cd: move the prompt only. --terminal-cwd drives the
-          // PS1, so setting it (inline, wins over head.html's :root rule) is the
-          // whole move. No fetch, no swap, no scroll jump — nothing above the
-          // prompt changes.
+          // Append-only cd: move the LIVE prompt only. --terminal-live-cwd
+          // drives the bottom input's PS1; --terminal-cwd (the frozen page cwd)
+          // is left untouched, so every history prompt above — header, tour
+          // lines, scrollback — stays where it ran. No fetch, no swap, no jump.
           document.documentElement.style.setProperty(
-            "--terminal-cwd",
+            "--terminal-live-cwd",
             '"' + (action.cwd || "~") + '"'
           );
           break;
@@ -5177,9 +5160,14 @@
     const TERMINAL_CD_KEY = "terminal-cd";
 
     function currentTerminalCwd() {
-      var value = window
-        .getComputedStyle(document.documentElement)
-        .getPropertyValue("--terminal-cwd")
+      // The LIVE working directory drives the bottom prompt and command
+      // resolution. It falls back to --terminal-cwd (the frozen page cwd) until
+      // the first append-only `cd` sets --terminal-live-cwd.
+      var style = window.getComputedStyle(document.documentElement);
+      var value = (
+        style.getPropertyValue("--terminal-live-cwd") ||
+        style.getPropertyValue("--terminal-cwd")
+      )
         .trim()
         .replace(/^["']|["']$/g, "");
       return value || "~";

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2317,6 +2317,7 @@
       "cv",
       "copy",
       "cat",
+      "open",
       "man",
       "uname",
       "colour",
@@ -2645,7 +2646,64 @@
     // in. Unknown path → an ls-style error; a real page whose contents can't
     // be listed from here (a different section) → a `cd` hint rather than a
     // bare empty result.
+    // The statusbar renders the loaded page as history: `~$ ls nav/` and
+    // `~$ ls settings/`. Make those real so typing them reproduces the header —
+    // the navigation and the settings toggles, listed. Both are menus, not
+    // places, so you `ls` them but don't `cd` into them (see the cd handler).
+    var TERMINAL_SECTION_DIRS = {
+      works: 1,
+      arbeten: 1,
+      writing: 1,
+      texter: 1,
+    };
+
+    function terminalNavEntries() {
+      var seen = {};
+      var out = [];
+      document
+        .querySelectorAll(
+          ".top-menu__nav a[href]:not(.terminal-quick), .terminal-prompt__host[href]"
+        )
+        .forEach(function (a) {
+          var href = a.getAttribute("href");
+          if (!href || href.charAt(0) === "#") {
+            return;
+          }
+          var segs = terminalHrefSegments(href);
+          var name = segs && segs.length ? segs[0] : "home";
+          if (seen[name]) {
+            return;
+          }
+          seen[name] = true;
+          out.push(TERMINAL_SECTION_DIRS[name] ? name + "/" : name);
+        });
+      return out;
+    }
+
+    function terminalSettingsEntries() {
+      return [
+        "theme",
+        "palette",
+        "typography",
+        "layout",
+        "effects",
+        "language",
+      ];
+    }
+
     function terminalLsOne(pathArg, showHidden) {
+      // nav/ and settings/ are global menus, reachable from any cwd — match the
+      // raw argument (~/nav, nav/, nav) before resolving relative to the cwd.
+      var rawArg = String(pathArg || "")
+        .replace(/^~\/?/, "")
+        .replace(/^\/+|\/+$/g, "")
+        .toLowerCase();
+      if (rawArg === "nav") {
+        return [terminalNavEntries().join("  ")];
+      }
+      if (rawArg === "settings") {
+        return [terminalSettingsEntries().join("  ")];
+      }
       var targetSegs = terminalResolveSegments(pathArg);
       var node = terminalNodeAt(targetSegs);
       if (!node) {
@@ -2654,15 +2712,22 @@
         ];
       }
       var isCwd = targetSegs.join("/") === terminalCwdSegments().join("/");
+      // Structural children (sections, tags) are directories — trailing slash.
       var entries = Object.keys(node.children)
         .sort()
         .map(function (k) {
           return node.children[k].name + "/";
         });
       if (isCwd) {
+        // The page's own content (posts) are FILES: a post is a .md you `cat`,
+        // not a directory you `cd` into — so it reads like real `ls` and the
+        // prompt stays in the section when you open one.
         terminalPageContentSlugs(targetSegs).forEach(function (slug) {
-          var entry = slug + "/";
-          if (entries.indexOf(entry) === -1) {
+          var entry = slug + ".md";
+          if (
+            entries.indexOf(entry) === -1 &&
+            entries.indexOf(slug + "/") === -1
+          ) {
             entries.push(entry);
           }
         });
@@ -3057,25 +3122,61 @@
         }
         case "cd": {
           var dest = args[0] || "~";
-          if (dest === "~" || dest === "/" || dest === "..") {
+          var destKey = dest.replace(/\/+$/, "").toLowerCase();
+          if (
+            dest === "~" ||
+            dest === "/" ||
+            dest === ".." ||
+            destKey === "home"
+          ) {
             return {
               echo: input,
               lines: [],
               action: { type: "navigate", url: terminalHomeUrl() },
             };
           }
-          var target = resolveCdTarget(dest);
-          if (!target) {
+          // nav/ and settings/ are menus, not places — list them, don't enter.
+          if (destKey === "nav" || destKey === "settings") {
             return {
               echo: input,
-              lines: ["cd: no such file or directory: " + dest],
+              lines: [
+                "cd: " +
+                  destKey +
+                  " is a menu, not a directory — try: ls " +
+                  destKey +
+                  "/",
+              ],
+              action: null,
+            };
+          }
+          // Sections are directories — cd enters them.
+          var sectionTarget = terminalNavTargets()[destKey];
+          if (sectionTarget) {
+            return {
+              echo: input,
+              lines: [],
+              action: { type: "navigate", url: sectionTarget },
+            };
+          }
+          // A post is a file — you cat it, you don't cd into it.
+          var postKey = destKey.replace(/\.(md|txt)$/i, "");
+          if (terminalContentTargetHref(postKey)) {
+            return {
+              echo: input,
+              lines: [
+                "cd: not a directory: " +
+                  dest +
+                  " — try: cat " +
+                  postKey +
+                  ".md",
+              ],
               action: null,
             };
           }
           return {
             echo: input,
-            lines: [],
-            action: { type: "navigate", url: target },
+            lines: ["cd: no such file or directory: " + dest],
+            action: null,
           };
         }
         case "lang":
@@ -3239,14 +3340,52 @@
             };
           }
           var fileLines = terminalFile(args[0]);
-          if (!fileLines) {
+          if (fileLines) {
+            return { echo: input, lines: fileLines.slice(), action: null };
+          }
+          // Not a pseudo-file — maybe a content post. `cat`-ing a post opens its
+          // page: the post renders as the cat output (`cat 'title.md'` + body),
+          // so navigating there IS printing the file. Strip the .md first.
+          var catHref = terminalContentTargetHref(
+            args[0].replace(/\.(md|txt)$/i, "")
+          );
+          if (catHref) {
             return {
               echo: input,
-              lines: ["cat: " + args[0] + ": No such file or directory"],
+              lines: [],
+              action: { type: "navigate", url: catHref },
+            };
+          }
+          return {
+            echo: input,
+            lines: ["cat: " + args[0] + ": No such file or directory"],
+            action: null,
+          };
+        }
+        case "open": {
+          if (!args.length) {
+            return {
+              echo: input,
+              lines: ["usage: open <name> — a section or a post"],
               action: null,
             };
           }
-          return { echo: input, lines: fileLines.slice(), action: null };
+          // A general "go there": resolves a section OR a post (resolveCdTarget
+          // already falls through to content files) and navigates.
+          var openName = args[0].replace(/\/$/, "").replace(/\.(md|txt)$/i, "");
+          var openHref = resolveCdTarget(openName);
+          if (!openHref) {
+            return {
+              echo: input,
+              lines: ["open: no such file or directory: " + args[0]],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: [],
+            action: { type: "navigate", url: openHref },
+          };
         }
         case "man": {
           var topic = (args[0] || "").toLowerCase();
@@ -4352,16 +4491,31 @@
         });
       } else {
         var verb = parts[0].toLowerCase();
-        if (verb !== "cd" && verb !== "ls" && verb !== "open") {
+        if (
+          verb !== "cd" &&
+          verb !== "ls" &&
+          verb !== "open" &&
+          verb !== "cat"
+        ) {
           return;
         }
         frag = (parts[parts.length - 1] || "").toLowerCase();
-        var node = terminalNodeAt(terminalCwdSegments());
+        var cwdSegs = terminalCwdSegments();
+        var node = terminalNodeAt(cwdSegs);
         candidates = node
           ? Object.keys(node.children).filter(function (name) {
               return name.indexOf(frag) === 0;
             })
           : [];
+        // cat/open reach the page's posts too — complete them as .md files.
+        if (verb === "cat" || verb === "open") {
+          terminalPageContentSlugs(cwdSegs).forEach(function (slug) {
+            var file = slug + ".md";
+            if (file.indexOf(frag) === 0 && candidates.indexOf(file) === -1) {
+              candidates.push(file);
+            }
+          });
+        }
       }
       if (candidates.length === 1) {
         parts[parts.length - 1] = candidates[0];

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3407,6 +3407,16 @@
           if (lsLong.indexOf("--info") !== -1) {
             return { echo: input, lines: terminalInfoLines(), action: null };
           }
+          if (lsLong.indexOf("--images") !== -1) {
+            var figs = document.querySelectorAll(
+              ".content figure[data-lightbox]"
+            ).length;
+            return {
+              echo: input,
+              lines: [figs ? figs + " images" : "(no images here)"],
+              action: null,
+            };
+          }
           return {
             echo: input,
             lines: terminalLsLines(lsPaths, lsShowHidden),

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3097,6 +3097,19 @@
       return out.length ? out : TERMINAL_FILES.colophon.slice();
     }
 
+    // The newsletter blurb the footer prints under `cat 'newsletter.txt'` —
+    // harvested from the live footer so typing it reproduces what's shown.
+    function terminalNewsletterLines() {
+      var desc = document.querySelector(".footer-newsletter__description");
+      if (desc) {
+        var text = desc.textContent.replace(/\s+/g, " ").trim();
+        if (text) {
+          return [text, "", "subscribe with: subscribe"];
+        }
+      }
+      return ["a short, occasional newsletter.", "subscribe with: subscribe"];
+    }
+
     function terminalFile(name) {
       var key = String(name || "")
         .toLowerCase()
@@ -3105,9 +3118,13 @@
       if (key === "secrets") {
         key = "secret";
       }
-      // colophon is the live footer, reproduced (see terminalColophonLines).
+      // colophon and newsletter are live footer blocks, reproduced so typing
+      // the `cat …` the chrome prints shows exactly what's on the page.
       if (key === "colophon") {
         return terminalColophonLines();
+      }
+      if (key === "newsletter") {
+        return terminalNewsletterLines();
       }
       return TERMINAL_FILES[key] || null;
     }
@@ -3268,12 +3285,26 @@
     // Returns { echo, lines, action }. `echo` is the command as typed (printed
     // with the prompt), `lines` are output rows, `action` (or null) is applied
     // separately. Kept free of DOM mutation so it is straightforward to test.
+    // Split a command line into words, honouring single/double quotes so a
+    // quoted filename with spaces (or one the chrome prints as `cat 'x.txt'`)
+    // parses as one argument — surrounding quotes stripped, like a real shell.
+    function terminalTokenize(input) {
+      var raw = input.match(/'[^']*'|"[^"]*"|\S+/g) || [];
+      return raw.map(function (tok) {
+        var q = tok.charAt(0);
+        if ((q === "'" || q === '"') && tok.charAt(tok.length - 1) === q) {
+          return tok.slice(1, -1);
+        }
+        return tok;
+      });
+    }
+
     function runTerminalCommand(raw) {
       var input = String(raw === null || raw === undefined ? "" : raw).trim();
       if (!input) {
         return { echo: "", lines: [], action: null };
       }
-      var parts = input.split(/\s+/);
+      var parts = terminalTokenize(input);
       var cmd = parts[0].toLowerCase();
       var args = parts.slice(1);
       var rest = input.slice(parts[0].length).trim();
@@ -3710,6 +3741,16 @@
             };
           }
           var catName = args[0].replace(/\.(md|txt)$/i, "").toLowerCase();
+          // An explicit `.txt` is a text blurb (readme, the newsletter/colophon
+          // footer blocks) — resolve it as a pseudo-file BEFORE a same-named
+          // page (e.g. `cat newsletter.txt` is the blurb; `cat newsletter.md`
+          // is the page). Bare/`.md` names fall through to the page resolver.
+          if (/\.txt$/i.test(args[0])) {
+            var txtLines = terminalFile(args[0]);
+            if (txtLines) {
+              return { echo: input, lines: txtLines.slice(), action: null };
+            }
+          }
           // A section is a directory — you ls it, you don't cat it.
           if (TERMINAL_SECTION_DIRS[catName]) {
             return {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2898,10 +2898,18 @@
         ) {
           continue;
         }
-        var text = (el.textContent || "").replace(/\s+/g, " ").trim();
-        if (text) {
-          tokens.push({ text: text });
-        }
+        // Split on <br> so a paragraph of <br>-separated lines (e.g. the CV's
+        // dates / roles / bullets, all one <p>) prints one line each instead of
+        // running together — textContent alone would drop the breaks.
+        var ownerDoc = el.ownerDocument || document;
+        (el.innerHTML || "").split(/<br\s*\/?>/i).forEach(function (part) {
+          var holder = ownerDoc.createElement("div");
+          holder.innerHTML = part;
+          var text = (holder.textContent || "").replace(/\s+/g, " ").trim();
+          if (text) {
+            tokens.push({ text: text });
+          }
+        });
       }
       // Append the project meta as its own trailing block — cat shows the whole
       // file, so the role/details/client you set in front matter come along.

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -101,6 +101,13 @@
     makeFiguresFocusable();
   }
 
+  // Terminal in-place navigation swaps #main, bringing in fresh figures that
+  // need tabindex/role to stay keyboard-reachable. Expose the (idempotent)
+  // focusability init so terminal-nav.js can re-run it after a swap. Everything
+  // else in this module is bound once to `document`/the overlay and the gallery
+  // is collected at open time, so swapped-in figures are already covered.
+  window.TerminalLightbox = { refresh: makeFiguresFocusable };
+
   document.addEventListener("keydown", function (e) {
     if (e.key !== "Enter" && e.key !== " ") {
       return;

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -63,6 +63,24 @@
     closeBtn.focus();
   }
 
+  // Open a single image by URL, with no gallery — used by the terminal layout
+  // when a cat'd post's `[image N]` token (whose figure isn't in the DOM) is
+  // clicked. No prev/next, since there's no on-page gallery to step through.
+  function openSrc(src, alt) {
+    if (!src) {
+      return;
+    }
+    previousFocus = document.activeElement;
+    gallery = [];
+    galleryIndex = -1;
+    img.src = src;
+    img.alt = alt || "";
+    nav.hidden = true;
+    overlay.classList.add("is-open");
+    document.documentElement.classList.add("lightbox-open");
+    closeBtn.focus();
+  }
+
   function close() {
     overlay.classList.remove("is-open");
     document.documentElement.classList.remove("lightbox-open");
@@ -106,7 +124,7 @@
   // focusability init so terminal-nav.js can re-run it after a swap. Everything
   // else in this module is bound once to `document`/the overlay and the gallery
   // is collected at open time, so swapped-in figures are already covered.
-  window.TerminalLightbox = { refresh: makeFiguresFocusable };
+  window.TerminalLightbox = { refresh: makeFiguresFocusable, openSrc: openSrc };
 
   document.addEventListener("keydown", function (e) {
     if (e.key !== "Enter" && e.key !== " ") {

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -1,0 +1,280 @@
+/**
+ * Terminal in-place navigation (typed-only, SPA-style #main swap).
+ *
+ * A typed `cd` in the terminal layout reads like a real shell: instead of
+ * reloading the machine, it swaps the page content under the live prompt and
+ * keeps the scrollback alive. Clicks are deliberately left untouched (they
+ * still full-reload with the top `cd` echo — see darkmode.js); only the
+ * command engine's `navigate` action routes here, and only for ordinary pages.
+ *
+ * darkmode.js decides eligibility it can know up front (terminal layout,
+ * same-origin, not home, not a language switch) and calls `TerminalNav.go()`.
+ * This module makes the final call after fetching — a special page (the four
+ * CSS-bundled pages: home, contact, ui-library, palette-generator) or a
+ * terminal-exempt page can only be recognised from the response, so `go()`
+ * resolves `false` and darkmode falls back to a full reload. Progressive
+ * enhancement throughout: no fetch / a parse failure / no #main all fall back.
+ *
+ * The DOM makes this cheap: all terminal chrome (nav, boot, scrollback, prompt)
+ * lives OUTSIDE `<main id="main">`, so #main is a clean, stable swap target.
+ * The real cost is content-dependent re-init, and in the terminal layout that
+ * collapses to almost nothing: reveal-on-scroll is a CSS no-op here (`.reveal`
+ * is forced visible), role-swapper is home-only (home full-reloads), and the
+ * cd echo is already the typed command sitting in the scrollback. What remains
+ * is lightbox figure focusability (+ the cheap idempotent Coty init).
+ */
+(function () {
+  "use strict";
+
+  var MAIN_SELECTOR = "#main";
+
+  // The path we last rendered into #main. Used to ignore hash-only popstates
+  // (smooth-scroll pushes those) and to detect real page changes on back/fwd.
+  var lastPath = window.location.pathname;
+
+  // Derive a page's cwd (~ or ~/segment) from a URL, mirroring head.html's
+  // per-page logic and darkmode.js's hrefToCwd (strip origin, query/hash, and
+  // the language prefix). Used for the prompt on back/forward restores.
+  function pathToCwd(href) {
+    var path = String(href || "")
+      .replace(/^[a-z]+:\/\/[^/]+/i, "")
+      .replace(/[?#].*$/, "")
+      .replace(/^\/+|\/+$/g, "");
+    var lang = (
+      document.documentElement.getAttribute("lang") || ""
+    ).toLowerCase();
+    var parts = path.split("/").filter(Boolean);
+    if (parts.length && parts[0].toLowerCase() === lang) {
+      parts.shift();
+    }
+    return parts.length ? "~/" + parts[0] : "~";
+  }
+
+  function isTerminalLayout() {
+    return document.documentElement.getAttribute("data-layout") === "terminal";
+  }
+
+  // A fetched document is swappable only if it's an ordinary content page:
+  // not terminal-exempt, and carrying no page-specific CSS bundle. The four
+  // special pages (home, contact, ui-library, palette-generator) are exactly
+  // those with a `css/pages/*` (dev) or `css-page-*` (prod) stylesheet, whose
+  // styles the current page never loaded — swapping them in would break their
+  // look, so they full-reload instead.
+  function isSwappableDoc(doc) {
+    if (!doc || !doc.documentElement) {
+      return false;
+    }
+    if (doc.documentElement.hasAttribute("data-terminal-exempt")) {
+      return false;
+    }
+    if (doc.querySelector('link[href*="css/pages/"], link[href*="css-page"]')) {
+      return false;
+    }
+    return !!doc.querySelector(MAIN_SELECTOR);
+  }
+
+  // Copy the SEO/meta head fields from the fetched document. Deliberately a
+  // fixed allow-list — the stylesheet links, fonts, inline theme script and the
+  // --terminal-host/--terminal-cwd style block must stay put. Remove-then-add
+  // per selector so a field the new page omits (e.g. robots, og:image) is
+  // correctly dropped.
+  function patchHead(doc) {
+    if (doc.title) {
+      document.title = doc.title;
+    }
+    var selectors = [
+      'meta[name="description"]',
+      'meta[name="robots"]',
+      'meta[property^="og:"]',
+      'meta[name^="twitter:"]',
+      'link[rel="canonical"]',
+      'link[rel="alternate"][hreflang]',
+    ];
+    var srcHead = doc.head;
+    if (!srcHead) {
+      return;
+    }
+    selectors.forEach(function (sel) {
+      var existing = document.head.querySelectorAll(sel);
+      for (var i = 0; i < existing.length; i++) {
+        existing[i].parentNode.removeChild(existing[i]);
+      }
+      var incoming = srcHead.querySelectorAll(sel);
+      for (var j = 0; j < incoming.length; j++) {
+        document.head.appendChild(document.importNode(incoming[j], true));
+      }
+    });
+  }
+
+  // The prompt reads its working directory from --terminal-cwd. Set it inline
+  // on <html> (wins over head.html's :root rule) so the PS1 tracks the new page.
+  function setCwd(cwd) {
+    document.documentElement.style.setProperty(
+      "--terminal-cwd",
+      '"' + cwd + '"'
+    );
+  }
+
+  // Re-run only the content-dependent init a #main swap invalidates. Kept tiny
+  // by design (see the file header): lightbox figure focusability, plus the
+  // cheap idempotent Coty init when that engine is loaded.
+  function refreshContentInit() {
+    if (
+      window.TerminalLightbox &&
+      typeof window.TerminalLightbox.refresh === "function"
+    ) {
+      window.TerminalLightbox.refresh();
+    }
+    if (
+      window.CotyScaleActions &&
+      typeof window.CotyScaleActions.init === "function"
+    ) {
+      window.CotyScaleActions.init();
+    }
+  }
+
+  // The prompt sits below #main, so a taller/shorter page shifts it — pin the
+  // viewport to the bottom, matching darkmode.js's scrollTerminalToEnd.
+  function keepPromptInView() {
+    window.requestAnimationFrame(function () {
+      window.scrollTo(0, document.body.scrollHeight);
+    });
+  }
+
+  function parseDoc(html) {
+    try {
+      return new DOMParser().parseFromString(html, "text/html");
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function sameOrigin(url) {
+    try {
+      return (
+        new URL(url, window.location.href).origin === window.location.origin
+      );
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // Apply a fetched document in place: swap #main (importNode carries its
+  // attributes, so the surrounding terminal chrome — scrollback, prompt, nav —
+  // stays intact), then patch head + cwd, refresh the content-dependent init
+  // and keep the prompt in view. Returns false if the document can't be swapped
+  // (special page / no #main).
+  //
+  // The post-swap steps run AFTER the DOM actually updates. That matters under
+  // a view transition: startViewTransition defers its callback a frame, so
+  // running refreshContentInit() eagerly would re-init against the old figures.
+  function render(doc, cwd) {
+    if (!isSwappableDoc(doc)) {
+      return false;
+    }
+    var current = document.querySelector(MAIN_SELECTOR);
+    var incoming = doc.querySelector(MAIN_SELECTOR);
+    if (!current || !incoming || !current.parentNode) {
+      return false;
+    }
+    var imported = document.importNode(incoming, true);
+    var swap = function () {
+      current.parentNode.replaceChild(imported, current);
+    };
+    var finish = function () {
+      patchHead(doc);
+      setCwd(cwd);
+      refreshContentInit();
+      keepPromptInView();
+    };
+    var transition =
+      typeof document.startViewTransition === "function"
+        ? document.startViewTransition(swap)
+        : null;
+    if (transition && transition.updateCallbackDone) {
+      transition.updateCallbackDone.then(finish, finish);
+    } else {
+      // No view-transition support: the swap ran synchronously above (or we
+      // run it now), so finish immediately.
+      if (!transition) {
+        swap();
+      }
+      finish();
+    }
+    return true;
+  }
+
+  // Fetch + swap for a typed navigation. Resolves true if it navigated in
+  // place, false if the caller should fall back to a full reload. Never
+  // rejects — every failure path resolves false.
+  function go(url, opts) {
+    opts = opts || {};
+    if (typeof window.fetch !== "function") {
+      return Promise.resolve(false);
+    }
+    return window
+      .fetch(url, { credentials: "same-origin", redirect: "follow" })
+      .then(function (res) {
+        if (!res.ok) {
+          return false;
+        }
+        // A redirect that left the origin can't be swapped safely.
+        if (res.redirected && res.url && !sameOrigin(res.url)) {
+          return false;
+        }
+        var finalUrl = res.redirected && res.url ? res.url : url;
+        return res.text().then(function (html) {
+          var doc = parseDoc(html);
+          var cwd = opts.cwd || pathToCwd(finalUrl);
+          if (!render(doc, cwd)) {
+            return false;
+          }
+          try {
+            window.history.pushState({ terminalNav: true }, "", finalUrl);
+          } catch (e) {
+            /* origin already checked; ignore a hostile pushState throw */
+          }
+          lastPath = window.location.pathname;
+          return true;
+        });
+      })
+      .catch(function () {
+        return false;
+      });
+  }
+
+  // Back/forward: restore the entry's content in place so the scrollback
+  // survives. Only in terminal layout; skip hash-only changes; reload if the
+  // target isn't swappable (e.g. stepping back onto a special page).
+  function onPopState() {
+    if (!isTerminalLayout()) {
+      return;
+    }
+    if (window.location.pathname === lastPath) {
+      return;
+    }
+    var url = window.location.href;
+    window
+      .fetch(url, { credentials: "same-origin", redirect: "follow" })
+      .then(function (res) {
+        if (!res.ok) {
+          throw new Error("bad status");
+        }
+        return res.text();
+      })
+      .then(function (html) {
+        if (!render(parseDoc(html), pathToCwd(url))) {
+          window.location.reload();
+          return;
+        }
+        lastPath = window.location.pathname;
+      })
+      .catch(function () {
+        window.location.reload();
+      });
+  }
+
+  window.addEventListener("popstate", onPopState);
+
+  window.TerminalNav = { go: go };
+})();

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -131,6 +131,13 @@
     ) {
       window.CotyScaleActions.init();
     }
+    // Stamp the swapped-in cards' slugs so they render as .md filenames.
+    if (
+      window.TerminalSlugs &&
+      typeof window.TerminalSlugs.refresh === "function"
+    ) {
+      window.TerminalSlugs.refresh();
+    }
   }
 
   // The prompt sits below #main, so a taller/shorter page shifts it — pin the

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -141,6 +141,28 @@
     });
   }
 
+  // Where to leave the viewport after a swap depends on what you navigated to.
+  // A LISTING (works/writing/tags — `.content.list` / `.content.startpage`) is
+  // read via `ls` at the prompt, so keep the prompt in view (the owner's
+  // continuous-session model). A READABLE page (a post or `about` —
+  // `.content.post` / `.content.page`) IS the destination, with no `ls` to
+  // surface it, so show it from the top like a full page load — otherwise the
+  // content sits above the prompt, unseen ("looks half-loaded").
+  function settleScroll() {
+    var content = document.querySelector("#main .content");
+    var isListing =
+      content &&
+      (content.classList.contains("list") ||
+        content.classList.contains("startpage"));
+    if (isListing) {
+      keepPromptInView();
+    } else {
+      window.requestAnimationFrame(function () {
+        window.scrollTo(0, 0);
+      });
+    }
+  }
+
   function parseDoc(html) {
     try {
       return new DOMParser().parseFromString(html, "text/html");
@@ -161,13 +183,12 @@
 
   // Apply a fetched document in place: swap #main (importNode carries its
   // attributes, so the surrounding terminal chrome — scrollback, prompt, nav —
-  // stays intact), then patch head + cwd, refresh the content-dependent init
-  // and keep the prompt in view. Returns false if the document can't be swapped
-  // (special page / no #main).
-  //
-  // The post-swap steps run AFTER the DOM actually updates. That matters under
-  // a view transition: startViewTransition defers its callback a frame, so
-  // running refreshContentInit() eagerly would re-init against the old figures.
+  // stays intact), then patch head + cwd, mark the session booted (so the swap
+  // drops the one-per-session boot banner like a full-reload nav would),
+  // refresh the content-dependent init and settle the scroll. Synchronous on
+  // purpose: a view-transition cross-fade animates from a snapshot and can flash
+  // a blank frame mid-swap ("looks half-loaded"), so the swap paints at once.
+  // Returns false if the document can't be swapped (special page / no #main).
   function render(doc, cwd) {
     if (!isSwappableDoc(doc)) {
       return false;
@@ -177,30 +198,21 @@
     if (!current || !incoming || !current.parentNode) {
       return false;
     }
-    var imported = document.importNode(incoming, true);
-    var swap = function () {
-      current.parentNode.replaceChild(imported, current);
-    };
-    var finish = function () {
-      patchHead(doc);
-      setCwd(cwd);
-      refreshContentInit();
-      keepPromptInView();
-    };
-    var transition =
-      typeof document.startViewTransition === "function"
-        ? document.startViewTransition(swap)
-        : null;
-    if (transition && transition.updateCallbackDone) {
-      transition.updateCallbackDone.then(finish, finish);
-    } else {
-      // No view-transition support: the swap ran synchronously above (or we
-      // run it now), so finish immediately.
-      if (!transition) {
-        swap();
-      }
-      finish();
-    }
+    current.parentNode.replaceChild(
+      document.importNode(incoming, true),
+      current
+    );
+    patchHead(doc);
+    setCwd(cwd);
+    // Subsequent pages skip the boot theater. Beyond hiding the banner
+    // (data-terminal-booted), we must clear the .terminal-booting class: its
+    // `#main { animation: terminal-print both 1.35s }` rule holds a freshly
+    // swapped #main at opacity 0 through the delay, so a swap mid-boot (fast
+    // navigation on the landing page) would paint blank until the animation ran.
+    document.documentElement.setAttribute("data-terminal-booted", "1");
+    document.documentElement.classList.remove("terminal-booting");
+    refreshContentInit();
+    settleScroll();
     return true;
   }
 

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -218,6 +218,15 @@
     // navigation on the landing page) would paint blank until the animation ran.
     document.documentElement.setAttribute("data-terminal-booted", "1");
     document.documentElement.classList.remove("terminal-booting");
+    // The home-only footer (login-tour blocks) is gated on data-terminal-home,
+    // a server-set flag on <html>. A swap doesn't reload <html>, so sync it from
+    // the fetched page — otherwise leaving home would keep the flag and show the
+    // footer on a content page (and vice versa).
+    if (doc.documentElement.hasAttribute("data-terminal-home")) {
+      document.documentElement.setAttribute("data-terminal-home", "true");
+    } else {
+      document.documentElement.removeAttribute("data-terminal-home");
+    }
     refreshContentInit();
     settleScroll();
     return true;

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -108,9 +108,15 @@
 
   // The prompt reads its working directory from --terminal-cwd. Set it inline
   // on <html> (wins over head.html's :root rule) so the PS1 tracks the new page.
+  // A real navigation is a fresh page, so reset BOTH the frozen page cwd and the
+  // live cwd (an append-only `cd` only moved the latter) to the new page.
   function setCwd(cwd) {
     document.documentElement.style.setProperty(
       "--terminal-cwd",
+      '"' + cwd + '"'
+    );
+    document.documentElement.style.setProperty(
+      "--terminal-live-cwd",
       '"' + cwd + '"'
     );
   }

--- a/config.toml
+++ b/config.toml
@@ -67,7 +67,7 @@ DefaultContentLanguage = "en"
       name = "Works"
       weight = 2
       identifier = "works"
-      url = "/works/tags/"
+      url = "/works/"
     [[languages.en.menu.top]]
       name = "Writing"
       weight = 3
@@ -106,7 +106,7 @@ DefaultContentLanguage = "en"
       name = "Arbeten"
       weight = 2
       identifier = "works"
-      url = "/sv/arbeten/tags/"
+      url = "/sv/arbeten/"
     [[languages.sv.menu.top]]
       name = "Texter"
       weight = 3

--- a/content/english/contact/index.md
+++ b/content/english/contact/index.md
@@ -2,6 +2,7 @@
 title = "Say hello."
 date = "2014-04-09"
 sidemenu = "true"
+terminal_kind = "action"
 type = "contact"
 description = "Whether you're curious about a project or simply want to say hi, my inbox is open. I enjoy hearing from thoughtful people and makers."
 +++
@@ -9,6 +10,5 @@ description = "Whether you're curious about a project or simply want to say hi, 
 <div class="page-notice">
   <p>{{ i18n "also_on_homepage" }} <a href="{{ "/" | relLangURL }}">{{ i18n "go_to_homepage" }}</a></p>
 </div>
-
 
 {{< contact_layout >}}

--- a/content/english/legal/_index.md
+++ b/content/english/legal/_index.md
@@ -1,0 +1,4 @@
+---
+title: Legal
+description: Licensing and privacy for tor-bjorn.com.
+---

--- a/content/english/legal/license/index.md
+++ b/content/english/legal/license/index.md
@@ -1,5 +1,7 @@
 ---
 title: License
+aliases:
+  - /license/
 description: Licensing terms for content on tor-bjorn.com.
 layout: legal
 ---
@@ -9,10 +11,12 @@ layout: legal
 All of the content on this site is produced under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 (CC BY‑NC‑SA 4.0) license. The footer uses the short form “CC BY‑NC‑SA 4.0”. This means:
 
 ## You are free to
+
 - Share — copy and redistribute the material in any medium or format.
 - Adapt — remix, transform, and build upon the material.
 
 ## Under the following terms
+
 - Attribution — provide a clearly visible backlink to tor-bjorn.com.
 - Non‑Commercial — you may not use the material for commercial purposes.
 - Share‑Alike — if you remix, transform, or build upon the material, you must distribute your contributions under the same license.

--- a/content/english/legal/privacy/index.md
+++ b/content/english/legal/privacy/index.md
@@ -1,5 +1,7 @@
 ---
 title: Privacy
+aliases:
+  - /privacy/
 description: How data is collected and used on tor-bjorn.com.
 layout: legal
 ---
@@ -9,6 +11,7 @@ layout: legal
 In line with GDPR and to be transparent, this page explains what data I collect on tor-bjorn.com, how it is used, and how I keep it safe.
 
 ## What data I collect
+
 - Newsletter sign‑ups: email address submitted via the form in the footer.
 - Contact form: name, email address, subject, and message.
 
@@ -17,15 +20,18 @@ For aggregate visitor statistics I use Cloudflare Web Analytics. It is privacy�
 I also use Google Search Console to understand how visitors find the site via Google Search. This does not give me access to personal data about you.
 
 ## What I do with the data
+
 - Newsletter data is stored in Mailchimp and used only to send newsletters to people who have explicitly subscribed.
 - Contact form data is sent via Make.com to my email so I can respond to your message.
 
 I do not sell personal information or share it with third‑party data brokers.
 
 ## How I keep your data safe
+
 I use strong, unique passwords and two‑factor authentication for service accounts. Access is limited to services needed to operate the site.
 
 Please note that no method of transmission over the internet is 100% secure. I take reasonable steps to protect your data, but I cannot guarantee absolute security.
 
 ## Questions or deletion requests
+
 If you have any concerns or want your data deleted, email me at hi@tor-bjorn.com.

--- a/content/english/palette-generator/index.md
+++ b/content/english/palette-generator/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Palette Generator"
+terminal_kind: exempt
 date: 2026-02-12
 draft: false
 type: "palette-generator"

--- a/content/english/thankyou/index.md
+++ b/content/english/thankyou/index.md
@@ -1,5 +1,6 @@
 +++
 title = "Thank you"
+terminal_kind = "hidden"
 sidemenu = "true"
 description = "Thank you for getting in touch"
 layout = "thankyou"

--- a/content/english/ui-library/_index.md
+++ b/content/english/ui-library/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "UI Library"
+terminal_kind: exempt
 date: 2026-01-07
 draft: false
 type: "ui-library"

--- a/content/swedish/contact/index.md
+++ b/content/swedish/contact/index.md
@@ -1,5 +1,6 @@
 ---
 title: Säg hej
+terminal_kind: action
 linktitle: Kontakt
 slug: kontakt
 url: "/sv/kontakt"

--- a/content/swedish/legal/_index.md
+++ b/content/swedish/legal/_index.md
@@ -1,0 +1,5 @@
+---
+title: Juridik
+description: Licens och integritet för tor-bjorn.com.
+url: "/sv/legal/"
+---

--- a/content/swedish/legal/license/index.md
+++ b/content/swedish/legal/license/index.md
@@ -1,7 +1,9 @@
 ---
 title: Licens
+aliases:
+  - /sv/licens/
 description: Licensvillkor för innehållet på tor-bjorn.com.
-url: "/sv/licens/"
+url: "/sv/legal/licens/"
 layout: legal
 ---
 
@@ -10,10 +12,12 @@ layout: legal
 Allt innehåll på den här webbplatsen publiceras under Creative Commons Attribution‑NonCommercial‑ShareAlike 4.0 (CC BY‑NC‑SA 4.0). I footern visas den kort som “CC BY‑NC‑SA 4.0”. Det innebär:
 
 ## Du får
+
 - Dela — kopiera och sprida materialet i valfritt medium eller format.
 - Bearbeta — remixa, förändra och bygga vidare på materialet.
 
 ## På följande villkor
+
 - Erkännande — ange mig som upphovsperson och länka tydligt till tor-bjorn.com.
 - Icke‑kommersiellt — du får inte använda materialet i kommersiella syften.
 - Dela lika — om du bygger vidare måste du publicera under samma licens.

--- a/content/swedish/legal/privacy/index.md
+++ b/content/swedish/legal/privacy/index.md
@@ -1,7 +1,9 @@
 ---
 title: Integritet
+aliases:
+  - /sv/integritet/
 description: Hur data samlas in och används på tor-bjorn.com.
-url: "/sv/integritet/"
+url: "/sv/legal/integritet/"
 layout: legal
 ---
 
@@ -10,6 +12,7 @@ layout: legal
 I enlighet med GDPR och för att vara transparent beskriver jag här vilken data som samlas in på tor-bjorn.com, hur den används och hur den skyddas.
 
 ## Vilken data jag samlar in
+
 - Nyhetsbrev: e‑postadress som skickas via formuläret i sidfoten.
 - Kontaktformulär: namn, e‑postadress, ämne och meddelande.
 
@@ -18,15 +21,18 @@ För övergripande besöksstatistik använder jag Cloudflare Web Analytics. Det 
 Jag använder även Google Search Console för att förstå hur besökare hittar hit via Google. Det ger mig inte tillgång till personuppgifter om dig.
 
 ## Hur data används
+
 - Nyhetsbrevsdata lagras i Mailchimp och används endast för att skicka nyhetsbrev till personer som aktivt har registrerat sig.
 - Data från kontaktformuläret skickas via Make.com till min e‑post så att jag kan svara på ditt meddelande.
 
 Jag säljer aldrig personuppgifter och delar inte information med data‑mäklare.
 
 ## Hur jag skyddar din data
+
 Jag använder starka, unika lösenord och tvåfaktorsautentisering för de tjänster som används. Åtkomst är begränsad till det som krävs för att driva sajten.
 
 Ingen metod för dataöverföring är 100% säker. Jag gör rimliga åtgärder för att skydda din information, men kan inte garantera absolut säkerhet.
 
 ## Frågor eller radering
+
 Om du har frågor eller vill att data raderas, kontakta mig på hej@tor-bjorn.com.

--- a/content/swedish/palette-generator/index.md
+++ b/content/swedish/palette-generator/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Palettgenerator"
+terminal_kind: exempt
 date: 2026-02-12
 draft: false
 type: "palette-generator"

--- a/content/swedish/thankyou/index.md
+++ b/content/swedish/thankyou/index.md
@@ -1,5 +1,6 @@
 ---
 title: Tack för ditt meddelande
+terminal_kind: hidden
 description: Tack för ditt meddelande
 layout: thankyou
 linktitle: Tack för ditt meddelande

--- a/content/swedish/ui-library/_index.md
+++ b/content/swedish/ui-library/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "UI-bibliotek"
+terminal_kind: exempt
 date: 2026-01-07
 draft: false
 type: "ui-library"

--- a/docs/features/terminal-followups-plan.md
+++ b/docs/features/terminal-followups-plan.md
@@ -13,7 +13,14 @@ Two follow-ups, in priority order:
 
 ---
 
-## 1. Mobile key bar (accessory row)
+## 1. Mobile key bar (accessory row) — ✅ shipped
+
+> Built as designed below: a `.terminal-keybar` in `footer.html`, styled in
+> `terminal.css` (coarse-pointer only, bracketed mono keys), wired in
+> `darkmode.js` (buttons reuse the existing handlers; `^C` factored into a
+> shared `terminalCancelLine()`; `visualViewport` tracks the keyboard;
+> `pointerdown` preventDefault keeps focus). Covered by four new Jest tests in
+> `terminal-commands.test.js`.
 
 ### Why
 

--- a/docs/features/terminal-followups-plan.md
+++ b/docs/features/terminal-followups-plan.md
@@ -50,7 +50,22 @@ a small on-screen accessory row of keys pinned above the keyboard.
 
 ---
 
-## 2. Terminal in-place navigation (SPA-style, typed-only)
+## 2. Terminal in-place navigation (SPA-style, typed-only) — ✅ shipped
+
+> Built as designed below. New IIFE `assets/js/terminal-nav.js` owns the swap
+> (fetch → swap `#main` → patch head + `--terminal-cwd` → `pushState` → refresh
+> hooks → keep prompt in view), exposing `window.TerminalNav.go()`. darkmode.js's
+> `navigate` action routes typed cd/resume/home here (same-origin, not home, not
+> a language switch) and full-reloads otherwise; `^`-echo already prints to the
+> scrollback so the swap needs no extra output. Special pages are recognised
+> generically post-fetch — the four CSS-bundled pages (home, contact,
+> ui-library, palette-generator) are exactly those carrying a `css/pages/*` /
+> `css-page-*` stylesheet — plus `data-terminal-exempt`. Content re-init
+> collapsed to lightbox figure focusability (exposed via `window.TerminalLightbox`)
+> once we noted reveal is a CSS no-op in terminal and role-swapper is home-only.
+> `popstate` restores in place. Covered by nine Jest tests (`terminal-nav.test.js`)
+> and a Playwright run (typed cd swaps, `cd ~`/click full-reload, back restores,
+> `ls` synergy, no page errors).
 
 ### Goal
 

--- a/docs/features/terminal-guide.md
+++ b/docs/features/terminal-guide.md
@@ -1,0 +1,96 @@
+# Terminal — how to use it
+
+> A personal reference for the terminal layout. Turning on terminal mode is a
+> deliberate act, so this leans all-in on terminal behaviour: the site _is_ a
+> little filesystem you drive with `ls`, `cd`, `cat`. Type `help` in the prompt
+> for the short version; this is the long one.
+
+## The mental model
+
+- **The site is a filesystem.** Sections are directories, documents are files.
+  - `works/`, `writing/` — directories of project/article files.
+  - a project or article — a `slug.md` **file** you `cat`.
+  - `about.md` — a single file (intro + CV in one).
+- **It's append-only, like a real shell.** `cd`, `ls`, `cat` never rewrite what's
+  above — they move the prompt or print _below_ it. Your scrollback is history:
+  each old prompt keeps the directory it ran in; only the bottom prompt tracks
+  where you are now.
+- **What you see is typeable.** Every `~$ cat '…'` / `~$ ls …` the page prints is
+  a real command you can type to reproduce it.
+
+## Turning it on / off
+
+- **On:** Settings → Layout → Terminal (or type `layout terminal` from any other
+  layout).
+- **Off:** `exit`, press `Esc`, click `[exit]`, or `layout column|editorial|index`.
+
+## Getting around
+
+| Command                | Does                                                  |
+| ---------------------- | ----------------------------------------------------- |
+| `ls`                   | list the current directory                            |
+| `ls ~`                 | list the top level (nav)                              |
+| `ls settings/`         | list the settings toggles                             |
+| `ls works/ --featured` | the featured selection                                |
+| `cd works`             | move into a section (prompt only — append-only)       |
+| `cd ~` / `cd ..`       | home / up                                             |
+| `cat utblick-no.2.md`  | print a project/article into the buffer               |
+| `cat about.md`         | print the about page                                  |
+| `cv`                   | just the résumé section of about                      |
+| `open <name>`          | load the _real_ page (escape hatch out of the buffer) |
+| `tree`                 | the whole site map                                    |
+| `pwd`                  | where am I                                            |
+
+On a project page, extra lenses: `ls --info` (role/details/client), `ls
+--related` (siblings), `ls --images` (count). Click an `[image N]` token to open
+the picture in the lightbox (it echoes `open <file>`).
+
+## Reading & reaching things
+
+- `cat <post>.md` works even for a file you only saw via `ls` in a section you
+  `cd`'d into — it fetches it.
+- Quotes work like a real shell: `cat 'a file with spaces.md'` is one argument.
+- `cat colophon` — the footer (© / license / status), reproduced.
+- `cat 'newsletter.txt'` — the newsletter blurb.
+
+## Settings, mode & effects (all live)
+
+| Command                                       | Does                                           |
+| --------------------------------------------- | ---------------------------------------------- |
+| `dark` / `light` / `system`                   | colour mode                                    |
+| `pantone [on\|off\|YYYY]`                     | colour-of-the-year palette (and pick a year)   |
+| `grain` / `blend` / `motion` `on\|off`        | visual effects                                 |
+| `grid`                                        | layout grid overlay                            |
+| `layout <column\|editorial\|index\|terminal>` | switch layout                                  |
+| `lang [sv\|en]`                               | language                                       |
+| `env`                                         | dump the current state (mode/palette/layout/…) |
+| `reset`                                       | restore defaults                               |
+
+## Actions
+
+- `contact` — the contact form, one field at a time (`cancel`/`Esc` aborts).
+- `subscribe` — newsletter signup, same wizard style.
+- `hire` / `social` — quick pointers. `copy email` / `copy url` — to clipboard.
+
+## Keys (desktop)
+
+- `↑` / `↓` — history recall
+- `Tab` — complete a command or path
+- `^L` clear · `^C` cancel line · `^U` clear line
+
+## Keys (mobile)
+
+The accessory bar above the keyboard gives you the keys iOS doesn't: `↑` `↓`
+history, `Tab`, `^C`, and a `⌄` to dismiss the keyboard.
+
+## Easter eggs
+
+There are a few hidden ones (a shell has to have them). `neofetch`, `fortune`,
+`matrix`, `sudo …`, `cowsay`, the Konami code at the prompt — and `easteregg`
+lists the rest. Left out of `help` on purpose.
+
+## Notes / still evolving
+
+- The top-level file/directory model is being tidied so standalone pages
+  (`about`, legal pages) read as files rather than directories — see
+  `terminal-structure-strategy.md`.

--- a/docs/features/terminal-structure-strategy.md
+++ b/docs/features/terminal-structure-strategy.md
@@ -101,11 +101,20 @@ honest and deletes the guesswork.
 3. **Legal pages** → a **`legal/` directory**. Move `license` and `privacy`
    under it so `cd legal; ls` → `license.md privacy.md`, keeping `~` uncluttered.
    (They stay reachable from `cat colophon` too.)
-4. **Tags / taxonomies** → **directories**. A tag lists its tagged posts, so
-   it's a dir like any section: `cd tags/<tag>; ls` → the posts as `.md` files.
-   Hugo already renders each tag as a term list page, so no content work.
+4. **Tags** → **directories, scoped per section** (not a shared global `tags/`).
+   Works and writing each keep their own tags (permalink `/:slug/tags/:title/`),
+   so a tag lives under its section: `works/tags/`, `writing/tags/`. Each tag is
+   a dir listing that section's posts as **symlinks** to their canonical file:
+   `cd works/tags/experimental; ls` → `projekt1.md@ -> ../../projekt1.md`. `cat`
+   follows the link to the same post. A section listing (`ls works`) includes a
+   `tags/` entry alongside the posts. Hugo already renders these term pages, so
+   no content work.
 5. **`works` nav target** → point at `/works/` (the section), so `cd works` and
    the nav agree. The by-tag browse stays reachable via `cd works/tags`.
+
+**One file, many references.** A post has one canonical home (its section);
+tag dirs list it as a symlink, never a copy — matching how the real site lists
+the same post under works and under each of its tags.
 
 ## 7. Scope / cost
 

--- a/docs/features/terminal-structure-strategy.md
+++ b/docs/features/terminal-structure-strategy.md
@@ -1,0 +1,112 @@
+# Terminal structure — repo vs. presentation, and an alignment strategy
+
+> **Status:** working draft / decision doc. The terminal presents the site as a
+> filesystem (`ls`, `cd`, `cat`). This maps what the repo _actually_ is against
+> what the terminal _shows_, flags where they diverge, and proposes one model to
+> align them. Decisions live here, not in chat. Built on the command engine in
+> `assets/js/darkmode.js`.
+
+---
+
+## 1. What the repo actually is (Hugo)
+
+From `content/english/` (Swedish mirrors it):
+
+| Path                                | Hugo kind             | Reality                                         |
+| ----------------------------------- | --------------------- | ----------------------------------------------- |
+| `works/`                            | section (`_index.md`) | **directory** — 11 project posts (leaf bundles) |
+| `writing/`                          | section               | **directory** — 9 article `.md` files           |
+| `newsletter/`                       | section               | a list page + a subscribe action                |
+| `clients/`, `employers/`            | section               | taxonomy-style groupings for works              |
+| `tags/`                             | taxonomy              | **directory** of tag terms                      |
+| `about/`                            | page (`index.md`)     | **single page** — one document (intro + CV)     |
+| `contact/`                          | page                  | a **form** (an action, not a document)          |
+| `license/`, `privacy/`, `thankyou/` | page                  | single utility/legal pages                      |
+| `ui-library/`, `palette-generator/` | section / page        | **visual tools** — can't collapse to text       |
+
+So the repo already has a clean three-way split: **directories** (sections,
+taxonomies), **documents** (posts, about, legal pages), and **things that aren't
+documents** (contact form, the visual tools).
+
+## 2. What the terminal shows today
+
+- `ls ~` → `about/  contact/  works/  writing/`
+- `cd works` / `cd writing` → move into the section; `ls` lists posts; `cat
+post.md` prints one. ✅ matches the repo.
+- Posts render as `slug.md` files. ✅
+- `about` renders as **one file** (`cat about.md`), `cv` prints the résumé. ✅
+- Footer/tour commands (`cat colophon`, `subscribe`, `cat 'newsletter.txt'`,
+  `ls -R ~/`, hero `cat welcome.txt`, `ls works/ --featured`) reproduce. ✅
+
+## 3. Where they diverge
+
+| #      | Repo                                      | Terminal shows                                               | Problem                                                                                                                        |
+| ------ | ----------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| **D1** | `about` = document                        | `about/` in `ls ~`; `cd about` enters it                     | half-file, half-dir: `cat about.md` works and `ls` inside says "it's a file", yet the listing and `cd` treat it as a directory |
+| **D2** | `contact` = form (action)                 | `contact/` in `ls ~`; `cd contact` enters it                 | it's not a place _or_ a file — it's the `contact` command                                                                      |
+| **D3** | `works` section lives at `/works/`        | nav "Works" → `/works/tags/`                                 | the nav target is a taxonomy, not the section root (minor, cosmetic)                                                           |
+| **D4** | `newsletter` = section                    | scattered: footer `subscribe` + `cat 'newsletter.txt'` blurb | is it a place, a file, or an action? Undeclared                                                                                |
+| **D5** | `license`, `privacy` = pages              | only footer links; not in `ls ~`                             | reachable documents that the filesystem never lists                                                                            |
+| **D6** | `ui-library`, `palette-generator` = tools | opt out of terminal (`data-terminal-exempt`)                 | ✅ correct — no change                                                                                                         |
+
+The root cause of D1/D2/D4: **the client can't tell a section from a page from a
+nav link alone.** It currently guesses with a hardcoded list
+(`TERMINAL_SECTION_DIRS = {works, writing, arbeten, texter}` in `darkmode.js`).
+Anything not on that list falls through to ad-hoc handling — which is why
+`about`/`contact` ended up half-and-half.
+
+## 4. Proposed model — four kinds
+
+Give every reachable thing exactly one kind, derived from Hugo, not guessed:
+
+| Kind       | Repo source                         | Terminal render   | Commands                                | Examples                          |
+| ---------- | ----------------------------------- | ----------------- | --------------------------------------- | --------------------------------- |
+| **dir**    | section / taxonomy with children    | `name/`           | `cd`, `ls`, `cat child.md`              | `works/`, `writing/`, `tags/`     |
+| **file**   | post or standalone content page     | `name.md`         | `cat`, `open`; `cd` → "not a directory" | a post, `about.md`, `license.md`  |
+| **action** | interactive page (no readable body) | `name` (no slash) | run it as a command                     | `contact`, `subscribe`            |
+| **exempt** | visual tool                         | (not listed)      | `open` to load the real page            | `ui-library`, `palette-generator` |
+
+Consequences:
+
+- `ls ~` → `about.md  license.md  works/  writing/  contact  …` — files, dirs and
+  actions visually distinct.
+- `cd about` / `cd license` → `not a directory — try: cat about.md`.
+- `cat about.md` / `cat license.md` → the document (already works for about).
+- `contact` stays the form command; it's no longer a fake directory.
+- Legal pages become real, listable files instead of footer-only links.
+
+## 5. The one enabling change
+
+Stop guessing on the client. **Stamp the kind server-side** and let the terminal
+read it:
+
+- In `topmenu.html` / the nav data, emit `data-terminal-kind="dir|file|action"`
+  on each entry, computed from Hugo (`.Kind`, `.IsSection`, path depth, or an
+  explicit front-matter flag like `terminal_kind`).
+- In `darkmode.js`, build the dir tree from that attribute instead of
+  `TERMINAL_SECTION_DIRS`. `ls`, `cd`, `tree` then classify correctly and the
+  hardcoded list goes away.
+
+Everything else (posts as files, `cat`, `cv`, `colophon`, quote parsing, the
+prompt-freeze) already fits this model — this change just makes the _top level_
+honest and deletes the guesswork.
+
+## 6. Open decisions (need your call)
+
+1. **Contact** — action command only (recommended), or also a readable
+   `contact.md`?
+2. **Newsletter** — treat as an **action** (`subscribe`, plus the
+   `newsletter.txt` blurb), and drop it as a "place"? Or keep a `newsletter/`
+   directory listing past issues (if you ever publish any)?
+3. **Legal pages** (`license`, `privacy`) — surface as files in `~`, tuck them
+   under a `legal/` directory, or leave them footer-only?
+4. **`works` nav target** — point it at `/works/` (the section) instead of
+   `/works/tags/`, so `cd works` and the nav agree?
+
+## 7. Scope / cost
+
+Small–medium. The server stamp is a few lines in a partial; the client change
+swaps a hardcoded lookup for an attribute read and adjusts three render sites
+(`ls`, `tree`, `cd`). No content restructuring required (unlike making `about/`
+a real directory, which we explicitly rejected — it would degrade the non-terminal
+`/about/` page). Fully reversible.

--- a/docs/features/terminal-structure-strategy.md
+++ b/docs/features/terminal-structure-strategy.md
@@ -91,22 +91,33 @@ Everything else (posts as files, `cat`, `cv`, `colophon`, quote parsing, the
 prompt-freeze) already fits this model — this change just makes the _top level_
 honest and deletes the guesswork.
 
-## 6. Open decisions (need your call)
+## 6. Decisions (settled)
 
-1. **Contact** — action command only (recommended), or also a readable
-   `contact.md`?
-2. **Newsletter** — treat as an **action** (`subscribe`, plus the
-   `newsletter.txt` blurb), and drop it as a "place"? Or keep a `newsletter/`
-   directory listing past issues (if you ever publish any)?
-3. **Legal pages** (`license`, `privacy`) — surface as files in `~`, tuck them
-   under a `legal/` directory, or leave them footer-only?
-4. **`works` nav target** — point it at `/works/` (the section) instead of
-   `/works/tags/`, so `cd works` and the nav agree?
+1. **Contact** → **action**. `contact` runs the form; `ls ~` shows `contact`
+   (no slash, no `.md`), not a directory. No `contact.md` document.
+2. **Newsletter** → **directory + action**. Issues are planned, so keep
+   `newsletter/` as a section (`cd newsletter; ls` lists issues — empty for
+   now), and `subscribe` / `cat 'newsletter.txt'` stay as the action + blurb.
+3. **Legal pages** → a **`legal/` directory**. Move `license` and `privacy`
+   under it so `cd legal; ls` → `license.md privacy.md`, keeping `~` uncluttered.
+   (They stay reachable from `cat colophon` too.)
+4. **Tags / taxonomies** → **directories**. A tag lists its tagged posts, so
+   it's a dir like any section: `cd tags/<tag>; ls` → the posts as `.md` files.
+   Hugo already renders each tag as a term list page, so no content work.
+5. **`works` nav target** → point at `/works/` (the section), so `cd works` and
+   the nav agree. The by-tag browse stays reachable via `cd works/tags`.
 
 ## 7. Scope / cost
 
-Small–medium. The server stamp is a few lines in a partial; the client change
-swaps a hardcoded lookup for an attribute read and adjusts three render sites
-(`ls`, `tree`, `cd`). No content restructuring required (unlike making `about/`
-a real directory, which we explicitly rejected — it would degrade the non-terminal
-`/about/` page). Fully reversible.
+Small–medium, in two parts:
+
+- **Client + server stamp** (the bulk): emit `data-terminal-kind` from Hugo,
+  swap the hardcoded `TERMINAL_SECTION_DIRS` lookup for it, and adjust three
+  render sites (`ls`, `tree`, `cd`). Fully reversible.
+- **Small content moves**: relocate `license`/`privacy` under `legal/`, and
+  retarget the `works` nav to `/works/`. (Hugo structure isn't sacred — these
+  are cheap.) Add `aliases` on the moved legal pages so old URLs still resolve.
+
+Still off the table: making `about/` a real directory — it would turn the
+non-terminal `/about/` into a listing, and the terminal is an opt-in layer that
+shouldn't degrade the base site.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -290,10 +290,10 @@ other = "Privacy"
 other = "License"
 
 [privacy_url]
-other = "privacy"
+other = "legal/privacy"
 
 [license_url]
-other = "license"
+other = "legal/license"
 
 [footer_meta_label]
 other = "Footer metadata"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -456,3 +456,18 @@ other = "type exit or press esc to leave the terminal"
 
 [terminal_input_label]
 other = "Terminal command input — type a command and press Enter (try 'help')"
+
+[terminal_key_prev]
+other = "Previous command"
+
+[terminal_key_next]
+other = "Next command"
+
+[terminal_key_tab]
+other = "Complete"
+
+[terminal_key_cancel]
+other = "Cancel line"
+
+[terminal_key_bottom]
+other = "Jump to prompt"

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -290,10 +290,10 @@ other = "Integritet"
 other = "Licens"
 
 [privacy_url]
-other = "integritet"
+other = "legal/integritet"
 
 [license_url]
-other = "licens"
+other = "legal/licens"
 
 [footer_meta_label]
 other = "Sidfotsmetadata"

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -450,3 +450,18 @@ other = "skriv exit eller tryck esc för att lämna terminalen"
 
 [terminal_input_label]
 other = "Terminalens kommandorad — skriv ett kommando och tryck Enter (testa 'help')"
+
+[terminal_key_prev]
+other = "Föregående kommando"
+
+[terminal_key_next]
+other = "Nästa kommando"
+
+[terminal_key_tab]
+other = "Komplettera"
+
+[terminal_key_cancel]
+other = "Avbryt raden"
+
+[terminal_key_bottom]
+other = "Hoppa till prompten"

--- a/layouts/_default/legal.html
+++ b/layouts/_default/legal.html
@@ -1,17 +1,34 @@
 {{ partial "header.html" . }}
 
-  <div class="content page use-subgrid">
-    <h1 class="type-headline-1 legal-page__title place-full">
-      {{ .Title }}
-    </h1>
-    {{ with .Description }}
-      <p class="type-preamble is-muted legal-page__description place-prose">
-        {{ . }}
-      </p>
-    {{ end }}
-    <div class="legal-content prose place-prose">
-      {{ .Content }}
-    </div>
+
+<div class="content page use-subgrid">
+  <h1 class="type-headline-1 legal-page__title place-full">
+    {{ .Title }}
+  </h1>
+  {{ with .Description }}
+    <p class="type-preamble is-muted legal-page__description place-prose">
+      {{ . }}
+    </p>
+  {{ end }}
+  <div class="legal-content prose place-prose">
+    {{ .Content }}
   </div>
+  {{ if .IsSection }}
+    {{/* The legal/ section index lists its pages as cards — plain links in
+      most layouts, harvested as `license.md`/`privacy.md` files in the
+      terminal (see darkmode.js's remote-ls).
+    */}}
+    {{ range .Pages }}
+      <article class="summary-card place-prose">
+        <h2 class="summary-card__title type-headline-4">
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </h2>
+        {{ with .Description }}
+          <p class="summary-card__excerpt type-body">{{ . }}</p>
+        {{ end }}
+      </article>
+    {{ end }}
+  {{ end }}
+</div>
 
 {{ partial "footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -187,6 +187,21 @@
         enterkeyhint="go"
       />
     </p>
+    {{/* Mobile key bar: the round-4 keyboard fundamentals (history recall, Tab
+         completion, ^C) ride keys the on-screen keyboard lacks. This accessory
+         row — shown only in terminal layout while the prompt is focused and
+         pinned above the keyboard via the visualViewport API in darkmode.js —
+         surfaces them on touch, plus a ⌄ jump-to-prompt. Buttons carry the
+         glyph for sighted users and an i18n label for assistive tech; the wiring
+         (which preventDefaults so a tap never drops the keyboard) is in
+         darkmode.js. Hidden on desktop via a coarse-pointer media query. */}}
+    <div class="terminal-keybar" data-js="terminal-keybar">
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="prev" aria-label="{{ i18n "terminal_key_prev" }}">↑</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="next" aria-label="{{ i18n "terminal_key_next" }}">↓</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="tab" aria-label="{{ i18n "terminal_key_tab" }}">Tab</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="cancel" aria-label="{{ i18n "terminal_key_cancel" }}">^C</button>
+      <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="bottom" aria-label="{{ i18n "terminal_key_bottom" }}">⌄</button>
+    </div>
   </div>
 </footer>
 <!-- Toast category labels (read by toast.js for title line) -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -704,6 +704,7 @@
   {{ $js20 := resources.Get "js/tabs.js" }}
   {{ $js21 := resources.Get "js/ui-library-pantone-scales.js" }}
   {{ $js_lightbox := resources.Get "js/lightbox.js" }}
+  {{ $js_terminal_nav := resources.Get "js/terminal-nav.js" }}
   {{/* NOTE: theme.js will be archived - logic moved to darkmode.js */}}
 
   <!-- JavaScript loading -->
@@ -750,9 +751,10 @@
       <script src="{{ $js21.RelPermalink }}" defer></script>
     {{ end }}
     <script src="{{ $js_lightbox.RelPermalink }}" defer></script>
+    <script src="{{ $js_terminal_nav.RelPermalink }}" defer></script>
   {{ else }}
     <!-- JavaScript production -->
-    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox }}
+    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav }}
     {{ $js = $js | resources.Concat "js.js" | minify | fingerprint }}
     <script src="{{ $js.RelPermalink }}" defer></script>
     {{ $pageJs := slice }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -552,17 +552,17 @@
     }
   </style>
 
-  {{/* Terminal filesystem manifest: maps each top-level segment to its kind so
-       the terminal classifies ls/cd/tree without a hardcoded guess. Sections are
-       directories, standalone top-level pages are files; a page overrides via a
-       `terminal_kind` param (contact = action, the visual tools = exempt). The
-       client (darkmode.js) reads this to render `works/`, `about.md`, `contact`
-       and to make `cd`/`cat` behave per kind. */}}
+  {{/* Terminal filesystem manifest: maps each top-level segment to its kind and
+       URL so the terminal classifies ls/cd/tree and can fetch a dir without a
+       hardcoded guess. Sections are directories, standalone top-level pages are
+       files; a page overrides its kind via a `terminal_kind` param (contact =
+       action, the visual tools = exempt). The URL lets the terminal reach
+       footer-only sections (legal) that aren't in the nav. */}}
   {{- $kinds := dict -}}
   {{- range site.Sections -}}
     {{- $k := "dir" -}}
     {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
-    {{- $kinds = merge $kinds (dict .Section $k) -}}
+    {{- $kinds = merge $kinds (dict .Section (dict "kind" $k "url" .RelPermalink)) -}}
   {{- end -}}
   {{- range where site.RegularPages "Kind" "page" -}}
     {{- $rel := strings.Trim .RelPermalink "/" -}}
@@ -572,7 +572,7 @@
     {{- if eq (len $segs) 1 -}}
       {{- $k := "file" -}}
       {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
-      {{- $kinds = merge $kinds (dict (index $segs 0) $k) -}}
+      {{- $kinds = merge $kinds (dict (index $segs 0) (dict "kind" $k "url" .RelPermalink)) -}}
     {{- end -}}
   {{- end -}}
   <script type="application/json" data-js="terminal-manifest">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -529,11 +529,22 @@
        as CSS string vars by dimensions/layout/terminal.css; harmless (unused)
        in every other layout. */}}
   {{- $terminalHost := (urls.Parse .Site.BaseURL).Host | default "tor-bjorn.com" -}}
-  {{- $terminalPath := strings.TrimPrefix "/" .RelPermalink -}}
+  {{- $terminalPath := strings.Trim .RelPermalink "/" -}}
   {{- $terminalPath = strings.TrimPrefix (printf "%s/" .Language.Lang) $terminalPath -}}
-  {{- $terminalSeg := index (split $terminalPath "/") 0 -}}
+  {{- $terminalPath = strings.Trim $terminalPath "/" -}}
+  {{- $terminalSegs := split $terminalPath "/" -}}
+  {{- $terminalSeg := index $terminalSegs 0 -}}
   {{- $terminalCwd := "~" -}}
-  {{- if $terminalSeg -}}{{- $terminalCwd = printf "~/%s" $terminalSeg -}}{{- end -}}
+  {{- if $terminalSeg -}}
+    {{- /* A standalone leaf page (about, a legal page) is a FILE that lives in
+           ~ — you `cat about.md` from home — so its cwd is ~, not ~/about. A
+           section listing or a post keeps its section segment as the cwd. */ -}}
+    {{- if and (eq .Kind "page") (eq (len $terminalSegs) 1) -}}
+      {{- $terminalCwd = "~" -}}
+    {{- else -}}
+      {{- $terminalCwd = printf "~/%s" $terminalSeg -}}
+    {{- end -}}
+  {{- end -}}
   <style>
     :root {
       --terminal-host: {{ printf "%q" $terminalHost | safeCSS }};

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -569,7 +569,7 @@
     {{- $rel = strings.TrimPrefix (printf "%s/" .Language.Lang) $rel -}}
     {{- $rel = strings.Trim $rel "/" -}}
     {{- $segs := split $rel "/" -}}
-    {{- if eq (len $segs) 1 -}}
+    {{- if and (eq (len $segs) 1) (ne (.Params.terminal_kind | default "") "hidden") -}}
       {{- $k := "file" -}}
       {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
       {{- $kinds = merge $kinds (dict (index $segs 0) (dict "kind" $k "url" .RelPermalink)) -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -552,6 +552,33 @@
     }
   </style>
 
+  {{/* Terminal filesystem manifest: maps each top-level segment to its kind so
+       the terminal classifies ls/cd/tree without a hardcoded guess. Sections are
+       directories, standalone top-level pages are files; a page overrides via a
+       `terminal_kind` param (contact = action, the visual tools = exempt). The
+       client (darkmode.js) reads this to render `works/`, `about.md`, `contact`
+       and to make `cd`/`cat` behave per kind. */}}
+  {{- $kinds := dict -}}
+  {{- range site.Sections -}}
+    {{- $k := "dir" -}}
+    {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
+    {{- $kinds = merge $kinds (dict .Section $k) -}}
+  {{- end -}}
+  {{- range where site.RegularPages "Kind" "page" -}}
+    {{- $rel := strings.Trim .RelPermalink "/" -}}
+    {{- $rel = strings.TrimPrefix (printf "%s/" .Language.Lang) $rel -}}
+    {{- $rel = strings.Trim $rel "/" -}}
+    {{- $segs := split $rel "/" -}}
+    {{- if eq (len $segs) 1 -}}
+      {{- $k := "file" -}}
+      {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
+      {{- $kinds = merge $kinds (dict (index $segs 0) $k) -}}
+    {{- end -}}
+  {{- end -}}
+  <script type="application/json" data-js="terminal-manifest">
+    {{- $kinds | jsonify | safeJS -}}
+  </script>
+
   <!-- Dark mode -->
   <script>
     (function () {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 {{- /* Visual tool pages (component library, palette generator) can't collapse to text — they opt out of the terminal layout. The pre-hydration script and darkmode.js fall back to column here without touching the stored preference. */ -}}
 {{- $terminalExempt := or (eq .Type "ui-library") (eq .Type "palette-generator") -}}
-<html lang="{{ .Language.Lang }}" data-brand-ready="false"{{ if $terminalExempt }} data-terminal-exempt="true"{{ end }}>
+<html lang="{{ .Language.Lang }}" data-brand-ready="false"{{ if $terminalExempt }} data-terminal-exempt="true"{{ end }}{{ if .IsHome }} data-terminal-home="true"{{ end }}>
   {{ partial "head.html" . }}
 
 

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -34,7 +34,7 @@
         aria-label="{{ i18n "menu_title" | default "Home" }}"
       ></a
       ><span class="terminal-prompt__cwd" aria-hidden="true"></span
-      ><span class="terminal-prompt__cmd" aria-hidden="true">ls nav/</span>
+      ><span class="terminal-prompt__cmd" aria-hidden="true">ls ~</span>
     </div>
     <nav class="top-menu__nav" aria-label="{{ i18n "menu_title" }}">
       <ul class="top-menu__list">


### PR DESCRIPTION
A typed `cd` in the terminal layout now reads like a real shell: instead
of reloading the machine, it swaps the page content under the live prompt
and keeps the scrollback alive. Clicks are deliberately untouched — they
still full-reload with the top `cd` echo (the gentle, battle-tested path).
Only the command engine's `navigate` action (typed cd/resume/home) gets
the new behaviour, so a bug there never reaches click-through visitors.

- terminal-nav.js (new IIFE, window.TerminalNav.go): fetch the URL, swap
  `#main` (importNode keeps its attributes; all terminal chrome lives
  outside <main>, so scrollback/prompt/nav stay intact), patch the SEO
  head fields + `--terminal-cwd`, pushState, refresh content-dependent
  init, keep the prompt in view. popstate restores in place so back/forward
  preserve the scrollback. A view transition cross-fades the swap where
  supported (post-swap init deferred until the transition's DOM update).
- darkmode.js: the `navigate` action routes typed nav here when it can
  swap (terminal layout, same-origin, not home, not a language switch) and
  falls back to a full reload otherwise. The command echo already prints to
  the scrollback, so an in-place swap needs no extra output; on fallback the
  stash reprints it on the reloaded page. `^C`/reload helpers factored out.
- Special pages full-reload, detected generically: the four CSS-bundled
  pages (home, contact, ui-library, palette-generator) are exactly those
  carrying a page-specific stylesheet, plus any data-terminal-exempt page.
  Progressive enhancement: no fetch / parse failure / no #main all fall back.
- lightbox.js exposes window.TerminalLightbox.refresh so swapped-in figures
  stay keyboard-reachable — the only content-init a terminal swap needs
  (reveal is a CSS no-op here, role-swapper is home-only, the cd echo is the
  typed command already in the scrollback).
- head.html bundles terminal-nav.js (dev tags + prod concat).

Synergy: after `cd writing` the new page's cards are in the DOM, so the
round-4 `ls` content-harvest lists them straight away.

Tests: nine Jest cases in terminal-nav.test.js drive the swap / skip /
head-patch / cwd logic against fetched-HTML fixtures; existing nav/cd tests
stay green (full reload when TerminalNav is absent). Verified end-to-end in
Chromium: typed cd swaps in place, `cd ~` and clicks full-reload, back
restores, `ls` synergy works, no page errors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D4zTzBqNu7qwhF5BhQPPgJ