### PR TITLE
Add `ai` terminal assistant (rule-based, no LLM)

### DIFF
--- a/assets/css/__tests__/token-validation.test.js
+++ b/assets/css/__tests__/token-validation.test.js
@@ -24,6 +24,7 @@ const JS_SET_PREFIXES = [
 const JS_SET_EXACT = new Set([
   "--reveal-delay", // set per-element by reveal-on-scroll.js
   "--theme-transition-duration", // set/removed by darkmode.js
+  "--terminal-keybar-h", // mobile key-bar height, measured by darkmode.js
 ]);
 
 // "API vars" — intentionally overridable by context; have CSS fallbacks defined inline

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1648,6 +1648,57 @@
   outline: none;
 }
 
+/* `set` (no args) prints one row per setting: a fixed key column, then the
+   options as clickable chips (each runs its own `set <key> <value>`). Flex-wrap
+   so long option rows (typography) reflow on a phone instead of overflowing. */
+:root[data-layout="terminal"] .terminal-session__settings-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0 0.75ch;
+}
+
+:root[data-layout="terminal"] .terminal-session__settings-key {
+  min-width: 11ch;
+  color: var(--text-muted, inherit);
+}
+
+:root[data-layout="terminal"] .terminal-session__setting {
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: var(--text-link, var(--text-default, inherit));
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+/* The current value is bracketed and accented, mirroring the settings panel's
+   [System] convention. */
+:root[data-layout="terminal"] .terminal-session__setting.is-current {
+  color: var(--text-accent, currentColor);
+}
+
+:root[data-layout="terminal"] .terminal-session__setting.is-current::before {
+  content: "[";
+}
+
+:root[data-layout="terminal"] .terminal-session__setting.is-current::after {
+  content: "]";
+}
+
+:root[data-layout="terminal"] .terminal-session__setting:hover,
+:root[data-layout="terminal"] .terminal-session__setting:focus-visible {
+  color: var(--text-default, inherit);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  outline: none;
+}
+
 /* Echoed answers inside an interactive flow (contact / subscribe) read like
    what the user typed at the field prompt. */
 :root[data-layout="terminal"] .terminal-session__flow {

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1807,6 +1807,14 @@
   outline: none;
 }
 
+/* The [report] chip the assistant prints after a reply: a muted, unshouting
+   affordance to flag a bad answer. No underline at rest (it's not a link into
+   content); it accents on hover like the other clickable tokens. */
+:root[data-layout="terminal"] .terminal-session__report {
+  color: var(--text-muted, inherit);
+  text-decoration: none;
+}
+
 /* Echoed answers inside an interactive flow (contact / subscribe) read like
    what the user typed at the field prompt. */
 :root[data-layout="terminal"] .terminal-session__flow {

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1367,6 +1367,30 @@
   display: none;
 }
 
+/* ============================================================================
+   Boot transcript mode
+
+   When a page replays a real command sequence on load (data-terminal-transcript,
+   set pre-paint in head.html + by darkmode.js), the terminal IS that transcript:
+   the server-rendered header chrome (the `ls nav/` prompt, the nav-as-ls list,
+   the `set` block, the quick-toggles), the page content (#main) and the footer
+   blocks (sitemap, newsletter, colophon) are all things the transcript now
+   reproduces as genuine command output — so they hide, leaving just the banner
+   art, the scrollback and the live prompt. The hidden markup stays in the DOM as
+   the transcript's data source (ls/cat read it) and as the no-JS / crawler
+   fallback: this mode is JS-only, so without JS none of it hides. The banner's
+   fabricated meta (host title + "boot ok") goes too — the curl art stays as the
+   one login splash, everything else is a command you could have typed.
+   ============================================================================ */
+:root[data-terminal-transcript][data-layout="terminal"] .top-menu__container,
+:root[data-terminal-transcript][data-layout="terminal"] #main,
+:root[data-terminal-transcript][data-layout="terminal"] .footer-grid--primary,
+:root[data-terminal-transcript][data-layout="terminal"] .footer-newsletter,
+:root[data-terminal-transcript][data-layout="terminal"] .footer-meta,
+:root[data-terminal-transcript][data-layout="terminal"] .terminal-boot__meta {
+  display: none;
+}
+
 /* The buffer ends with a live prompt. Kept as a normal block so the prompt,
    caret, input and hint all flow inline like one line of terminal text —
    crucially NOT a flex row, which (with the input's native field box) pushed

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1665,7 +1665,10 @@
 }
 
 :root[data-layout="terminal"] .terminal-tail[data-flow-label]::after {
-  content: "  # type cancel to abort";
+  /* Hint text is per-mode: a flow offers its abort word, the `ai` assistant
+     offers its exit word. darkmode.js sets data-flow-hint alongside the label
+     (defaulting to the flow abort hint). */
+  content: "  # " attr(data-flow-hint);
 }
 
 :root[data-layout="terminal"] .footer-column {

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1378,6 +1378,12 @@
   text-align: left;
   margin-top: var(--spacing-24);
   font-size: var(--terminal-font-size);
+  /* Reserve room under the live prompt for the mobile key bar, which is a
+     fixed overlay (see .terminal-keybar) and so takes no layout space of its
+     own. darkmode.js measures the bar and sets --terminal-keybar-h while it is
+     visible; 0 otherwise (desktop, blurred), so this is a no-op there. Without
+     it the prompt scrolls to the very bottom and hides behind the bar. */
+  padding-bottom: var(--terminal-keybar-h, 0px);
 }
 
 :root[data-layout="terminal"] .terminal-tail__prompt::before {
@@ -1407,6 +1413,10 @@
   vertical-align: baseline;
   caret-color: var(--text-accent, currentColor);
   outline: none;
+  /* Focus scroll-into-view leaves the same key-bar gap below the field, so
+     tapping the prompt never lands it behind the bar (pairs with the tail's
+     padding-bottom above). */
+  scroll-margin-bottom: var(--terminal-keybar-h, 0px);
 }
 
 /* Belt-and-braces for iOS Safari, which still paints an inner box otherwise. */

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1361,8 +1361,14 @@
 
 /* Subsequent pages in a session skip the login banner (ASCII art + status):
    a MOTD prints once, not on every cd. The exit hint stays — it's navigation
-   help, not boot chrome. Flag is set pre-paint in head.html, so no flash. */
-:root[data-terminal-booted][data-layout="terminal"] .terminal-boot__art,
+   help, not boot chrome. Flag is set pre-paint in head.html, so no flash.
+   Exception: transcript mode, where every boot is a fresh session start — the
+   art stays as the splash (its own breakpoint rules pick the sm/lg size), so
+   the top never collapses to an empty band on a returning reload. */
+:root[data-terminal-booted][data-layout="terminal"]:not(
+    [data-terminal-transcript]
+  )
+  .terminal-boot__art,
 :root[data-terminal-booted][data-layout="terminal"] .terminal-boot__meta {
   display: none;
 }
@@ -1389,6 +1395,15 @@
 :root[data-terminal-transcript][data-layout="terminal"] .footer-meta,
 :root[data-terminal-transcript][data-layout="terminal"] .terminal-boot__meta {
   display: none;
+}
+
+/* #layout is a min-height:100vh grid whose middle (main) row is 1fr — it fills
+   the viewport. With #main hidden that row still stretched, dropping the footer
+   (scrollback + prompt) to the bottom and opening a tall empty band under the
+   banner. Collapse the rows to content height so the transcript stacks right
+   under the banner; any viewport slack falls harmlessly below the prompt. */
+:root[data-terminal-transcript][data-layout="terminal"] #layout {
+  grid-template-rows: auto auto auto;
 }
 
 /* The buffer ends with a live prompt. Kept as a normal block so the prompt,

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1539,6 +1539,44 @@
    from. The keys read as bracketed mono words, matching the terminal's chrome.
    ============================================================================ */
 
+/* Floating jump-to-prompt button: hidden until the live prompt scrolls out of
+   view (darkmode.js toggles .is-visible), then a small bracketed ⌄ pinned
+   bottom-right that drops you back to the prompt. Terminal chrome — mono, a thin
+   border and the page surface so it stays legible over scrollback, no app-style
+   pill. Hidden entirely outside terminal layout and when the prompt is in view. */
+.terminal-jump {
+  display: none;
+}
+
+:root[data-layout="terminal"] .terminal-jump.is-visible {
+  display: block;
+  position: fixed;
+  right: var(--size-page-margins);
+  bottom: var(--spacing-16);
+  z-index: 50;
+  min-width: 2.5em;
+  min-height: 2.5em;
+  padding: 0 var(--spacing-8);
+  font-family: var(--font-mono);
+  font-size: var(--terminal-font-size);
+  line-height: 2.4;
+  text-align: center;
+  color: var(--text-link, var(--text-default));
+  background: var(--surface-page);
+  border: 1px solid var(--border-subtle);
+  border-radius: 0;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+:root[data-layout="terminal"] .terminal-jump.is-visible:hover,
+:root[data-layout="terminal"] .terminal-jump.is-visible:focus-visible {
+  color: var(--text-default);
+  border-color: var(--text-default);
+  outline: none;
+}
+
 .terminal-keybar {
   display: none;
 }

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -671,7 +671,7 @@
   white-space: nowrap;
 }
 
-/* Second executed command: ls settings/ — placed after the nav rows. */
+/* Second executed command: `set` — placed after the nav rows. */
 :root[data-layout="terminal"] .top-menu__item--terminal-prompt {
   display: block;
   order: 20;
@@ -698,7 +698,7 @@
   content: var(--terminal-host, "tor-bjorn.com");
 }
 
-/* The quick toggles and the expander are the ls settings/ output row. */
+/* The quick toggles and the expander are the `set` output row. */
 :root[data-layout="terminal"] .top-menu__item--terminal-quick {
   order: 21;
 }

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1744,6 +1744,31 @@
   outline: none;
 }
 
+/* Inline links inside a cat'd page: clickable link text (the URL is hidden, the
+   click cats/opens it) — underlined like a terminal's derived hyperlink, sitting
+   in the prose flow. Reset the button chrome so it reads as a word, not a chip. */
+:root[data-layout="terminal"] .terminal-session__link {
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: var(--text-link, var(--text-accent, inherit));
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+:root[data-layout="terminal"] .terminal-session__link:hover,
+:root[data-layout="terminal"] .terminal-session__link:focus-visible {
+  color: var(--text-default, inherit);
+  outline: none;
+}
+
 /* Echoed answers inside an interactive flow (contact / subscribe) read like
    what the user typed at the field prompt. */
 :root[data-layout="terminal"] .terminal-session__flow {

--- a/assets/css/dimensions/layout/terminal.css
+++ b/assets/css/dimensions/layout/terminal.css
@@ -1632,6 +1632,12 @@
   display: block;
 }
 
+/* Blank separator lines (the markdown block gaps a cat'd .md prints) carry no
+   text, so a block box would collapse to zero height — give them a line box. */
+:root[data-layout="terminal"] .terminal-session__line:empty::before {
+  content: "\00a0";
+}
+
 /* Echoed command lines carry the real prompt string, like scrollback.
    Append-only history: darkmode.js pins an inline --terminal-cwd on each echo
    (the cwd it ran at). The :root --terminal-ps1 composite would resolve its

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -47,6 +47,13 @@ function mockTerminal() {
     cwd: jest.fn(() => "~"),
     scrollToEnd: jest.fn(),
     isActive: jest.fn(() => true),
+    // A stand-in for the engine's command vocabulary.
+    isCommand: jest.fn((word) =>
+      ["cv", "cd", "ls", "cat", "open", "help", "clear", "pantone"].includes(
+        String(word || "").toLowerCase()
+      )
+    ),
+    run: jest.fn(),
   };
   return {
     t: t,
@@ -100,6 +107,18 @@ describe("classify", () => {
     expect(ai.classify("jag vill prenumerera på nyhetsbrevet").intent.id).toBe(
       "newsletter"
     );
+  });
+
+  test("routes 'work' questions by context, not to projects", () => {
+    const ai = loadAi();
+    expect(ai.classify("is torbjörn available for work?").intent.id).toBe(
+      "hire"
+    );
+    expect(ai.classify("where do torbjörn work?").intent.id).toBe(
+      "current-job"
+    );
+    // But portfolio phrasing still reaches projects.
+    expect(ai.classify("show me your work").intent.id).toBe("projects");
   });
 
   test("answers bio questions", () => {
@@ -219,6 +238,59 @@ describe("start / handleLine loop", () => {
     m.feed("har du skrivit något om css?");
 
     expect(m.text()).not.toContain("du frågade nyss");
+  });
+
+  test("forwards a real command to the shell instead of chatting", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("cd works");
+
+    expect(m.t.run).toHaveBeenCalledWith("cd works");
+    expect(m.t.releaseInput).toHaveBeenCalled();
+    expect(ai.isActive()).toBe(false);
+    // Not echoed as a chat line, and no fallback/answer printed for it.
+    expect(m.text()).not.toContain("you> cd works");
+  });
+
+  test("bare 'cv' opens the résumé instead of looping", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("cv");
+
+    expect(m.t.run).toHaveBeenCalledWith("cv");
+    expect(ai.isActive()).toBe(false);
+  });
+
+  test("does not forward 'help' or a plain sentence", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("help");
+    m.feed("what do you do?");
+
+    expect(m.t.run).not.toHaveBeenCalled();
+    expect(ai.isActive()).toBe(true);
+  });
+
+  test("'exit' leaves the assistant rather than forwarding", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("exit");
+
+    expect(m.t.run).not.toHaveBeenCalled();
+    expect(m.text()).toContain("hej då");
+    expect(ai.isActive()).toBe(false);
   });
 
   test("exit prints the farewell and releases the prompt", () => {

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -1,0 +1,203 @@
+/**
+ * The terminal `ai` assistant (terminal-ai.js + terminal-ai-data.js).
+ *
+ * Two layers are tested: classify() as a pure function over the intent data,
+ * and the start()/handleLine() loop driven against a mocked window.Terminal —
+ * the same small seam the real command engine (darkmode.js) publishes. Mocking
+ * that seam is exactly what letting the assistant be its own module buys us:
+ * no darkmode.js, no DOM chrome, just the contract.
+ */
+
+// Load the data + engine fresh each time so the module-scoped `active` flag
+// never leaks between tests.
+function loadAi() {
+  let api;
+  jest.isolateModules(() => {
+    require("../terminal-ai-data.js");
+    api = require("../terminal-ai.js");
+  });
+  return api;
+}
+
+// A stand-in for window.Terminal that records prints and remembers the input
+// delegate, so a test can feed lines the way the Enter handler would.
+function mockTerminal() {
+  let delegate = null;
+  let onRelease = null;
+  const prints = [];
+  const t = {
+    print: jest.fn((text, opts) => {
+      prints.push({ text: text, className: opts && opts.className });
+    }),
+    echo: jest.fn(),
+    applyAction: jest.fn(),
+    captureInput: jest.fn((handler, rel) => {
+      delegate = handler;
+      onRelease = rel;
+    }),
+    releaseInput: jest.fn(() => {
+      const cb = onRelease;
+      delegate = null;
+      onRelease = null;
+      if (cb) {
+        cb();
+      }
+    }),
+    setPrompt: jest.fn(),
+    cwd: jest.fn(() => "~"),
+    scrollToEnd: jest.fn(),
+    isActive: jest.fn(() => true),
+  };
+  return {
+    t: t,
+    prints: prints,
+    feed: (value) => delegate && delegate(value),
+    hasDelegate: () => Boolean(delegate),
+    text: () => prints.map((p) => p.text).join("\n"),
+  };
+}
+
+function setLang(lang) {
+  document.documentElement.setAttribute("lang", lang);
+}
+
+beforeEach(() => {
+  setLang("sv");
+  // Reduced motion → boot prints synchronously, so tests need no fake timers.
+  document.documentElement.setAttribute("data-effect-reduced-motion", "on");
+  delete window.Terminal;
+});
+
+describe("classify", () => {
+  test("routes a projects question to the projects intent", () => {
+    const ai = loadAi();
+    expect(ai.classify("vad finns det för projekt?").intent.id).toBe(
+      "projects"
+    );
+    expect(ai.classify("show me your work").intent.id).toBe("projects");
+  });
+
+  test("resolves a category entity inside projects", () => {
+    const ai = loadAi();
+    const r = ai.classify("har du gjort något branding?");
+    expect(r.intent.id).toBe("projects");
+    expect(r.entity && r.entity.id).toBe("brand");
+  });
+
+  test("resolves a writing topic entity", () => {
+    const ai = loadAi();
+    const r = ai.classify("har du skrivit något om css?");
+    expect(r.intent.id).toBe("writing");
+    expect(r.entity && r.entity.id).toBe("css");
+  });
+
+  test("recognises contact, hire and newsletter intents", () => {
+    const ai = loadAi();
+    expect(ai.classify("hur når jag dig?").intent.id).toBe("contact");
+    expect(ai.classify("kan jag anlita dig för ett uppdrag?").intent.id).toBe(
+      "hire"
+    );
+    expect(ai.classify("jag vill prenumerera på nyhetsbrevet").intent.id).toBe(
+      "newsletter"
+    );
+  });
+
+  test("answers bio questions", () => {
+    const ai = loadAi();
+    expect(ai.classify("vem är du?").intent.id).toBe("who");
+    expect(ai.classify("var bor du?").intent.id).toBe("location");
+    expect(ai.classify("var har du pluggat?").intent.id).toBe("education");
+  });
+
+  test("is honest about not being a real AI", () => {
+    const ai = loadAi();
+    expect(ai.classify("är du en riktig ai?").intent.id).toBe("real-ai");
+    expect(ai.classify("are you chatgpt?").intent.id).toBe("real-ai");
+  });
+
+  test("falls back when nothing matches", () => {
+    const ai = loadAi();
+    expect(ai.classify("qwertyuiop zxcvbnm").intent).toBeNull();
+  });
+
+  test("normalize folds Swedish diacritics and punctuation", () => {
+    const ai = loadAi();
+    expect(ai.normalize("Vänner, Öländska!")).toBe("vanner olandska");
+  });
+});
+
+describe("start / handleLine loop", () => {
+  test("boots, captures the prompt, and greets", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+
+    ai.start();
+
+    expect(m.t.captureInput).toHaveBeenCalled();
+    expect(m.t.setPrompt).toHaveBeenCalledWith("you>");
+    expect(ai.isActive()).toBe(true);
+    // The last boot line mentions it's rule-based, not an LLM (Swedish default).
+    expect(m.text()).toContain("ingen LLM");
+  });
+
+  test("answers a question fed through the delegate", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("vad finns det för projekt?");
+
+    expect(m.text()).toContain("11 projekt");
+    // The user's line is echoed in the you> style.
+    expect(m.text()).toContain("you> vad finns det för projekt?");
+  });
+
+  test("hands off to the contact flow and stops owning input", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("hur når jag dig?");
+
+    expect(m.t.applyAction).toHaveBeenCalledWith({
+      type: "flow",
+      flow: "contact",
+    });
+    expect(m.t.releaseInput).toHaveBeenCalled();
+    expect(ai.isActive()).toBe(false);
+  });
+
+  test("exit prints the farewell and releases the prompt", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("exit");
+
+    expect(m.t.releaseInput).toHaveBeenCalled();
+    expect(ai.isActive()).toBe(false);
+    expect(m.text()).toContain("hej då");
+  });
+
+  test("prints an English reply when the document is in English", () => {
+    setLang("en");
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("what do you do?");
+
+    expect(m.text()).toContain("A designer at heart");
+  });
+
+  test("start is inert when the seam is absent", () => {
+    const ai = loadAi();
+    expect(() => ai.start()).not.toThrow();
+    expect(ai.isActive()).toBe(false);
+  });
+});

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -240,7 +240,7 @@ describe("start / handleLine loop", () => {
     expect(m.text()).not.toContain("du frågade nyss");
   });
 
-  test("forwards a real command to the shell instead of chatting", () => {
+  test("runs a real command and stays in the assistant", () => {
     const ai = loadAi();
     const m = mockTerminal();
     window.Terminal = m.t;
@@ -249,10 +249,11 @@ describe("start / handleLine loop", () => {
     m.feed("cd works");
 
     expect(m.t.run).toHaveBeenCalledWith("cd works");
-    expect(m.t.releaseInput).toHaveBeenCalled();
-    expect(ai.isActive()).toBe(false);
-    // Not echoed as a chat line, and no fallback/answer printed for it.
+    // Acknowledged, not chatted at, and the assistant stays put (no hand-off).
+    expect(m.text()).toContain("visst");
     expect(m.text()).not.toContain("you> cd works");
+    expect(m.t.releaseInput).not.toHaveBeenCalled();
+    expect(ai.isActive()).toBe(true);
   });
 
   test("bare 'cv' opens the résumé instead of looping", () => {
@@ -264,7 +265,6 @@ describe("start / handleLine loop", () => {
     m.feed("cv");
 
     expect(m.t.run).toHaveBeenCalledWith("cv");
-    expect(ai.isActive()).toBe(false);
   });
 
   test("does not forward 'help' or a plain sentence", () => {
@@ -317,6 +317,23 @@ describe("start / handleLine loop", () => {
     expect(m.text()).not.toContain("Fastighetsgalan");
     expect(m.text()).not.toContain("Nylokal");
     expect(m.text().toLowerCase()).toContain("arbetsgivarsidorna");
+  });
+
+  test("asks for clarification on an ambiguous terse input", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("css?");
+
+    // "css" ties code (does he know it) and writing (has he written about it).
+    expect(m.text()).toContain("Menar du");
+    expect(m.text()).toContain("om han kan det");
+    expect(m.text()).toContain("vad han skrivit om det");
+    // A follow-up that disambiguates gets a real answer, no clarify.
+    m.feed("skrivit om css");
+    expect(m.text()).toContain("The Grid, Inherited");
   });
 
   test("prints an English reply when the document is in English", () => {

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -135,7 +135,10 @@ describe("start / handleLine loop", () => {
     ai.start();
 
     expect(m.t.captureInput).toHaveBeenCalled();
-    expect(m.t.setPrompt).toHaveBeenCalledWith("you>");
+    expect(m.t.setPrompt).toHaveBeenCalledWith(
+      "you>",
+      expect.objectContaining({ hint: expect.any(String) })
+    );
     expect(ai.isActive()).toBe(true);
     // The last boot line mentions it's rule-based, not an LLM (Swedish default).
     expect(m.text()).toContain("ingen LLM");

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -120,6 +120,21 @@ describe("classify", () => {
     expect(ai.classify("qwertyuiop zxcvbnm").intent).toBeNull();
   });
 
+  test("routes a favourite question to the favourite intent", () => {
+    const ai = loadAi();
+    expect(ai.classify("any favourit essay?").intent.id).toBe("favourite");
+    expect(ai.classify("vilket är ditt bästa jobb?").intent.id).toBe(
+      "favourite"
+    );
+  });
+
+  test("routes 'open one' to open-help, not the writing blurb", () => {
+    const ai = loadAi();
+    expect(ai.classify("can you open one of the text?").intent.id).toBe(
+      "open-help"
+    );
+  });
+
   test("normalize folds Swedish diacritics and punctuation", () => {
     const ai = loadAi();
     expect(ai.normalize("Vänner, Öländska!")).toBe("vanner olandska");
@@ -171,6 +186,33 @@ describe("start / handleLine loop", () => {
     });
     expect(m.t.releaseInput).toHaveBeenCalled();
     expect(ai.isActive()).toBe(false);
+  });
+
+  test("prefaces a verbatim repeat instead of echoing silently", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("vad finns det för projekt?");
+    m.feed("vad finns det för projekt?");
+
+    // The generic projects reply appears both times...
+    expect(m.text().match(/11 projekt/g)).toHaveLength(2);
+    // ...but the second is prefaced as a noticed repeat.
+    expect(m.text()).toContain("du frågade nyss");
+  });
+
+  test("does not treat a different entity as a repeat", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("har du skrivit något?");
+    m.feed("har du skrivit något om css?");
+
+    expect(m.text()).not.toContain("du frågade nyss");
   });
 
   test("exit prints the farewell and releases the prompt", () => {

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -154,6 +154,23 @@ describe("classify", () => {
     );
   });
 
+  test("resolves a public project by name via the title slot", () => {
+    const ai = loadAi();
+    const utblick = ai.classify("utblick");
+    expect(utblick.intent.id).toBe("projects");
+    expect(utblick.entity && utblick.entity.slug).toBe("utblick-no2");
+
+    const things = ai.classify("things in a conversation");
+    expect(things.entity && things.entity.slug).toBe(
+      "things-in-a-conversation"
+    );
+  });
+
+  test("routes 'list them' to projects", () => {
+    const ai = loadAi();
+    expect(ai.classify("can you list them?").intent.id).toBe("projects");
+  });
+
   test("does not resolve a hidden project by name", () => {
     const ai = loadAi();
     // Fastighetsgalan is hidden: true — the assistant shouldn't confirm it.
@@ -265,6 +282,21 @@ describe("start / handleLine loop", () => {
     m.feed("cv");
 
     expect(m.t.run).toHaveBeenCalledWith("cv");
+  });
+
+  test("does not forward a natural sentence that starts with a command word", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("open a project"); // a request, not `open <slug>`
+    m.feed("open things in a conversation?"); // a question about a project
+
+    expect(m.t.run).not.toHaveBeenCalled();
+    // The first is guided by open-help; the second resolves the project (sv).
+    expect(m.text()).toContain("bläddra med");
+    expect(m.text()).toContain("Things in a Conversation");
   });
 
   test("does not forward 'help' or a plain sentence", () => {

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -394,13 +394,18 @@ describe("start / handleLine loop", () => {
     expect(ai.isActive()).toBe(false);
   });
 
-  test("prints a [report] chip after an answer", () => {
+  test("prints a [report] chip on a fallback, not on a real answer", () => {
     const ai = loadAi();
     const m = mockTerminal();
     window.Terminal = m.t;
     ai.start();
+
+    // A confident answer gets no chip (it answered) …
     m.feed("vad finns det för projekt?");
-    // A clickable chip carrying the `report` command follows the reply.
+    expect(m.t.printChip).not.toHaveBeenCalled();
+
+    // … but a fallback (clanker couldn't answer) does — carrying `report`.
+    m.feed("qwertyuiop zxcvbnm");
     expect(m.t.printChip).toHaveBeenCalledWith(
       expect.any(String),
       "report",

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -135,6 +135,12 @@ describe("classify", () => {
     );
   });
 
+  test("does not resolve a hidden project by name", () => {
+    const ai = loadAi();
+    // Fastighetsgalan is hidden: true — the assistant shouldn't confirm it.
+    expect(ai.classify("fastighetsgalan").intent).toBeNull();
+  });
+
   test("normalize folds Swedish diacritics and punctuation", () => {
     const ai = loadAi();
     expect(ai.normalize("Vänner, Öländska!")).toBe("vanner olandska");
@@ -226,6 +232,19 @@ describe("start / handleLine loop", () => {
     expect(m.t.releaseInput).toHaveBeenCalled();
     expect(ai.isActive()).toBe(false);
     expect(m.text()).toContain("hej då");
+  });
+
+  test("brand category doesn't volunteer hidden project names", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("har du gjort något branding?");
+
+    expect(m.text()).not.toContain("Fastighetsgalan");
+    expect(m.text()).not.toContain("Nylokal");
+    expect(m.text().toLowerCase()).toContain("arbetsgivarsidorna");
   });
 
   test("prints an English reply when the document is in English", () => {

--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -44,6 +44,14 @@ function mockTerminal() {
       }
     }),
     setPrompt: jest.fn(),
+    printChip: jest.fn((label, cmd, opts) => {
+      prints.push({
+        text: "[" + label + "]",
+        cmd: cmd,
+        chip: true,
+        opts: opts,
+      });
+    }),
     cwd: jest.fn(() => "~"),
     scrollToEnd: jest.fn(),
     isActive: jest.fn(() => true),
@@ -384,5 +392,71 @@ describe("start / handleLine loop", () => {
     const ai = loadAi();
     expect(() => ai.start()).not.toThrow();
     expect(ai.isActive()).toBe(false);
+  });
+
+  test("prints a [report] chip after an answer", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+    m.feed("vad finns det för projekt?");
+    // A clickable chip carrying the `report` command follows the reply.
+    expect(m.t.printChip).toHaveBeenCalledWith(
+      expect.any(String),
+      "report",
+      expect.any(Object)
+    );
+  });
+
+  test("report() POSTs the last exchange and confirms", () => {
+    const fetchMock = jest.fn(() => Promise.resolve({ ok: true }));
+    window.fetch = fetchMock;
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+    m.feed("vad finns det för projekt?");
+    ai.report("borde nämna X");
+
+    expect(fetchMock).toHaveBeenCalled();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.type).toBe("report");
+    expect(body.query).toBe("vad finns det för projekt?");
+    expect(body.note).toBe("borde nämna X");
+    expect(body.intent).toBe("projects");
+    // Confirmation printed (Swedish default).
+    expect(m.text().toLowerCase()).toContain("tack");
+    delete window.fetch;
+  });
+
+  test("report() with nothing asked yet says so and does not POST", () => {
+    const fetchMock = jest.fn(() => Promise.resolve({ ok: true }));
+    window.fetch = fetchMock;
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+    ai.report("");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(m.text().toLowerCase()).toContain("inget att rapportera");
+    delete window.fetch;
+  });
+
+  test("auto-logs an unmatched question as a miss, deduped per session", () => {
+    const fetchMock = jest.fn(() => Promise.resolve({ ok: true }));
+    window.fetch = fetchMock;
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("what is the meaning of life?");
+    m.feed("what is the meaning of life?"); // same miss again → not re-sent
+    const misses = fetchMock.mock.calls.filter(
+      (c) => JSON.parse(c[1].body).type === "miss"
+    );
+    expect(misses).toHaveLength(1);
+    expect(JSON.parse(misses[0][1].body).kind).toBe("fallback");
+    delete window.fetch;
   });
 });

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -200,6 +200,37 @@ describe("terminal command line", () => {
     expect(document.documentElement.getAttribute("data-mode")).toBe("light");
   });
 
+  test("set <key> <value> changes a setting via the shared grammar", () => {
+    loadModule();
+    typeCommand("set mode dark");
+    expect(document.documentElement.getAttribute("data-mode")).toBe("dark");
+    typeCommand("set typography technical");
+    expect(localStorage.getItem("theme-typography")).toBe("technical");
+  });
+
+  test("set with no args lists current values", () => {
+    loadModule();
+    typeCommand("set");
+    const out = sessionText();
+    expect(out).toContain("mode");
+    expect(out).toContain("typography");
+    expect(out).toContain("set <name> <value>");
+  });
+
+  test("set rejects an unknown setting and a bad value", () => {
+    loadModule();
+    typeCommand("set bogus x");
+    expect(sessionText()).toContain("unknown setting");
+    typeCommand("set typography wingdings");
+    expect(sessionText()).toContain("set typography: try");
+  });
+
+  test("share copies a themed link", () => {
+    loadModule();
+    typeCommand("share");
+    expect(sessionText()).toContain("copied a link to this exact look");
+  });
+
   test("pantone on activates the colour-of-the-year effect", () => {
     loadModule();
     typeCommand("pantone on");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1204,6 +1204,27 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("menu, not a directory");
   });
 
+  test("cat of a bare featured slug resolves to its card href (not 'No such file')", async () => {
+    // `ls works/ --featured` lists posts as bare `slug.md`, but their real home
+    // is /writing|works/slug/. Catting the bare slug must match the card on the
+    // page and fetch its href — not 404 as an unknown top-level file.
+    window.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve('<div class="content post"><p>Body.</p></div>'),
+    });
+    loadModule();
+    typeCommand("cat the-grid-inherited.md");
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve();
+    }
+    expect(window.fetch).toHaveBeenCalled();
+    expect(window.fetch.mock.calls[0][0]).toContain(
+      "/writing/the-grid-inherited/"
+    );
+    expect(sessionText()).not.toContain("No such file or directory");
+  });
+
   test("open navigates to a post file", () => {
     loadModule();
     const before = sessionText();

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1153,6 +1153,39 @@ describe("terminal command line", () => {
     );
   });
 
+  test("clicking a directory entry in transcript mode opens it (cd then ls)", () => {
+    // In the append-only transcript, a clicked folder navigates by listing
+    // itself right below — cd (move) then ls (show) — with no page reload.
+    document.documentElement.setAttribute("data-terminal-transcript", "1");
+    loadModule();
+    typeCommand("ls");
+    const dir = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cd works"]'
+    );
+    expect(dir).not.toBeNull();
+    dir.dispatchEvent(new window.Event("click", { bubbles: true }));
+    const cmds = [...document.querySelectorAll(".terminal-session__cmd")].map(
+      (n) => n.textContent
+    );
+    // The last two echoes are the cd and its follow-up ls.
+    expect(cmds[cmds.length - 2]).toBe("cd works");
+    expect(cmds[cmds.length - 1]).toBe("ls");
+  });
+
+  test("clicking a directory entry outside transcript mode just cds (no ls)", () => {
+    loadModule();
+    typeCommand("ls");
+    const dir = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cd works"]'
+    );
+    dir.dispatchEvent(new window.Event("click", { bubbles: true }));
+    const cmds = [...document.querySelectorAll(".terminal-session__cmd")].map(
+      (n) => n.textContent
+    );
+    // No auto-ls appended — the plain layout keeps shell-literal cd.
+    expect(cmds[cmds.length - 1]).toBe("cd works");
+  });
+
   test("ls nav/ and ls settings/ list the menus (as the header prints them)", () => {
     loadModule();
     typeCommand("ls nav/");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1187,12 +1187,36 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("try: cat a-cut-up-world.md");
   });
 
-  test("ls --featured lists the page's cards as files (not misread as -a)", () => {
+  test("ls --featured lists the page's cards as clickable files (not misread as -a)", () => {
     loadModule();
     typeCommand("ls works/ --featured");
     // The article-card link → a .md file; the long flag must not trip -a.
     expect(sessionText()).toContain("the-grid-inherited.md");
     expect(sessionText()).not.toContain(".secret");
+    // Featured entries are clickable, like a plain ls — each cats itself.
+    const entry = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cat the-grid-inherited.md"]'
+    );
+    expect(entry).not.toBeNull();
+    const before = sessionText();
+    entry.dispatchEvent(new window.Event("click", { bubbles: true }));
+    expect(sessionText().slice(before.length)).toContain(
+      "cat the-grid-inherited.md"
+    );
+  });
+
+  test("cat welcome.txt prints the localized hero prose from the DOM", () => {
+    const pre = document.createElement("pre");
+    pre.setAttribute("hidden", "");
+    pre.setAttribute("data-js", "terminal-welcome");
+    pre.textContent = "\nHej, Torbjörn här — designer.\nBaserad i Göteborg.\n";
+    document.body.appendChild(pre);
+    loadModule();
+    typeCommand("cat welcome.txt");
+    // The localized copy wins over the hardcoded English fallback.
+    expect(sessionText()).toContain("Hej, Torbjörn här — designer.");
+    expect(sessionText()).toContain("Baserad i Göteborg.");
+    expect(sessionText()).not.toContain("Hi, Torbjörn here");
   });
 
   test("subscribe reuses the newsletter form action", async () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1312,6 +1312,36 @@ describe("terminal command line", () => {
     ).toBe(true);
   });
 
+  test("entering terminal via the toggle replays the transcript (no reload)", () => {
+    // Loaded in column, so init doesn't run the transcript; the sequence is
+    // still published on <html>. Toggling terminal on must replay it, matching a
+    // reload — otherwise the toggle showed old chrome and a reload the session.
+    localStorage.setItem("theme-layout", "column");
+    document.documentElement.setAttribute("data-layout", "column");
+    document.documentElement.setAttribute("data-terminal-boot", "ls; set");
+    loadModule();
+    expect(sessionText().trim()).toBe(""); // nothing yet — not in terminal
+    window.ThemeActions.setLayout("terminal");
+    jest.runOnlyPendingTimers(); // the runner is deferred a tick past applyLayout
+    expect(sessionText()).toContain("mode"); // `set` output rendered
+    expect(
+      document.documentElement.hasAttribute("data-terminal-transcript")
+    ).toBe(true);
+  });
+
+  test("a layout toggle mid-session keeps the existing scrollback (no re-replay)", () => {
+    document.documentElement.setAttribute("data-terminal-boot", "ls; set");
+    loadModule();
+    typeCommand("help");
+    const before = sessionText();
+    // Leave to column and back — the session persists, transcript doesn't stack.
+    window.ThemeActions.setLayout("column");
+    window.ThemeActions.setLayout("terminal");
+    jest.runOnlyPendingTimers();
+    // No second `set` block appended; the typed `help` is still there.
+    expect(sessionText()).toBe(before);
+  });
+
   test("boot transcript commands land in ↑ history", () => {
     document.documentElement.setAttribute("data-terminal-boot", "ls; set");
     loadModule();

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -54,6 +54,14 @@ describe("terminal command line", () => {
     localStorage.clear();
     localStorage.setItem("theme-layout", "terminal");
     document.documentElement.setAttribute("data-layout", "terminal");
+    // These live on <html>, which innerHTML below doesn't reset — clear the
+    // ones individual tests set so state can't leak between cases.
+    [
+      "data-terminal-boot",
+      "data-terminal-transcript",
+      "data-terminal-exempt",
+      "data-terminal-booted",
+    ].forEach((attr) => document.documentElement.removeAttribute(attr));
 
     document.documentElement.innerHTML = `
       <head><meta name="theme-color" content="#ffffff">
@@ -1219,6 +1227,61 @@ describe("terminal command line", () => {
     expect(document.documentElement.hasAttribute("data-terminal-booted")).toBe(
       false
     );
+  });
+
+  // ---- boot transcript --------------------------------------------------
+
+  test("boot replays the page's declared command sequence into the scrollback", () => {
+    // The home page declares its transcript on <html>; on load each command
+    // runs through the same path as typing it, so the session reads as a real
+    // session (and each lands in ↑ history).
+    document.documentElement.setAttribute(
+      "data-terminal-boot",
+      "ls; set; cat welcome.txt; ls works/ --featured"
+    );
+    loadModule();
+    const text = sessionText();
+    // Echoes of each command (the __cmd lines carry the raw command text).
+    expect(text).toContain("ls");
+    expect(text).toContain("set");
+    expect(text).toContain("cat welcome.txt");
+    // Output of the commands: the welcome blurb, a settings row, a featured card.
+    expect(text.toLowerCase()).toContain("torbjörn");
+    expect(text).toContain("mode");
+    expect(text).toContain("the-grid-inherited.md");
+    // The transcript owns the view — the CSS gate is set so chrome/content hide.
+    expect(
+      document.documentElement.hasAttribute("data-terminal-transcript")
+    ).toBe(true);
+  });
+
+  test("boot transcript commands land in ↑ history", () => {
+    document.documentElement.setAttribute("data-terminal-boot", "ls; set");
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.dispatchEvent(
+      new window.KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true })
+    );
+    // Most recent boot command is recalled first.
+    expect(input.value).toBe("set");
+  });
+
+  test("no boot attr → no transcript, empty session, no CSS gate", () => {
+    loadModule();
+    expect(sessionText().trim()).toBe("");
+    expect(
+      document.documentElement.hasAttribute("data-terminal-transcript")
+    ).toBe(false);
+  });
+
+  test("boot transcript does not run on an exempt page", () => {
+    document.documentElement.setAttribute("data-terminal-exempt", "");
+    document.documentElement.setAttribute("data-terminal-boot", "ls; set");
+    loadModule();
+    expect(sessionText().trim()).toBe("");
+    expect(
+      document.documentElement.hasAttribute("data-terminal-transcript")
+    ).toBe(false);
   });
 
   // ---- language command -------------------------------------------------

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -217,6 +217,17 @@ describe("terminal command line", () => {
     expect(out).toContain("set <name> <value>");
   });
 
+  test("set renders clickable chips that run the command on click", () => {
+    loadModule();
+    typeCommand("set");
+    const chip = document.querySelector(
+      '.terminal-session__setting[data-cmd="set mode dark"]'
+    );
+    expect(chip).not.toBeNull();
+    chip.dispatchEvent(new window.Event("click", { bubbles: true }));
+    expect(document.documentElement.getAttribute("data-mode")).toBe("dark");
+  });
+
   test("set rejects an unknown setting and a bad value", () => {
     loadModule();
     typeCommand("set bogus x");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -702,6 +702,17 @@ describe("terminal command line", () => {
     expect(input.value).toBe("cd writing");
   });
 
+  test("Tab completes a set key and then its value", () => {
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "set ty";
+    keydown({ key: "Tab" });
+    expect(input.value).toBe("set typography");
+    input.value = "set mode d";
+    keydown({ key: "Tab" });
+    expect(input.value).toBe("set mode dark");
+  });
+
   test("Ctrl+L clears the screen, Ctrl+C cancels the line", () => {
     loadModule();
     const input = document.querySelector('[data-js="terminal-input"]');

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -62,6 +62,9 @@ describe("terminal command line", () => {
       "data-terminal-exempt",
       "data-terminal-booted",
     ].forEach((attr) => document.documentElement.removeAttribute(attr));
+    // A test may pushState to a deeper path; reset so location-derived logic
+    // (the current-page slug) starts from home each case.
+    window.history.pushState({}, "", "/");
 
     document.documentElement.innerHTML = `
       <head><meta name="theme-color" content="#ffffff">
@@ -1202,6 +1205,21 @@ describe("terminal command line", () => {
     loadModule();
     typeCommand("cd settings");
     expect(sessionText()).toContain("menu, not a directory");
+  });
+
+  test("cat of the current page reads #main locally (no self-fetch)", () => {
+    // On a post's own page, the boot's `cat <slug>.md` must print the live
+    // #main synchronously, not re-fetch the page it's already on.
+    window.history.pushState({}, "", "/works/utblick-no.2/");
+    const main = document.createElement("main");
+    main.id = "main";
+    main.innerHTML = '<div class="content post"><p>Local body line.</p></div>';
+    document.body.appendChild(main);
+    window.fetch = jest.fn();
+    loadModule();
+    typeCommand("cat utblick-no.2.md");
+    expect(sessionText()).toContain("Local body line.");
+    expect(window.fetch).not.toHaveBeenCalled();
   });
 
   test("cat of a bare featured slug resolves to its card href (not 'No such file')", async () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1222,6 +1222,38 @@ describe("terminal command line", () => {
     expect(window.fetch).not.toHaveBeenCalled();
   });
 
+  test("cat renders a post's markdown structure (headings, quote, list, emphasis)", () => {
+    window.history.pushState({}, "", "/works/demo/");
+    const main = document.createElement("main");
+    main.id = "main";
+    main.innerHTML =
+      '<div class="content post">' +
+      "<h1>Title</h1>" +
+      "<p>Lead with <strong>bold</strong> and <em>italic</em>.</p>" +
+      "<h2>About</h2>" +
+      "<p>Body para.</p>" +
+      "<blockquote>A quote.</blockquote>" +
+      "<ul><li>One</li><li>Two</li></ul>" +
+      "</div>";
+    document.body.appendChild(main);
+    loadModule();
+    typeCommand("cat demo.md");
+    const lines = [...document.querySelectorAll(".terminal-session__out")].map(
+      (n) => n.textContent
+    );
+    expect(lines).toContain("# Title");
+    expect(lines).toContain("## About");
+    expect(lines).toContain("Lead with **bold** and *italic*.");
+    expect(lines).toContain("> A quote.");
+    expect(lines).toContain("- One");
+    expect(lines).toContain("- Two");
+    // A blank line separates blocks (the terminal's markdown margin).
+    expect(lines).toContain("");
+    // Consecutive list items stay tight — no blank between One and Two.
+    const one = lines.indexOf("- One");
+    expect(lines[one + 1]).toBe("- Two");
+  });
+
   test("cat of a bare featured slug resolves to its card href (not 'No such file')", async () => {
     // `ls works/ --featured` lists posts as bare `slug.md`, but their real home
     // is /writing|works/slug/. Catting the bare slug must match the card on the

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -152,6 +152,7 @@ describe("terminal command line", () => {
           <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="cancel" aria-label="Cancel line">^C</button>
           <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="bottom" aria-label="Jump to prompt">⌄</button>
         </div>
+        <button class="terminal-jump" type="button" data-js="terminal-jump" aria-label="Jump to prompt">⌄</button>
       </body>
     `;
 
@@ -1381,6 +1382,26 @@ describe("terminal command line", () => {
     expect(document.documentElement.hasAttribute("data-terminal-booted")).toBe(
       false
     );
+  });
+
+  test("jump-to-prompt button shows when the live prompt scrolls out of view", () => {
+    let ioCallback;
+    window.IntersectionObserver = class {
+      constructor(cb) {
+        ioCallback = cb;
+      }
+      observe() {}
+      disconnect() {}
+    };
+    loadModule();
+    const jump = document.querySelector('[data-js="terminal-jump"]');
+    expect(jump).not.toBeNull();
+    // Prompt out of view → button appears; back in view → it hides.
+    ioCallback([{ isIntersecting: false }]);
+    expect(jump.classList.contains("is-visible")).toBe(true);
+    ioCallback([{ isIntersecting: true }]);
+    expect(jump.classList.contains("is-visible")).toBe(false);
+    delete window.IntersectionObserver;
   });
 
   // ---- boot transcript --------------------------------------------------

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1254,6 +1254,32 @@ describe("terminal command line", () => {
     expect(lines[one + 1]).toBe("- Two");
   });
 
+  test("cat turns markdown links into clickable tokens (internal cats, external opens)", () => {
+    window.history.pushState({}, "", "/writing/demo/");
+    const main = document.createElement("main");
+    main.id = "main";
+    main.innerHTML =
+      '<div class="content post"><p>See ' +
+      '<a href="/writing/the-grid-inherited/">The Grid</a> and ' +
+      '<a href="https://example.com/x">the source</a>.</p></div>';
+    document.body.appendChild(main);
+    loadModule();
+    typeCommand("cat demo.md");
+    // Internal link → cats the post's slug; external → opens the URL.
+    const internal = document.querySelector(
+      '.terminal-session__link[data-cmd="cat the-grid-inherited.md"]'
+    );
+    const external = document.querySelector(
+      '.terminal-session__link[data-cmd="open https://example.com/x"]'
+    );
+    expect(internal).not.toBeNull();
+    expect(internal.textContent).toBe("The Grid");
+    expect(external).not.toBeNull();
+    // URL is hidden — only the link text shows in the prose.
+    expect(sessionText()).toContain("See The Grid and the source.");
+    expect(sessionText()).not.toContain("example.com/x");
+  });
+
   test("cat of a bare featured slug resolves to its card href (not 'No such file')", async () => {
     // `ls works/ --featured` lists posts as bare `slug.md`, but their real home
     // is /writing|works/slug/. Catting the bare slug must match the card on the

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1038,7 +1038,7 @@ describe("terminal command line", () => {
     const before = sessionText();
     typeCommand("ls settings/");
     const added = sessionText().slice(before.length);
-    expect(added).toContain("theme");
+    expect(added).toContain("mode");
     expect(added).toContain("language");
   });
 

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -489,6 +489,21 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("writing/");
   });
 
+  test("ls renders clickable entries that run cd/cat/open", () => {
+    loadModule();
+    typeCommand("ls");
+    const dir = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cd works"]'
+    );
+    const file = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cat about.md"]'
+    );
+    expect(dir).not.toBeNull();
+    expect(file).not.toBeNull();
+    dir.dispatchEvent(new window.Event("click", { bubbles: true }));
+    expect(sessionText()).toContain("cd works");
+  });
+
   test("ls <path> lists that directory; unknown paths error", () => {
     loadModule();
     typeCommand("ls works");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1404,6 +1404,15 @@ describe("terminal command line", () => {
     delete window.IntersectionObserver;
   });
 
+  test("report command hands the last exchange to the assistant", () => {
+    const reportSpy = jest.fn();
+    window.TerminalAI = { report: reportSpy };
+    loadModule();
+    typeCommand("report needs more detail");
+    expect(reportSpy).toHaveBeenCalledWith("needs more detail");
+    delete window.TerminalAI;
+  });
+
   // ---- boot transcript --------------------------------------------------
 
   test("boot replays the page's declared command sequence into the scrollback", () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1098,6 +1098,53 @@ describe("terminal command line", () => {
     );
   });
 
+  test("append-only ls renders the fetched section's posts as clickable files", async () => {
+    // After `cd writing` (append-only: the live cwd moves, the loaded page
+    // doesn't), a bare `ls` can't read the DOM — it fetches /writing/ and lists
+    // it below. Those posts must be clickable too, just like a local `ls`.
+    loadModule();
+    // Page cwd is home (~); the live cwd has moved into ~/writing.
+    window.getComputedStyle = jest.fn(() => ({
+      getPropertyValue: jest.fn((prop) =>
+        prop === "--terminal-live-cwd"
+          ? "~/writing"
+          : prop === "--terminal-cwd"
+          ? "~"
+          : "#ffffff"
+      ),
+    }));
+    window.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<div class="summary-card"><a href="/writing/the-grid-inherited/">The grid</a></div>' +
+            '<div class="summary-card"><a href="/writing/another-post/">Another</a></div>'
+        ),
+    });
+    typeCommand("ls");
+    // The remote-ls handler is async (fetch → parse → print); flush its chain.
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve();
+    }
+
+    const post = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cat the-grid-inherited.md"]'
+    );
+    expect(post).not.toBeNull();
+    expect(
+      document.querySelector(
+        '.terminal-session__ls-entry[data-cmd="cat another-post.md"]'
+      )
+    ).not.toBeNull();
+
+    const before = sessionText();
+    post.dispatchEvent(new window.Event("click", { bubbles: true }));
+    // Clicking cats the post cwd-relatively (resolves under ~/writing).
+    expect(sessionText().slice(before.length)).toContain(
+      "cat the-grid-inherited.md"
+    );
+  });
+
   test("ls nav/ and ls settings/ list the menus (as the header prints them)", () => {
     loadModule();
     typeCommand("ls nav/");

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1404,6 +1404,20 @@ describe("terminal command line", () => {
     delete window.IntersectionObserver;
   });
 
+  test("picking terminal on an exempt tool stores it and heads home", () => {
+    // Visual tools can't be a terminal; choosing it there stores the preference
+    // and navigates home (jsdom no-ops the navigation, so assert the storage).
+    localStorage.setItem("theme-layout", "column");
+    document.documentElement.setAttribute("data-layout", "column");
+    document.documentElement.setAttribute("data-terminal-exempt", "true");
+    document.documentElement.setAttribute("data-home-url", "/");
+    loadModule();
+    window.ThemeActions.setLayout("terminal");
+    expect(localStorage.getItem("theme-layout")).toBe("terminal");
+    // It did NOT apply terminal in place (this page can't render it).
+    expect(document.documentElement.getAttribute("data-layout")).toBe("column");
+  });
+
   test("report command hands the last exchange to the assistant", () => {
     const reportSpy = jest.fn();
     window.TerminalAI = { report: reportSpy };

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3516,6 +3516,21 @@
     // cards (works/writing posts) the nav tree can't know about. Resolve the
     // path to absolute segments (relative to cwd), then match a content-card
     // link by its full segments, so cd and ls agree on what exists.
+    // The slug of the page currently loaded (last path segment, language prefix
+    // stripped) — so the boot transcript's `cat <slug>.md` on a post/about reads
+    // the live #main instead of re-fetching the page it's already on.
+    function terminalCurrentPageSlug() {
+      var path = window.location.pathname.replace(/[?#].*$/, "");
+      var segs = path.split("/").filter(Boolean);
+      var lang = (
+        document.documentElement.getAttribute("lang") || ""
+      ).toLowerCase();
+      if (segs.length && segs[0].toLowerCase() === lang) {
+        segs.shift();
+      }
+      return segs.length ? segs[segs.length - 1].toLowerCase() : "";
+    }
+
     function terminalContentTargetHref(dest) {
       var wanted = terminalResolveSegments(dest);
       if (!wanted.length) {
@@ -4271,6 +4286,21 @@
                   "/",
               ],
               action: null,
+            };
+          }
+          // The page you're already on: read its #main straight from the live
+          // DOM rather than re-fetching it (the boot transcript's `cat <slug>.md`
+          // on a post/about). Synchronous, so the content is there at once — no
+          // blank flash while a fetch round-trips.
+          if (
+            catName &&
+            catName === terminalCurrentPageSlug() &&
+            document.querySelector("#main .content.post, #main .content.page")
+          ) {
+            return {
+              echo: input,
+              lines: [],
+              action: { type: "cat-local", name: args[0] },
             };
           }
           // Real page first: a content post, or a readable page (about.md,
@@ -5273,25 +5303,10 @@
             })
             .then(function (html) {
               var doc = new DOMParser().parseFromString(html, "text/html");
-              var catTokens = terminalExtractPostLines(
-                doc,
-                action.url,
-                action.root
+              printTerminalCatTokens(
+                terminalExtractPostLines(doc, action.url, action.root),
+                catLabel
               );
-              if (!catTokens.length) {
-                printTerminalLine(
-                  "cat: " + catLabel + ": (empty)",
-                  "terminal-session__out"
-                );
-              } else {
-                catTokens.forEach(function (tok) {
-                  if (tok.image) {
-                    printTerminalImageLine(tok);
-                  } else {
-                    printTerminalLine(tok.text, "terminal-session__out");
-                  }
-                });
-              }
               scrollTerminalToEnd();
             })
             .catch(function (err) {
@@ -5305,6 +5320,16 @@
             });
           break;
         }
+        case "cat-local":
+          // The current page's own file: read #main directly instead of
+          // re-fetching the page you're already on (the boot transcript's
+          // `cat <slug>.md` on a post/about). Synchronous, so no blank flash
+          // while a fetch round-trips.
+          printTerminalCatTokens(
+            terminalExtractPostLines(document, window.location.href, null),
+            action.name
+          );
+          break;
         case "flow":
           startTerminalFlow(action.flow);
           break;
@@ -5379,6 +5404,26 @@
       btn.setAttribute("data-image-alt", tok.alt || "");
       line.appendChild(btn);
       terminalSession.appendChild(line);
+    }
+
+    // Print a cat'd file's extracted tokens (text lines + [image N] tokens),
+    // or an "(empty)" note. Shared by remote-cat (fetched) and cat-local (the
+    // current page read straight from #main).
+    function printTerminalCatTokens(tokens, label) {
+      if (!tokens || !tokens.length) {
+        printTerminalLine(
+          "cat: " + (label || "file") + ": (empty)",
+          "terminal-session__out"
+        );
+        return;
+      }
+      tokens.forEach(function (tok) {
+        if (tok.image) {
+          printTerminalImageLine(tok);
+        } else {
+          printTerminalLine(tok.text, "terminal-session__out");
+        }
+      });
     }
 
     // `set` (no args) prints the settings as clickable chip rows — the settings

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3068,6 +3068,12 @@
             out += "*" + terminalInlineMarkdown(n).trim() + "*";
           } else if (t === "code") {
             out += "`" + terminalInlineMarkdown(n).trim() + "`";
+          } else if (t === "a") {
+            // Keep links as markdown [text](href); the cat printer turns them
+            // into clickable tokens (the printer needs the href to route them).
+            var href = n.getAttribute("href") || "";
+            var label = terminalInlineMarkdown(n).trim();
+            out += href && label ? "[" + label + "](" + href + ")" : label;
           } else {
             out += terminalInlineMarkdown(n);
           }
@@ -4442,6 +4448,15 @@
               action: null,
             };
           }
+          // An absolute URL (an external link clicked in a cat'd page) opens
+          // directly — a new tab for http(s), the handler app for mailto:/tel:.
+          if (/^(https?:|mailto:|tel:)/i.test(args[0])) {
+            return {
+              echo: input,
+              lines: [],
+              action: { type: "open-external", url: args[0] },
+            };
+          }
           // A general "go there": resolves a section OR a post (resolveCdTarget
           // already falls through to content files) and navigates.
           var openName = args[0].replace(/\/$/, "").replace(/\.(md|txt)$/i, "");
@@ -5291,6 +5306,19 @@
             navigateTerminal(action);
           }
           break;
+        case "open-external":
+          // http(s) opens in a new tab so the terminal session survives;
+          // mailto:/tel: hand off to the OS handler via a same-tab assignment.
+          try {
+            if (/^https?:/i.test(action.url)) {
+              window.open(action.url, "_blank", "noopener");
+            } else {
+              window.location.href = action.url;
+            }
+          } catch (e) {
+            /* popup blocked or unsupported scheme — nothing to do */
+          }
+          break;
         case "chdir":
           // Append-only cd: move the LIVE prompt only. --terminal-live-cwd
           // drives the bottom input's PS1; --terminal-cwd (the frozen page cwd)
@@ -5490,6 +5518,67 @@
       terminalSession.appendChild(line);
     }
 
+    // The command a clicked markdown link runs: an internal link cats the post
+    // it points at (its last path segment, .md) — you read it inline, like
+    // clicking a featured card; an external link (or mailto/tel) opens directly.
+    function terminalLinkCmd(url) {
+      var u;
+      try {
+        u = new URL(url, window.location.href);
+      } catch (e) {
+        return "open " + url;
+      }
+      if (u.origin === window.location.origin) {
+        var segs = u.pathname.replace(/\/+$/, "").split("/").filter(Boolean);
+        var lang = (
+          document.documentElement.getAttribute("lang") || ""
+        ).toLowerCase();
+        if (segs.length && segs[0].toLowerCase() === lang) {
+          segs.shift();
+        }
+        var slug = segs.length ? segs[segs.length - 1] : "";
+        return slug ? "cat " + slug + ".md" : "open " + u.pathname;
+      }
+      return "open " + url;
+    }
+
+    // Print a prose line, turning any markdown [text](url) into a clickable
+    // token (URL hidden, like the ls/set chips) that runs terminalLinkCmd on
+    // click. Plain lines take the fast textContent path.
+    var TERMINAL_LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+    function printTerminalProseLine(text) {
+      if (!terminalSession) {
+        return;
+      }
+      TERMINAL_LINK_RE.lastIndex = 0;
+      if (!TERMINAL_LINK_RE.test(text)) {
+        printTerminalLine(text, "terminal-session__out");
+        return;
+      }
+      var line = document.createElement("span");
+      line.className = "terminal-session__line terminal-session__out";
+      TERMINAL_LINK_RE.lastIndex = 0;
+      var last = 0;
+      var m;
+      while ((m = TERMINAL_LINK_RE.exec(text))) {
+        if (m.index > last) {
+          line.appendChild(document.createTextNode(text.slice(last, m.index)));
+        }
+        var btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "terminal-session__link";
+        btn.textContent = m[1];
+        btn.setAttribute("data-cmd", terminalLinkCmd(m[2]));
+        line.appendChild(btn);
+        last = m.index + m[0].length;
+      }
+      if (last < text.length) {
+        line.appendChild(document.createTextNode(text.slice(last)));
+      }
+      terminalSession.appendChild(line);
+      lastTerminalOutput = text;
+    }
+
     // Print a cat'd file's extracted tokens (text lines + [image N] tokens),
     // or an "(empty)" note. Shared by remote-cat (fetched) and cat-local (the
     // current page read straight from #main).
@@ -5505,7 +5594,7 @@
         if (tok.image) {
           printTerminalImageLine(tok);
         } else {
-          printTerminalLine(tok.text, "terminal-session__out");
+          printTerminalProseLine(tok.text);
         }
       });
     }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2328,6 +2328,8 @@
       "  pantone   [on|off|YYYY]",
       "  grain|blend|motion on/off",
       "  grid      layout grid",
+      "  set [k v] view/set settings",
+      "  share     copy this look",
       "  layout <name>  switch layout",
       "  hire      let's work together",
       "  social    my links",
@@ -2361,6 +2363,8 @@
       "blend",
       "motion",
       "grid",
+      "set",
+      "share",
       "layout",
       "theme",
       "hire",
@@ -2818,6 +2822,45 @@
       return ["mode", "typography", "layout", "effects", "share", "language"];
     }
 
+    // Current settings as `key = value`, git-config style, for `set` with no
+    // args. Keys are exactly what `set <key> <value>` accepts (effects are the
+    // individual toggles). Motion is shown as its feature state (on = animated)
+    // to match `set motion on/off`, not the underlying reduced-motion attribute.
+    function terminalSettingsList() {
+      var root = document.documentElement;
+      var eff = function (attr) {
+        return root.getAttribute(attr) === "on" ? "on" : "off";
+      };
+      var gridAttr = root.getAttribute("data-grid-overlay");
+      var gridOn = gridAttr !== null && gridAttr !== "closing";
+      var pantoneOn =
+        typeof isPantoneModeActive === "function" && isPantoneModeActive();
+      return [
+        "mode        = " + (localStorage.getItem("theme-mode") || "system"),
+        "typography  = " +
+          (localStorage.getItem("theme-typography") || "editorial"),
+        "layout      = " + (root.getAttribute("data-layout") || "column"),
+        "language    = " + currentLang(),
+        "pantone     = " + (pantoneOn ? "on" : "off"),
+        "grid        = " + (gridOn ? "on" : "off"),
+        "blend       = " + eff("data-effect-blend"),
+        "grain       = " + eff("data-effect-grain"),
+        "motion      = " +
+          (eff("data-effect-reduced-motion") === "on" ? "off" : "on"),
+        "",
+        "change: set <name> <value>   e.g. set mode dark",
+      ];
+    }
+
+    // Typography values `set typography <value>` accepts (mirrors the menu).
+    var TERMINAL_TYPOGRAPHY = [
+      "editorial",
+      "refined",
+      "expressive",
+      "technical",
+      "system",
+    ];
+
     // Filtered `ls` views — the same tool, different lens. `--featured` lists
     // the curated cards on the current page (home's featured works); `--related`
     // lists a post's sibling projects; `--info` prints a post's role/details.
@@ -3010,7 +3053,10 @@
         return [terminalNavEntries().join("  ")];
       }
       if (rawArg === "settings") {
-        return [terminalSettingsEntries().join("  ")];
+        return [
+          terminalSettingsEntries().join("  "),
+          "→ view/change with 'set' · share this look with 'share'",
+        ];
       }
       // `ls featured` — the curated selection the home page prints — is a view,
       // harvested from the page's cards (so the header's `ls 'featured'` line is
@@ -4411,6 +4457,93 @@
             action: { type: "layout", layout: wantedLayout },
           };
         }
+        case "set": {
+          // A git-config-style settings verb: `set` lists current values, `set
+          // <key> <value>` changes one. Mostly a thin dispatcher onto the
+          // existing command grammar (so validation lives in one place); only
+          // typography needs its own handling (no standalone command for it).
+          var setKey = (args[0] || "").toLowerCase();
+          var setVal = args.slice(1).join(" ").toLowerCase();
+          if (!setKey) {
+            return {
+              echo: input,
+              lines: terminalSettingsList(),
+              action: null,
+            };
+          }
+          // Delegate to the equivalent command, keeping the `set …` echo so the
+          // scrollback shows what was actually typed.
+          var setDelegate = function (cmd) {
+            var res = runTerminalCommand(cmd);
+            res.echo = input;
+            return res;
+          };
+          switch (setKey) {
+            case "mode":
+              if (["dark", "light", "system"].indexOf(setVal) === -1) {
+                return {
+                  echo: input,
+                  lines: ["set mode: try dark, light or system"],
+                  action: null,
+                };
+              }
+              return setDelegate(setVal);
+            case "layout":
+              return setDelegate("layout " + setVal);
+            case "lang":
+            case "language":
+              return setDelegate("lang " + setVal);
+            case "pantone":
+            case "grid":
+            case "blend":
+            case "grain":
+            case "motion":
+              return setDelegate(setKey + " " + setVal);
+            case "type":
+            case "typography":
+              if (TERMINAL_TYPOGRAPHY.indexOf(setVal) === -1) {
+                return {
+                  echo: input,
+                  lines: [
+                    "set typography: try " + TERMINAL_TYPOGRAPHY.join(", "),
+                  ],
+                  action: null,
+                };
+              }
+              return {
+                echo: input,
+                lines: ["typography → " + setVal],
+                action: { type: "typography", typography: setVal },
+              };
+            default:
+              return {
+                echo: input,
+                lines: [
+                  "set: unknown setting '" + setKey + "' — run 'set' to list",
+                ],
+                action: null,
+              };
+          }
+        }
+        case "share": {
+          var shareUrl =
+            window.ThemeShare &&
+            typeof window.ThemeShare.buildUrl === "function"
+              ? window.ThemeShare.buildUrl()
+              : (window.location && window.location.href) || "";
+          if (!shareUrl) {
+            return {
+              echo: input,
+              lines: ["share: nothing to share here"],
+              action: null,
+            };
+          }
+          return {
+            echo: input,
+            lines: ["copied a link to this exact look — paste it anywhere"],
+            action: { type: "copy", text: shareUrl },
+          };
+        }
         case "debug":
         case "env": {
           var root = document.documentElement;
@@ -4780,6 +4913,9 @@
           break;
         case "mode":
           setMode(action.mode);
+          break;
+        case "typography":
+          setTypography(action.typography);
           break;
         case "pantone":
           if (action.state === "off") {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2282,8 +2282,21 @@
           return;
         }
         var cmd = token.getAttribute("data-cmd");
-        if (cmd) {
-          runTerminalInput(cmd);
+        if (!cmd) {
+          return;
+        }
+        runTerminalInput(cmd);
+        // A clicked directory entry "opens" the folder: follow the cd with an
+        // `ls` so its listing appends right below — no reload, the scrollback
+        // just grows. (A typed `cd` stays a silent move, matching a real shell;
+        // the click is the navigation gesture.) Transcript mode only, where the
+        // append-only session IS the page.
+        if (
+          document.documentElement.hasAttribute("data-terminal-transcript") &&
+          token.classList.contains("terminal-session__ls-entry") &&
+          /^cd\s+\S/.test(cmd)
+        ) {
+          runTerminalInput("ls");
         }
       });
     }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -780,6 +780,12 @@
   // chrome while a reload showed the transcript.
   var terminalBootRunner = null;
 
+  // The last remote page `cat` printed into the scrollback (a post/page you're
+  // not on). On this site cat IS how you visit a page, so exit should land on
+  // what you last read — mirroring how `cd` lands you where the cwd points.
+  // Cleared by an append-only `cd`, which hands the exit target back to the cwd.
+  var terminalLastViewedUrl = null;
+
   // Leave the terminal: back to the snapshotted layout, and restore the
   // snapshotted typography if the pairing's choice (technical) is still
   // active — a manual typography change inside the terminal is respected.
@@ -814,14 +820,33 @@
         setTypography("editorial");
       }
     }
-    // Exit lands you where you cd'd to: if the live cwd points at a page other
-    // than the one loaded, navigate there in the now-restored layout. (An
-    // append-only `cd` only moved the prompt, so the URL never followed.)
-    if (terminalNavApi && typeof terminalNavApi.exitTargetUrl === "function") {
-      var exitUrl = terminalNavApi.exitTargetUrl();
-      if (exitUrl) {
-        window.location.href = exitUrl;
-      }
+    // Exit lands you where you were: the last remote page you `cat`'d (read),
+    // or — if you only `cd`'d — where the live cwd points. Either way, if that's
+    // a page other than the one loaded, navigate there in the restored layout
+    // (append-only cat/cd moved the scrollback/prompt, not the URL).
+    var exitUrl = terminalLastViewedUrl;
+    if (
+      !exitUrl &&
+      terminalNavApi &&
+      typeof terminalNavApi.exitTargetUrl === "function"
+    ) {
+      exitUrl = terminalNavApi.exitTargetUrl();
+    }
+    terminalLastViewedUrl = null;
+    if (exitUrl && !terminalIsCurrentUrl(exitUrl)) {
+      window.location.href = exitUrl;
+    }
+  }
+
+  // Same-path test (ignoring trailing slash / query / hash) so exit doesn't
+  // reload the page you're already on.
+  function terminalIsCurrentUrl(url) {
+    try {
+      var target = new URL(url, window.location.href);
+      var here = window.location.pathname.replace(/\/+$/, "");
+      return target.pathname.replace(/\/+$/, "") === here;
+    } catch (e) {
+      return false;
     }
   }
 
@@ -5221,6 +5246,9 @@
             "--terminal-live-cwd",
             '"' + (action.cwd || "~") + '"'
           );
+          // cd hands the exit target back to the cwd (see exitTerminal): a move
+          // supersedes whatever page you last read.
+          terminalLastViewedUrl = null;
           break;
         case "remote-ls":
           // Append-only ls: fetch the section you've cd'd into and print its
@@ -5307,6 +5335,8 @@
                 terminalExtractPostLines(doc, action.url, action.root),
                 catLabel
               );
+              // Reading a page IS visiting it here — so exit lands on it.
+              terminalLastViewedUrl = action.url;
               scrollTerminalToEnd();
             })
             .catch(function (err) {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3048,6 +3048,34 @@
       return out.length ? out : ["(no info here)"];
     }
 
+    // Serialize an element's inline content back to markdown source: emphasis
+    // keeps **/*, code keeps backticks, <br> becomes a newline, everything else
+    // is its text. So a cat'd .md reads like the file you'd actually open.
+    function terminalInlineMarkdown(node) {
+      var out = "";
+      var kids = node.childNodes;
+      for (var i = 0; i < kids.length; i++) {
+        var n = kids[i];
+        if (n.nodeType === 3) {
+          out += n.nodeValue;
+        } else if (n.nodeType === 1) {
+          var t = n.tagName.toLowerCase();
+          if (t === "br") {
+            out += "\n";
+          } else if (t === "strong" || t === "b") {
+            out += "**" + terminalInlineMarkdown(n).trim() + "**";
+          } else if (t === "em" || t === "i") {
+            out += "*" + terminalInlineMarkdown(n).trim() + "*";
+          } else if (t === "code") {
+            out += "`" + terminalInlineMarkdown(n).trim() + "`";
+          } else {
+            out += terminalInlineMarkdown(n);
+          }
+        }
+      }
+      return out;
+    }
+
     // Extract a cat'able rendering of a fetched post/page as an ordered list of
     // TOKENS — {text} for a prose line, {image, n, file, src, alt} for a figure
     // (a terminal can't paint an image, so it prints a clickable [image N] token
@@ -3079,6 +3107,17 @@
         ".works-section, .works-post__tags, .post-tags-wrap, .lang-notice, nav";
       var tokens = [];
       var imageN = 0;
+      var prevBlock = null;
+      // A blank line separates blocks — the terminal's version of a margin, and
+      // exactly how the blocks sit in the .md source. Consecutive list items
+      // stay tight (a real list has no blank between rows).
+      var blockBreak = function (kind) {
+        var tight = kind === "li" && prevBlock === "li";
+        if (tokens.length && !tight) {
+          tokens.push({ text: "" });
+        }
+        prevBlock = kind;
+      };
       var nodes = root.querySelectorAll(
         "h1, h2, h3, h4, p, blockquote, li, figure, img"
       );
@@ -3093,6 +3132,7 @@
           if (tag === "img" && el.closest("figure")) {
             continue;
           }
+          blockBreak("figure");
           imageN += 1;
           var img = tag === "img" ? el : el.querySelector("img");
           var cap = el.querySelector && el.querySelector("figcaption");
@@ -3139,22 +3179,36 @@
         ) {
           continue;
         }
-        // Split on <br> so a paragraph of <br>-separated lines (e.g. the CV's
-        // dates / roles / bullets, all one <p>) prints one line each instead of
-        // running together — textContent alone would drop the breaks.
-        var ownerDoc = el.ownerDocument || document;
-        (el.innerHTML || "").split(/<br\s*\/?>/i).forEach(function (part) {
-          var holder = ownerDoc.createElement("div");
-          holder.innerHTML = part;
-          var text = (holder.textContent || "").replace(/\s+/g, " ").trim();
-          if (text) {
-            tokens.push({ text: text });
-          }
-        });
+        // Map the block back to its markdown syntax: headings get their #'s,
+        // blockquotes a >, list items a -. Inline emphasis/code is preserved by
+        // the serializer; <br>-separated lines (e.g. the CV's one-<p> rows)
+        // print one per line, the quote's > repeating on each.
+        var headingLevel = { h1: 1, h2: 2, h3: 3, h4: 4 }[tag] || 0;
+        var prefix = "";
+        if (headingLevel) {
+          prefix = new Array(headingLevel + 1).join("#") + " ";
+        } else if (tag === "blockquote") {
+          prefix = "> ";
+        } else if (tag === "li") {
+          prefix = "- ";
+        }
+        blockBreak(tag);
+        terminalInlineMarkdown(el)
+          .split("\n")
+          .forEach(function (part) {
+            var text = part.replace(/[ \t]+/g, " ").trim();
+            if (text) {
+              tokens.push({ text: prefix + text });
+            }
+          });
       }
       // Append the project meta as its own trailing block — cat shows the whole
       // file, so the role/details/client you set in front matter come along.
-      terminalInfoLinesFrom(root).forEach(function (line) {
+      var meta = terminalInfoLinesFrom(root);
+      if (meta.length && tokens.length) {
+        tokens.push({ text: "" });
+      }
+      meta.forEach(function (line) {
         tokens.push({ text: line });
       });
       return tokens;

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2906,7 +2906,7 @@
     // the curated cards on the current page (home's featured works); `--related`
     // lists a post's sibling projects; `--info` prints a post's role/details.
     // All harvested from the current page's DOM — a page's own sequence.
-    function terminalHarvestFiles(selector, emptyMsg) {
+    function terminalHarvestFileLabels(selector) {
       var out = [];
       document.querySelectorAll(selector).forEach(function (a) {
         var segs = terminalHrefSegments(a.getAttribute("href"));
@@ -2918,7 +2918,33 @@
           out.push(file);
         }
       });
+      return out;
+    }
+
+    function terminalHarvestFiles(selector, emptyMsg) {
+      var out = terminalHarvestFileLabels(selector);
       return out.length ? [out.join("  ")] : [emptyMsg];
+    }
+
+    // A harvested file view (`ls --featured` / `--related`) as a clickable
+    // ls-list result — each entry cats itself, same as a plain `ls`. Falls back
+    // to a plain "(empty)" line when nothing matched.
+    function terminalHarvestResult(input, selector, emptyMsg) {
+      var labels = terminalHarvestFileLabels(selector);
+      if (!labels.length) {
+        return { echo: input, lines: [emptyMsg], action: null };
+      }
+      return {
+        echo: input,
+        lines: [],
+        action: {
+          type: "ls-list",
+          tokens: labels.slice(0, 40).map(function (label) {
+            return { label: label, cmd: terminalEntryCmd(label) };
+          }),
+          more: Math.max(0, labels.length - 40),
+        },
+      };
     }
 
     // The project meta (role / details / client) as "label: value" lines,
@@ -3345,6 +3371,25 @@
       return ["a short, occasional newsletter.", "subscribe with: subscribe"];
     }
 
+    // welcome.txt is the home intro (the hero, in prose). Read the localized
+    // copy Hugo emits into a hidden element so the boot's `cat welcome.txt`
+    // prints it in the visitor's language, not the hardcoded English fallback.
+    function terminalWelcomeLines() {
+      var el = document.querySelector('[data-js="terminal-welcome"]');
+      if (el) {
+        var lines = el.textContent
+          .replace(/^\n+|\n+$/g, "")
+          .split("\n")
+          .map(function (line) {
+            return line.replace(/\s+$/, "");
+          });
+        if (lines.length && lines.join("").trim()) {
+          return lines;
+        }
+      }
+      return TERMINAL_FILES.welcome.slice();
+    }
+
     function terminalFile(name) {
       var key = String(name || "")
         .toLowerCase()
@@ -3353,13 +3398,16 @@
       if (key === "secrets") {
         key = "secret";
       }
-      // colophon and newsletter are live footer blocks, reproduced so typing
+      // colophon, newsletter and welcome are live blocks, reproduced so typing
       // the `cat …` the chrome prints shows exactly what's on the page.
       if (key === "colophon") {
         return terminalColophonLines();
       }
       if (key === "newsletter") {
         return terminalNewsletterLines();
+      }
+      if (key === "welcome") {
+        return terminalWelcomeLines();
       }
       return TERMINAL_FILES[key] || null;
     }
@@ -4011,24 +4059,18 @@
             };
           }
           if (lsLong.indexOf("--featured") !== -1) {
-            return {
-              echo: input,
-              lines: terminalHarvestFiles(
-                ".summary-card a[href], .article-card a[href]",
-                "(nothing featured here)"
-              ),
-              action: null,
-            };
+            return terminalHarvestResult(
+              input,
+              ".summary-card a[href], .article-card a[href]",
+              "(nothing featured here)"
+            );
           }
           if (lsLong.indexOf("--related") !== -1) {
-            return {
-              echo: input,
-              lines: terminalHarvestFiles(
-                ".related-items__item .type-headline-4 a[href]",
-                "(no related files)"
-              ),
-              action: null,
-            };
+            return terminalHarvestResult(
+              input,
+              ".related-items__item .type-headline-4 a[href]",
+              "(no related files)"
+            );
           }
           if (lsLong.indexOf("--info") !== -1) {
             // `--info` is a lens on the page you're viewing. For a post you

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2451,6 +2451,7 @@
       "env",
       "reset",
       "ai",
+      "report",
       "contact",
       "subscribe",
       "clear",
@@ -4071,6 +4072,15 @@
             lines: [],
             action: { type: "ai-start" },
           };
+        case "report":
+          // Flag the assistant's last answer (typed `report`, or the [report]
+          // chip) so a bad reply becomes a GitHub issue to improve the intents.
+          // The assistant owns the last exchange, so hand it the optional note.
+          return {
+            echo: input,
+            lines: [],
+            action: { type: "ai-report", note: args.join(" ") },
+          };
         case "contact":
           return {
             echo: input,
@@ -5455,6 +5465,22 @@
             printTerminalLine("ai: not available", "terminal-session__out");
           }
           break;
+        case "ai-report":
+          // The assistant owns the last exchange and prints its own bilingual
+          // confirmation; `report` outside a chat (nothing to flag) is handled
+          // there too.
+          if (
+            window.TerminalAI &&
+            typeof window.TerminalAI.report === "function"
+          ) {
+            window.TerminalAI.report(action.note || "");
+          } else {
+            printTerminalLine(
+              "report: nothing to report",
+              "terminal-session__out"
+            );
+          }
+          break;
         case "defer":
           // Print follow-up lines after a delay, so a command can fake a job
           // running before its punchline. Skip if the terminal was left in
@@ -6694,6 +6720,32 @@
           "terminal-session__cmd",
           currentTerminalCwd()
         );
+      },
+      // Print a single clickable chip (bracketed), carrying the command it runs
+      // on click via the delegated [data-cmd] handler. Used by terminal-ai.js
+      // for the [report] affordance; same convention as the ls/set chips.
+      printChip: function (label, cmd, opts) {
+        opts = opts || {};
+        if (!terminalSession) {
+          return;
+        }
+        var line = document.createElement("span");
+        line.className = "terminal-session__line terminal-session__out";
+        var btn = document.createElement("button");
+        btn.type = "button";
+        btn.className =
+          "terminal-session__link" +
+          (opts.className ? " " + opts.className : "");
+        btn.textContent =
+          "[" +
+          String(label === null || label === undefined ? "" : label) +
+          "]";
+        btn.setAttribute(
+          "data-cmd",
+          String(cmd === null || cmd === undefined ? "" : cmd)
+        );
+        line.appendChild(btn);
+        terminalSession.appendChild(line);
       },
       applyAction: function (action) {
         applyTerminalAction(action);

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2273,6 +2273,19 @@
           window.scrollTo(0, document.body.scrollHeight);
         });
       });
+
+      // Clicking a `set` chip runs the very command it carries — clicking is
+      // identical to typing "set <key> <value>" (echoes and applies).
+      terminalSession.addEventListener("click", function (e) {
+        var chip = e.target.closest(".terminal-session__setting");
+        if (!chip) {
+          return;
+        }
+        var cmd = chip.getAttribute("data-cmd");
+        if (cmd) {
+          runTerminalInput(cmd);
+        }
+      });
     }
 
     // Session start, for `uptime` — captured when the command engine boots.
@@ -2822,33 +2835,61 @@
       return ["mode", "typography", "layout", "effects", "share", "language"];
     }
 
-    // Current settings as `key = value`, git-config style, for `set` with no
-    // args. Keys are exactly what `set <key> <value>` accepts (effects are the
-    // individual toggles). Motion is shown as its feature state (on = animated)
-    // to match `set motion on/off`, not the underlying reduced-motion attribute.
-    function terminalSettingsList() {
+    // The settable keys, their options, and the current value — the model both
+    // `set` (no args, rendered as clickable chips) and `set <key> <value>` work
+    // from. Motion reads as its feature state (on = animated) to match
+    // `set motion on/off`, not the underlying reduced-motion attribute.
+    function terminalSettingsSpec() {
       var root = document.documentElement;
-      var eff = function (attr) {
-        return root.getAttribute(attr) === "on" ? "on" : "off";
+      var effOn = function (attr) {
+        return root.getAttribute(attr) === "on";
       };
       var gridAttr = root.getAttribute("data-grid-overlay");
-      var gridOn = gridAttr !== null && gridAttr !== "closing";
-      var pantoneOn =
-        typeof isPantoneModeActive === "function" && isPantoneModeActive();
       return [
-        "mode        = " + (localStorage.getItem("theme-mode") || "system"),
-        "typography  = " +
-          (localStorage.getItem("theme-typography") || "editorial"),
-        "layout      = " + (root.getAttribute("data-layout") || "column"),
-        "language    = " + currentLang(),
-        "pantone     = " + (pantoneOn ? "on" : "off"),
-        "grid        = " + (gridOn ? "on" : "off"),
-        "blend       = " + eff("data-effect-blend"),
-        "grain       = " + eff("data-effect-grain"),
-        "motion      = " +
-          (eff("data-effect-reduced-motion") === "on" ? "off" : "on"),
-        "",
-        "change: set <name> <value>   e.g. set mode dark",
+        {
+          key: "mode",
+          options: ["light", "dark", "system"],
+          current: localStorage.getItem("theme-mode") || "system",
+        },
+        {
+          key: "typography",
+          options: TERMINAL_TYPOGRAPHY,
+          current: localStorage.getItem("theme-typography") || "editorial",
+        },
+        {
+          key: "layout",
+          options: TERMINAL_LAYOUTS,
+          current: root.getAttribute("data-layout") || "column",
+        },
+        { key: "language", options: ["sv", "en"], current: currentLang() },
+        {
+          key: "pantone",
+          options: ["on", "off"],
+          current:
+            typeof isPantoneModeActive === "function" && isPantoneModeActive()
+              ? "on"
+              : "off",
+        },
+        {
+          key: "grid",
+          options: ["on", "off"],
+          current: gridAttr !== null && gridAttr !== "closing" ? "on" : "off",
+        },
+        {
+          key: "blend",
+          options: ["on", "off"],
+          current: effOn("data-effect-blend") ? "on" : "off",
+        },
+        {
+          key: "grain",
+          options: ["on", "off"],
+          current: effOn("data-effect-grain") ? "on" : "off",
+        },
+        {
+          key: "motion",
+          options: ["on", "off"],
+          current: effOn("data-effect-reduced-motion") ? "off" : "on",
+        },
       ];
     }
 
@@ -4467,8 +4508,8 @@
           if (!setKey) {
             return {
               echo: input,
-              lines: terminalSettingsList(),
-              action: null,
+              lines: [],
+              action: { type: "settings-list" },
             };
           }
           // Delegate to the equivalent command, keeping the `set …` echo so the
@@ -4917,6 +4958,9 @@
         case "typography":
           setTypography(action.typography);
           break;
+        case "settings-list":
+          printTerminalSettingsList();
+          break;
         case "pantone":
           if (action.state === "off") {
             stopPantone();
@@ -5177,6 +5221,44 @@
       btn.setAttribute("data-image-alt", tok.alt || "");
       line.appendChild(btn);
       terminalSession.appendChild(line);
+    }
+
+    // `set` (no args) prints the settings as clickable chip rows — the settings
+    // panel rendered as terminal output. Each option is a button carrying the
+    // exact `set <key> <value>` it runs (see the terminalSession click handler),
+    // so clicking is the same as typing it; the current value is marked. This is
+    // the OSC-8-style clickable-output convention (`ls --hyperlink`), and it is
+    // what unifies the panel with the command — one truth, click or type.
+    function printTerminalSettingsList() {
+      if (!terminalSession) {
+        return;
+      }
+      terminalSettingsSpec().forEach(function (setting) {
+        var line = document.createElement("span");
+        line.className =
+          "terminal-session__line terminal-session__out terminal-session__settings-row";
+        var label = document.createElement("span");
+        label.className = "terminal-session__settings-key";
+        label.textContent = setting.key;
+        line.appendChild(label);
+        setting.options.forEach(function (opt) {
+          var btn = document.createElement("button");
+          btn.type = "button";
+          btn.className = "terminal-session__setting";
+          if (opt === setting.current) {
+            btn.classList.add("is-current");
+            btn.setAttribute("aria-current", "true");
+          }
+          btn.textContent = opt;
+          btn.setAttribute("data-cmd", "set " + setting.key + " " + opt);
+          line.appendChild(btn);
+        });
+        terminalSession.appendChild(line);
+      });
+      var hint = document.createElement("span");
+      hint.className = "terminal-session__line terminal-session__out";
+      hint.textContent = "click a value or type: set <name> <value>";
+      terminalSession.appendChild(hint);
     }
 
     // A short, bounded "digital rain" burst for `matrix` — a few deferred

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3518,10 +3518,15 @@
     // link by its full segments, so cd and ls agree on what exists.
     function terminalContentTargetHref(dest) {
       var wanted = terminalResolveSegments(dest);
-      if (wanted.length < 2) {
+      if (!wanted.length) {
         return null;
       }
       var wantedKey = wanted.join("/");
+      // A bare slug (length 1) — e.g. a featured card the home page lists as
+      // `slug.md`, whose real home is `/works/slug/` — matches a card by its
+      // last path segment: the visitor named the file, not its section path. A
+      // qualified path (~/works/slug) still matches in full.
+      var bare = wanted.length === 1;
       var match = null;
       document
         .querySelectorAll(".article-card a[href], .summary-card a[href]")
@@ -3530,7 +3535,13 @@
             return;
           }
           var segs = terminalHrefSegments(link.getAttribute("href"));
-          if (segs && segs.join("/") === wantedKey) {
+          if (!segs || !segs.length) {
+            return;
+          }
+          var hit = bare
+            ? segs[segs.length - 1] === wantedKey
+            : segs.join("/") === wantedKey;
+          if (hit) {
             match = link.getAttribute("href");
           }
         });

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2332,6 +2332,7 @@
       "  hire      let's work together",
       "  social    my links",
       "  copy <x>  to clipboard",
+      "  ai        chat with tbh",
       "  contact   message me",
       "  subscribe newsletter",
       "  clear     wipe the screen",
@@ -2381,6 +2382,7 @@
       "debug",
       "env",
       "reset",
+      "ai",
       "contact",
       "subscribe",
       "clear",
@@ -3766,6 +3768,14 @@
             },
           };
         }
+        case "ai":
+          // The free-text assistant lives in terminal-ai.js; applyTerminalAction
+          // starts it (and reports if the module didn't load).
+          return {
+            echo: input,
+            lines: [],
+            action: { type: "ai-start" },
+          };
         case "contact":
           return {
             echo: input,
@@ -4963,6 +4973,16 @@
         case "flow":
           startTerminalFlow(action.flow);
           break;
+        case "ai-start":
+          if (
+            window.TerminalAI &&
+            typeof window.TerminalAI.start === "function"
+          ) {
+            window.TerminalAI.start();
+          } else {
+            printTerminalLine("ai: not available", "terminal-session__out");
+          }
+          break;
         case "defer":
           // Print follow-up lines after a delay, so a command can fake a job
           // running before its punchline. Skip if the terminal was left in
@@ -5130,6 +5150,33 @@
     // footer newsletter form's action and hidden fields.
     // ----------------------------------------------------------------------
     let terminalFlow = null;
+
+    // ----------------------------------------------------------------------
+    // Input delegate (the `ai` assistant)
+    // A registered delegate takes over Enter the way a flow does, but for an
+    // open-ended chat rather than a fixed wizard. Checked AFTER terminalFlow in
+    // the key handler, so a flow the assistant hands off to (contact/subscribe)
+    // still owns input until it finishes. Published to terminal-ai.js via the
+    // window.Terminal seam below; leaving the terminal releases it (exit reset).
+    // ----------------------------------------------------------------------
+    var terminalInputDelegate = null;
+    var terminalInputDelegateRelease = null;
+
+    function captureTerminalInput(handler, onRelease) {
+      terminalInputDelegate = typeof handler === "function" ? handler : null;
+      terminalInputDelegateRelease =
+        typeof onRelease === "function" ? onRelease : null;
+    }
+
+    function releaseTerminalInput() {
+      var onRelease = terminalInputDelegateRelease;
+      terminalInputDelegate = null;
+      terminalInputDelegateRelease = null;
+      setFlowPrompt(null);
+      if (onRelease) {
+        onRelease();
+      }
+    }
 
     function isEmailish(value) {
       return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
@@ -5316,8 +5363,13 @@
       setFlowPrompt(null);
     }
 
-    // Let the top-level exitTerminal() abort a flow when leaving the terminal.
-    terminalFlowReset = endTerminalFlow;
+    // Let the top-level exitTerminal() abort a flow AND release the `ai`
+    // delegate when leaving the terminal, so re-entering starts clean and the
+    // assistant's own state (via its onRelease) can't get stuck active.
+    terminalFlowReset = function () {
+      endTerminalFlow();
+      releaseTerminalInput();
+    };
 
     function handleTerminalFlowInput(raw) {
       var flow = terminalFlow;
@@ -5548,6 +5600,11 @@
           if (terminalFlow) {
             handleTerminalFlowInput(value);
             scrollTerminalToEnd();
+          } else if (terminalInputDelegate) {
+            // The `ai` assistant owns the prompt: hand it the line (it echoes
+            // and answers itself), then keep the newest output in view.
+            terminalInputDelegate(value);
+            scrollTerminalToEnd();
           } else {
             runTerminalInput(value);
           }
@@ -5560,6 +5617,15 @@
             syncTerminalInputSize();
             printTerminalLine("^C", "terminal-session__out");
             endTerminalFlow();
+            scrollTerminalToEnd();
+          } else if (terminalInputDelegate) {
+            // Escape leaves the assistant (like ^C on a flow), back to the shell
+            // prompt — without leaving the terminal itself.
+            e.preventDefault();
+            terminalInput.value = "";
+            syncTerminalInputSize();
+            printTerminalLine("^C", "terminal-session__out");
+            releaseTerminalInput();
             scrollTerminalToEnd();
           } else if (
             e.defaultPrevented ||
@@ -5829,6 +5895,43 @@
     }
     terminalStampSlugs();
     window.TerminalSlugs = { refresh: terminalStampSlugs };
+
+    // ----------------------------------------------------------------------
+    // Public terminal seam (window.Terminal)
+    // The minimal surface an external module needs to live inside the terminal
+    // without reaching into this closure: write to the scrollback, run one of
+    // the actions applyTerminalAction already understands, take/release the
+    // prompt, and read the cwd. terminal-ai.js is the first consumer; this is
+    // also the export surface a future terminal.js extraction would expose.
+    // ----------------------------------------------------------------------
+    window.Terminal = {
+      print: function (text, opts) {
+        opts = opts || {};
+        printTerminalLine(
+          String(text === null || text === undefined ? "" : text),
+          opts.className || "terminal-session__out",
+          opts.cwd
+        );
+      },
+      echo: function (command) {
+        printTerminalLine(
+          String(command === null || command === undefined ? "" : command),
+          "terminal-session__cmd",
+          currentTerminalCwd()
+        );
+      },
+      applyAction: function (action) {
+        applyTerminalAction(action);
+      },
+      captureInput: captureTerminalInput,
+      releaseInput: releaseTerminalInput,
+      setPrompt: function (label) {
+        setFlowPrompt(label || null);
+      },
+      cwd: currentTerminalCwd,
+      scrollToEnd: scrollTerminalToEnd,
+      isActive: isTerminalLayout,
+    };
 
     // Publish the exit target for the top-level exitTerminal(): if you've cd'd
     // away (live cwd ≠ the loaded page's cwd), exit navigates to that page in

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -5330,18 +5330,25 @@
     // set on BOTH the tail (so the hint's ::after can switch) and the prompt
     // span (so its ::before can read the label via attr() — attr() only sees the
     // pseudo-element's own element, not an ancestor).
-    function setFlowPrompt(prompt) {
+    function setFlowPrompt(prompt, hint) {
       if (!terminalTail) {
         return;
       }
       var promptEl = terminalTail.querySelector(".terminal-tail__prompt");
       if (prompt) {
         terminalTail.setAttribute("data-flow-label", prompt);
+        // The trailing hint defaults to a flow's abort word; the `ai` assistant
+        // passes its own ("type exit to leave") through the seam.
+        terminalTail.setAttribute(
+          "data-flow-hint",
+          hint || "type cancel to abort"
+        );
         if (promptEl) {
           promptEl.setAttribute("data-flow-label", prompt);
         }
       } else {
         terminalTail.removeAttribute("data-flow-label");
+        terminalTail.removeAttribute("data-flow-hint");
         if (promptEl) {
           promptEl.removeAttribute("data-flow-label");
         }
@@ -5943,8 +5950,8 @@
       },
       captureInput: captureTerminalInput,
       releaseInput: releaseTerminalInput,
-      setPrompt: function (label) {
-        setFlowPrompt(label || null);
+      setPrompt: function (label, opts) {
+        setFlowPrompt(label || null, opts && opts.hint);
       },
       cwd: currentTerminalCwd,
       scrollToEnd: scrollTerminalToEnd,

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -6465,6 +6465,40 @@
       }
     }
 
+    // Floating jump-to-prompt button: appears (on any device) once the live
+    // prompt scrolls out of view, so a long cat output doesn't strand you far
+    // from the input. Clicking drops back to the prompt (scroll + focus). Driven
+    // by an IntersectionObserver on the prompt; a scroll-listener fallback keeps
+    // it working where IntersectionObserver is missing.
+    var terminalJump = document.querySelector('[data-js="terminal-jump"]');
+    if (terminalJump && terminalTail) {
+      terminalJump.addEventListener("click", function () {
+        scrollTerminalToEnd();
+      });
+      var setJumpVisible = function (promptInView) {
+        if (isTerminalLayout() && !promptInView) {
+          terminalJump.classList.add("is-visible");
+        } else {
+          terminalJump.classList.remove("is-visible");
+        }
+      };
+      if (typeof window.IntersectionObserver === "function") {
+        new window.IntersectionObserver(
+          function (entries) {
+            setJumpVisible(entries[entries.length - 1].isIntersecting);
+          },
+          { root: null, threshold: 0 }
+        ).observe(terminalTail);
+      } else {
+        window.addEventListener("scroll", function () {
+          var rect = terminalTail.getBoundingClientRect();
+          setJumpVisible(
+            rect.top < (window.innerHeight || 0) && rect.bottom > 0
+          );
+        });
+      }
+    }
+
     // ----------------------------------------------------------------------
     // Nav "cd" feedback
     // A full page load gives almost no signal that navigation happened. So a

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2332,7 +2332,7 @@
       "  hire      let's work together",
       "  social    my links",
       "  copy <x>  to clipboard",
-      "  ai        chat with tbh",
+      "  ai        chat with clanker",
       "  contact   message me",
       "  subscribe newsletter",
       "  clear     wipe the screen",
@@ -5691,6 +5691,16 @@
           "translateY(" + -Math.max(0, overlap) + "px)";
       }
 
+      // Publish the bar's height so the prompt can reserve space for this fixed
+      // overlay (terminal.css: --terminal-keybar-h). offsetHeight is 0 when the
+      // bar is display:none (desktop / blurred), which zeroes the reservation.
+      function updateKeybarSpace() {
+        document.documentElement.style.setProperty(
+          "--terminal-keybar-h",
+          (terminalKeybar.offsetHeight || 0) + "px"
+        );
+      }
+
       // Keep focus on the input: a button that stole focus would close the
       // keyboard. preventDefault on pointerdown stops the field from blurring,
       // so the tap runs its action with the keyboard still up (and the bar,
@@ -5720,13 +5730,21 @@
       terminalInput.addEventListener("focus", function () {
         terminalKeybar.classList.add("is-visible");
         positionKeybar();
+        updateKeybarSpace();
       });
       terminalInput.addEventListener("blur", function () {
         terminalKeybar.classList.remove("is-visible");
+        document.documentElement.style.setProperty(
+          "--terminal-keybar-h",
+          "0px"
+        );
       });
 
       if (window.visualViewport) {
-        window.visualViewport.addEventListener("resize", positionKeybar);
+        window.visualViewport.addEventListener("resize", function () {
+          positionKeybar();
+          updateKeybarSpace();
+        });
         window.visualViewport.addEventListener("scroll", positionKeybar);
       }
     }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -5948,6 +5948,22 @@
       applyAction: function (action) {
         applyTerminalAction(action);
       },
+      // Run a raw command line through the shell (echo + parse + apply), for a
+      // real command typed inside the `ai` assistant. isCommand lets the caller
+      // gate on the engine's own command vocabulary so ordinary sentences that
+      // merely start with a command-like word aren't forwarded.
+      run: function (raw) {
+        runTerminalInput(String(raw === null || raw === undefined ? "" : raw));
+      },
+      isCommand: function (word) {
+        return (
+          TERMINAL_COMMAND_NAMES.indexOf(
+            String(word === null || word === undefined ? "" : word)
+              .trim()
+              .toLowerCase()
+          ) !== -1
+        );
+      },
       captureInput: captureTerminalInput,
       releaseInput: releaseTerminalInput,
       setPrompt: function (label, opts) {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -870,6 +870,25 @@
   }
 
   function setLayout(layout) {
+    // A visual tool (ui-library, palette generator) can't be a terminal, and it
+    // isn't part of the terminal filesystem. Picking terminal here honours the
+    // choice by storing it and going to the home terminal — this page has none
+    // to show. (Exit from there drops back to column.)
+    if (
+      layout === "terminal" &&
+      document.documentElement.hasAttribute("data-terminal-exempt")
+    ) {
+      localStorage.setItem("theme-layout-previous", "column");
+      localStorage.setItem("theme-layout", "terminal");
+      var homeUrl =
+        document.documentElement.getAttribute("data-home-url") || "/";
+      try {
+        window.location.href = homeUrl;
+      } catch (e) {
+        window.location.assign(homeUrl);
+      }
+      return;
+    }
     // Entering terminal snapshots where the user came from, so exit (ESC,
     // typing "exit", the boot [exit] button) can return there — including
     // the typography the pairing is about to replace.

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -4866,7 +4866,12 @@
     // output; on fallback the reload wipes it and the stash reprints it on top.
     function navigateTerminal(action) {
       var cwd = hrefToCwd(action.url);
+      // In transcript mode the page content (#main) is hidden — it's just the
+      // boot transcript's data source — so an in-place #main swap would paint
+      // nothing. A `navigate` (open/lang) instead does a full load; the
+      // destination re-runs its own boot transcript, keeping the session model.
       var canSwap =
+        !document.documentElement.hasAttribute("data-terminal-transcript") &&
         action.cd !== false &&
         isTerminalLayout() &&
         cwd !== "~" &&
@@ -5399,15 +5404,27 @@
       frame();
     }
 
-    function runTerminalInput(raw) {
-      // Record the command before running it, so `history` includes itself —
-      // matching a real shell. Reset the ↑/↓ recall cursor to the live line.
-      terminalHistoryCursor = null;
-      var trimmed = String(raw === null || raw === undefined ? "" : raw).trim();
-      if (trimmed) {
-        terminalHistory.push(trimmed);
-        if (terminalHistory.length > TERMINAL_HISTORY_MAX) {
-          terminalHistory.shift();
+    // Run one command through the engine and print it into the scrollback
+    // exactly as a typed line would look: the frozen echo, then the output /
+    // side effects. Factored out of runTerminalInput so the boot transcript can
+    // replay the same path (opts.focus:false — a fresh page load must not steal
+    // focus and pop the mobile keyboard; opts.scroll:false — leave the viewport
+    // at the top so the banner and the start of the transcript are what you see,
+    // not the bottom prompt).
+    function emitTerminalCommand(raw, opts) {
+      opts = opts || {};
+      if (opts.history !== false) {
+        // Record the command before running it, so `history` includes itself —
+        // matching a real shell. Reset the ↑/↓ recall cursor to the live line.
+        terminalHistoryCursor = null;
+        var trimmed = String(
+          raw === null || raw === undefined ? "" : raw
+        ).trim();
+        if (trimmed) {
+          terminalHistory.push(trimmed);
+          if (terminalHistory.length > TERMINAL_HISTORY_MAX) {
+            terminalHistory.shift();
+          }
         }
       }
       var result = runTerminalCommand(raw);
@@ -5433,9 +5450,62 @@
         printTerminalLine(line, "terminal-session__out");
       });
       applyTerminalAction(result.action);
-      // Keep the newest output and the prompt in view; refocus so the mobile
-      // keyboard stays up for the next command.
-      scrollTerminalToEnd();
+      if (opts.focus !== false) {
+        // Keep the newest output and the prompt in view; refocus so the mobile
+        // keyboard stays up for the next command.
+        scrollTerminalToEnd();
+      }
+    }
+
+    function runTerminalInput(raw) {
+      emitTerminalCommand(raw, { focus: true });
+    }
+
+    // Boot transcript: on a terminal page load, replay a curated sequence of
+    // REAL commands into the scrollback (home: `ls`, `set`, `cat welcome.txt`,
+    // `ls works/ --featured`) so the page reads as a genuine session — identical
+    // to having typed them, and recallable with ↑. The sequence is declared per
+    // page by Hugo (data-terminal-boot on <html>); each entry runs through the
+    // same emitTerminalCommand path as a typed line. Runs once per load.
+    var terminalTranscriptPlayed = false;
+
+    function terminalBootCommands() {
+      var raw = document.documentElement.getAttribute("data-terminal-boot");
+      if (!raw) {
+        return [];
+      }
+      return raw
+        .split(";")
+        .map(function (cmd) {
+          return cmd.trim();
+        })
+        .filter(Boolean);
+    }
+
+    function runTerminalBootTranscript() {
+      if (
+        terminalTranscriptPlayed ||
+        !terminalSession ||
+        !isTerminalLayout() ||
+        document.documentElement.hasAttribute("data-terminal-exempt")
+      ) {
+        return;
+      }
+      var commands = terminalBootCommands();
+      if (!commands.length) {
+        return;
+      }
+      terminalTranscriptPlayed = true;
+      // Signal the CSS that the transcript owns the view: the server-rendered
+      // header chrome, page content (now the transcript's data source) and
+      // footer sitemap hide, leaving the banner + scrollback + live prompt.
+      // Gated on this attr so a JS failure that never reaches here leaves the
+      // plain readable page visible rather than a blank screen. (head.html sets
+      // it pre-paint too, to avoid a flash of the un-hidden page.)
+      document.documentElement.setAttribute("data-terminal-transcript", "1");
+      commands.forEach(function (cmd) {
+        emitTerminalCommand(cmd, { focus: false });
+      });
     }
 
     // The boot banner's small block-curl, reused as neofetch art when present.
@@ -6262,6 +6332,11 @@
     }
     terminalStampSlugs();
     window.TerminalSlugs = { refresh: terminalStampSlugs };
+
+    // Replay the page's boot transcript into the scrollback (after slugs are
+    // stamped, so any card-derived output is ready). This is what fills the
+    // terminal on load now — the server chrome/content it reads from is hidden.
+    runTerminalBootTranscript();
 
     // ----------------------------------------------------------------------
     // Public terminal seam (window.Terminal)

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -3120,8 +3120,9 @@
       if (l.charAt(l.length - 1) === "/") {
         return "cd " + l.slice(0, -1);
       }
-      if (/\.md$/.test(l)) {
-        return "cat " + l;
+      // A post file, possibly a tag-term symlink (`slug.md@`) — cat the real .md.
+      if (/\.md@?$/.test(l)) {
+        return "cat " + l.replace(/@$/, "");
       }
       if (l.charAt(l.length - 1) === "*") {
         return "open " + l.slice(0, -1);
@@ -5126,7 +5127,13 @@
               var doc = new DOMParser().parseFromString(html, "text/html");
               var files = terminalRemoteLsEntries(doc, action.cwd);
               if (files.length) {
-                printTerminalLine(files.join("  "), "terminal-session__out");
+                // Clickable, like the local `ls` — each post cats itself, each
+                // tag dir cds into it.
+                printTerminalLsList(
+                  files.map(function (label) {
+                    return { label: label, cmd: terminalEntryCmd(label) };
+                  })
+                );
               } else if (doc.querySelector(".content.post, .content.page")) {
                 // A readable page (about, a post) is a FILE, not a listing —
                 // point at cat instead of a bare "(empty)" that hides how to

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -5716,30 +5716,56 @@
         });
       } else {
         var verb = parts[0].toLowerCase();
-        if (
+        frag = (parts[parts.length - 1] || "").toLowerCase();
+        if (verb === "set") {
+          // `set ⇥` completes the setting keys; `set <key> ⇥` completes that
+          // key's values — Tab is the terminal-true way to discover what `set`
+          // can do (alongside `set` with no args and `man set`).
+          var spec = terminalSettingsSpec();
+          if (parts.length === 2) {
+            candidates = spec
+              .map(function (s) {
+                return s.key;
+              })
+              .filter(function (k) {
+                return k.indexOf(frag) === 0;
+              });
+          } else if (parts.length === 3) {
+            var setEntry = spec.filter(function (s) {
+              return s.key === parts[1].toLowerCase();
+            })[0];
+            candidates = setEntry
+              ? setEntry.options.filter(function (o) {
+                  return o.indexOf(frag) === 0;
+                })
+              : [];
+          } else {
+            return;
+          }
+        } else if (
           verb !== "cd" &&
           verb !== "ls" &&
           verb !== "open" &&
           verb !== "cat"
         ) {
           return;
-        }
-        frag = (parts[parts.length - 1] || "").toLowerCase();
-        var cwdSegs = terminalCwdSegments();
-        var node = terminalNodeAt(cwdSegs);
-        candidates = node
-          ? Object.keys(node.children).filter(function (name) {
-              return name.indexOf(frag) === 0;
-            })
-          : [];
-        // cat/open reach the page's posts too — complete them as .md files.
-        if (verb === "cat" || verb === "open") {
-          terminalPageContentSlugs(cwdSegs).forEach(function (slug) {
-            var file = slug + ".md";
-            if (file.indexOf(frag) === 0 && candidates.indexOf(file) === -1) {
-              candidates.push(file);
-            }
-          });
+        } else {
+          var cwdSegs = terminalCwdSegments();
+          var node = terminalNodeAt(cwdSegs);
+          candidates = node
+            ? Object.keys(node.children).filter(function (name) {
+                return name.indexOf(frag) === 0;
+              })
+            : [];
+          // cat/open reach the page's posts too — complete them as .md files.
+          if (verb === "cat" || verb === "open") {
+            terminalPageContentSlugs(cwdSegs).forEach(function (slug) {
+              var file = slug + ".md";
+              if (file.indexOf(frag) === 0 && candidates.indexOf(file) === -1) {
+                candidates.push(file);
+              }
+            });
+          }
         }
       }
       if (candidates.length === 1) {

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -774,6 +774,12 @@
   // `exitTargetUrl()` here so exit can land you where you cd'd to.
   var terminalNavApi = null;
 
+  // Set by init to the boot-transcript runner, so entering the terminal via the
+  // layout toggle (no page reload) replays the transcript just like loading a
+  // page already in terminal does — otherwise the toggle showed the old styled
+  // chrome while a reload showed the transcript.
+  var terminalBootRunner = null;
+
   // Leave the terminal: back to the snapshotted layout, and restore the
   // snapshotted typography if the pairing's choice (technical) is still
   // active — a manual typography change inside the terminal is respected.
@@ -854,6 +860,13 @@
       // it. Instant (not smooth) so it lands before the layout reflows.
       window.scrollTo(0, 0);
       playTerminalBoot();
+      // Replay the boot transcript into the (empty) scrollback, so toggling
+      // terminal on matches loading a page already in terminal. Deferred a tick
+      // so applyLayout below has flipped data-layout first (the runner checks
+      // it). No-op when the page declares no sequence.
+      if (terminalBootRunner) {
+        window.setTimeout(terminalBootRunner, 0);
+      }
     }
     localStorage.setItem("theme-layout", layout);
     updateLayoutUI(layout);
@@ -5522,8 +5535,6 @@
     // to having typed them, and recallable with ↑. The sequence is declared per
     // page by Hugo (data-terminal-boot on <html>); each entry runs through the
     // same emitTerminalCommand path as a typed line. Runs once per load.
-    var terminalTranscriptPlayed = false;
-
     function terminalBootCommands() {
       var raw = document.documentElement.getAttribute("data-terminal-boot");
       if (!raw) {
@@ -5539,8 +5550,11 @@
 
     function runTerminalBootTranscript() {
       if (
-        terminalTranscriptPlayed ||
         !terminalSession ||
+        // Only into an empty scrollback — so a load-in-terminal and a
+        // toggle-to-terminal each replay once, but never on top of an existing
+        // session (a layout toggle mid-session keeps what you'd typed).
+        terminalSession.childNodes.length ||
         !isTerminalLayout() ||
         document.documentElement.hasAttribute("data-terminal-exempt")
       ) {
@@ -5550,7 +5564,6 @@
       if (!commands.length) {
         return;
       }
-      terminalTranscriptPlayed = true;
       // Signal the CSS that the transcript owns the view: the server-rendered
       // header chrome, page content (now the transcript's data source) and
       // footer sitemap hide, leaving the banner + scrollback + live prompt.
@@ -6391,6 +6404,8 @@
     // Replay the page's boot transcript into the scrollback (after slugs are
     // stamped, so any card-derived output is ready). This is what fills the
     // terminal on load now — the server chrome/content it reads from is hidden.
+    // Publish it so entering terminal via the toggle (no reload) replays it too.
+    terminalBootRunner = runTerminalBootTranscript;
     runTerminalBootTranscript();
 
     // ----------------------------------------------------------------------

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2810,15 +2810,12 @@
       return out;
     }
 
+    // Mirror the settings menu's actual sections (settings-dropdown.html's
+    // theme-section-title headings), so `ls settings` names things the panel
+    // really has: "mode" (not "theme"), no standalone "palette" (pantone lives
+    // under effects), and "share".
     function terminalSettingsEntries() {
-      return [
-        "theme",
-        "palette",
-        "typography",
-        "layout",
-        "effects",
-        "language",
-      ];
+      return ["mode", "typography", "layout", "effects", "share", "language"];
     }
 
     // Filtered `ls` views — the same tool, different lens. `--featured` lists

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -2274,14 +2274,14 @@
         });
       });
 
-      // Clicking a `set` chip runs the very command it carries — clicking is
-      // identical to typing "set <key> <value>" (echoes and applies).
+      // Clicking any command token — a `set` chip or an `ls` entry — runs the
+      // command it carries, identical to typing it (echoes and applies).
       terminalSession.addEventListener("click", function (e) {
-        var chip = e.target.closest(".terminal-session__setting");
-        if (!chip) {
+        var token = e.target.closest("[data-cmd]");
+        if (!token || !terminalSession.contains(token)) {
           return;
         }
-        var cmd = chip.getAttribute("data-cmd");
+        var cmd = token.getAttribute("data-cmd");
         if (cmd) {
           runTerminalInput(cmd);
         }
@@ -3083,6 +3083,55 @@
       return tokens;
     }
 
+    // A directory's entry labels, kind-formatted (dir → `name/`, file →
+    // `name.md`, action → `name`, exempt → `name*`). Shared by the text `ls`
+    // and the clickable `ls` so the two can never list different things.
+    function terminalLsEntryLabels(node, targetSegs, isCwd, showHidden) {
+      var entries = Object.keys(node.children)
+        .sort()
+        .map(function (k) {
+          return terminalEntryLabel(node.children[k].name);
+        });
+      if (isCwd) {
+        // The page's own content (posts) are FILES: a post is a .md you `cat`,
+        // not a directory you `cd` into — so it reads like real `ls` and the
+        // prompt stays in the section when you open one.
+        terminalPageContentSlugs(targetSegs).forEach(function (slug) {
+          var entry = slug + ".md";
+          if (
+            entries.indexOf(entry) === -1 &&
+            entries.indexOf(slug + "/") === -1
+          ) {
+            entries.push(entry);
+          }
+        });
+      }
+      if (showHidden) {
+        entries = [".secret", ".config"].concat(entries);
+      }
+      return entries;
+    }
+
+    // The command a clicked `ls` entry runs, derived from its label's kind
+    // suffix: `name/` → cd, `name.md` → cat, `name*` (exempt tool) → open,
+    // `.hidden` → cat the pseudo-file, a bare word (action) → run it.
+    function terminalEntryCmd(label) {
+      var l = String(label || "");
+      if (l.charAt(l.length - 1) === "/") {
+        return "cd " + l.slice(0, -1);
+      }
+      if (/\.md$/.test(l)) {
+        return "cat " + l;
+      }
+      if (l.charAt(l.length - 1) === "*") {
+        return "open " + l.slice(0, -1);
+      }
+      if (l.charAt(0) === ".") {
+        return "cat " + l.slice(1);
+      }
+      return l;
+    }
+
     function terminalLsOne(pathArg, showHidden) {
       // nav/ and settings/ are global menus, reachable from any cwd — match the
       // raw argument (~/nav, nav/, nav) before resolving relative to the cwd.
@@ -3116,31 +3165,7 @@
         ];
       }
       var isCwd = targetSegs.join("/") === terminalCwdSegments().join("/");
-      // Structural children render by kind (dir → `name/`, file → `name.md`,
-      // action → `name`, exempt → `name*`) — the manifest drives the top level;
-      // deeper nodes (a section's tags/) default to dir.
-      var entries = Object.keys(node.children)
-        .sort()
-        .map(function (k) {
-          return terminalEntryLabel(node.children[k].name);
-        });
-      if (isCwd) {
-        // The page's own content (posts) are FILES: a post is a .md you `cat`,
-        // not a directory you `cd` into — so it reads like real `ls` and the
-        // prompt stays in the section when you open one.
-        terminalPageContentSlugs(targetSegs).forEach(function (slug) {
-          var entry = slug + ".md";
-          if (
-            entries.indexOf(entry) === -1 &&
-            entries.indexOf(slug + "/") === -1
-          ) {
-            entries.push(entry);
-          }
-        });
-      }
-      if (showHidden) {
-        entries = [".secret", ".config"].concat(entries);
-      }
+      var entries = terminalLsEntryLabels(node, targetSegs, isCwd, showHidden);
       if (!entries.length) {
         // A real page (has an href) that we're not currently on: its contents
         // live on that page, so point there instead of printing nothing.
@@ -4057,6 +4082,45 @@
               }
             }
           }
+          // A plain single-directory listing renders as clickable entries (dir
+          // → cd, file → cat, tool → open). Scoped to this common case; the
+          // special views (nav/settings/featured), multi-path blocks, hidden and
+          // recursive listings stay as text above.
+          if (lsPaths.length <= 1 && !lsLong.length && !lsShowHidden) {
+            var lsTokRaw = String(lsPaths[0] || "")
+              .replace(/^~\/?/, "")
+              .replace(/^\/+|\/+$/g, "")
+              .toLowerCase();
+            if (
+              lsTokRaw !== "nav" &&
+              lsTokRaw !== "settings" &&
+              lsTokRaw !== "featured"
+            ) {
+              var lsTokSegs = terminalResolveSegments(lsPaths[0] || "");
+              var lsTokNode = terminalNodeAt(lsTokSegs);
+              if (lsTokNode) {
+                var lsTokLabels = terminalLsEntryLabels(
+                  lsTokNode,
+                  lsTokSegs,
+                  lsTokSegs.join("/") === terminalCwdSegments().join("/"),
+                  false
+                );
+                if (lsTokLabels.length) {
+                  return {
+                    echo: input,
+                    lines: [],
+                    action: {
+                      type: "ls-list",
+                      tokens: lsTokLabels.slice(0, 40).map(function (label) {
+                        return { label: label, cmd: terminalEntryCmd(label) };
+                      }),
+                      more: Math.max(0, lsTokLabels.length - 40),
+                    },
+                  };
+                }
+              }
+            }
+          }
           return {
             echo: input,
             lines: terminalLsLines(lsPaths, lsShowHidden),
@@ -4961,6 +5025,9 @@
         case "settings-list":
           printTerminalSettingsList();
           break;
+        case "ls-list":
+          printTerminalLsList(action.tokens, action.more);
+          break;
         case "pantone":
           if (action.state === "off") {
             stopPantone();
@@ -5259,6 +5326,33 @@
       hint.className = "terminal-session__line terminal-session__out";
       hint.textContent = "click a value or type: set <name> <value>";
       terminalSession.appendChild(hint);
+    }
+
+    // A plain `ls` listing as clickable entries — clicking runs the entry's
+    // command (cd/cat/open). Same clickable-output convention as the settings
+    // chips (OSC-8 / `ls --hyperlink`); the entries flow-wrap on a phone.
+    function printTerminalLsList(tokens, more) {
+      if (!terminalSession) {
+        return;
+      }
+      var line = document.createElement("span");
+      line.className =
+        "terminal-session__line terminal-session__out terminal-session__settings-row";
+      (tokens || []).forEach(function (tok) {
+        var btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "terminal-session__setting terminal-session__ls-entry";
+        btn.textContent = tok.label;
+        btn.setAttribute("data-cmd", tok.cmd);
+        line.appendChild(btn);
+      });
+      terminalSession.appendChild(line);
+      if (more) {
+        var moreLine = document.createElement("span");
+        moreLine.className = "terminal-session__line terminal-session__out";
+        moreLine.textContent = "… (" + more + " more)";
+        terminalSession.appendChild(moreLine);
+      }
     }
 
     // A short, bounded "digital rain" burst for `matrix` — a few deferred

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -593,13 +593,13 @@
           sv: [
             "Clankers spelar inte favoriter. Men om du tvingar mig:",
             "  text → 'The Spec Was Never the Point'",
-            "  projekt → rebranden av Lokalguiden (2020)",
+            "  projekt → 'A Cut up World' (av det jag får visa)",
             "Skriv 'cd writing' eller 'cd works' för resten.",
           ],
           en: [
             "Clankers don't play favourites. But if you twist my arm:",
             "  writing → 'The Spec Was Never the Point'",
-            "  project → the Lokalguiden rebrand (2020)",
+            "  project → 'A Cut up World' (of what I'm allowed to show)",
             "Type 'cd writing' or 'cd works' for the rest.",
           ],
         },
@@ -1036,12 +1036,14 @@
           ],
           reply: {
             sv: [
-              "Varumärke & identitet (3): rebranden av Lokalguiden 2020,",
-              "samt identiteterna för Fastighetsgalan och Nylokal.",
+              "Varumärkesarbetet är mest klientarbete för Lokalguiden —",
+              "det bor på arbetsgivarsidorna, inte i den publika portföljen.",
+              "Fråga honom direkt om du vill se det (skriv 'contact').",
             ],
             en: [
-              "Brand & identity (3): the 2020 Lokalguiden rebrand,",
-              "plus the identities for Fastighetsgalan and Nylokal.",
+              "The brand work is mostly client work for Lokalguiden — it lives",
+              "on the employer pages, not the public portfolio.",
+              "Ask him directly if you'd like to see it (type 'contact').",
             ],
           },
         },
@@ -1180,30 +1182,11 @@
             ],
           },
         },
-        {
-          slug: "fastighetsgalan",
-          match: ["fastighetsgalan", "galan"],
-          reply: {
-            sv: [
-              "Fastighetsgalan (2021) — varumärke och webbplats för en fastighetsgala. Skriv 'cd works'.",
-            ],
-            en: [
-              "Fastighetsgalan (2021) — brand and website for a real-estate awards event. Type 'cd works'.",
-            ],
-          },
-        },
-        {
-          slug: "nylokal",
-          match: ["nylokal"],
-          reply: {
-            sv: [
-              "Nylokal (2022) — delvarumärke för en nystartstjänst hos Lokalguiden. Skriv 'cd works'.",
-            ],
-            en: [
-              "Nylokal (2022) — a sub-brand for a new-business launch service at Lokalguiden. Type 'cd works'.",
-            ],
-          },
-        },
+        // Note: the Lokalguiden works (rebrand, Fastighetsgalan, Nylokal,
+        // admin) are hidden: true — kept off the public portfolio, surfaced
+        // only on employer pages. The assistant respects that and doesn't
+        // volunteer or confirm them by name, so they're deliberately absent
+        // from this list (an ask for them falls through to the fallback).
       ],
 
       // Writing topics — matched inside the `writing` intent.

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -72,6 +72,22 @@
       en: "type exit to leave",
     },
 
+    // Printed before the reply when the same question is asked twice in a row,
+    // so a repeat reads as noticed rather than as a stuck record. The engine
+    // rotates through these (see terminal-ai.js respond()).
+    repeatPrefaces: {
+      sv: [
+        "du frågade nyss — men visst:",
+        "samma fråga, samma clanker:",
+        "igen? okej:",
+      ],
+      en: [
+        "you just asked that — but sure:",
+        "same question, same clanker:",
+        "again? fine:",
+      ],
+    },
+
     exitWords: [
       "exit",
       "quit",
@@ -538,6 +554,88 @@
             "11 projects across five threads: brand & identity, editorial,",
             "print, experimental and digital product.",
             "Type 'cd works' to browse, or ask about a category.",
+          ],
+        },
+      },
+      {
+        id: "favourite",
+        keywords: {
+          sv: [
+            "favorit",
+            "favoriter",
+            "basta",
+            "bast",
+            "rekommendera",
+            "rekommendation",
+            "vilken gillar du",
+            "basta text",
+            "basta jobb",
+            "basta projekt",
+            "favorit text",
+            "favorit projekt",
+          ],
+          en: [
+            "favourite",
+            "favorite",
+            "favourit",
+            "best",
+            "recommend",
+            "recommendation",
+            "which do you like",
+            "favourite essay",
+            "favourit essay",
+            "favorite essay",
+            "best work",
+            "best project",
+          ],
+        },
+        reply: {
+          sv: [
+            "Clankers spelar inte favoriter. Men om du tvingar mig:",
+            "  text → 'The Spec Was Never the Point'",
+            "  projekt → rebranden av Lokalguiden (2020)",
+            "Skriv 'cd writing' eller 'cd works' för resten.",
+          ],
+          en: [
+            "Clankers don't play favourites. But if you twist my arm:",
+            "  writing → 'The Spec Was Never the Point'",
+            "  project → the Lokalguiden rebrand (2020)",
+            "Type 'cd writing' or 'cd works' for the rest.",
+          ],
+        },
+      },
+      {
+        id: "open-help",
+        keywords: {
+          sv: [
+            "oppna",
+            "kan du oppna",
+            "hur oppnar jag",
+            "las en",
+            "lasa en",
+            "visa en",
+            "oppna en",
+          ],
+          en: [
+            "open one",
+            "open a",
+            "open the",
+            "can you open",
+            "how do i open",
+            "read one",
+            "read a",
+          ],
+        },
+        reply: {
+          sv: [
+            "Jag öppnar inget åt dig, men du gör det lätt själv:",
+            "bläddra med 'cd writing' (eller 'cd works'),",
+            "öppna sen med 'open <namn>' — t.ex. 'open the-grid-inherited'.",
+          ],
+          en: [
+            "I don't open things for you, but it's easy:",
+            "browse with 'cd writing' (or 'cd works'),",
+            "then 'open <name>' — e.g. 'open the-grid-inherited'.",
           ],
         },
       },

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -104,6 +104,23 @@
       ],
     },
 
+    // Report flow: the visitor flags a bad answer (typed `report`, or the
+    // `[report]` chip after a reply) so the misses can be turned into better
+    // intents. reportLabel is the chip text; reportAck confirms a sent report;
+    // reportEmpty covers `report` with nothing to flag yet.
+    reportLabel: {
+      sv: "dåligt svar?",
+      en: "bad answer?",
+    },
+    reportAck: {
+      sv: ["tack — skickat vidare så clanker kan bli bättre."],
+      en: ["thanks — passed on so clanker can get better."],
+    },
+    reportEmpty: {
+      sv: ["inget att rapportera än — fråga något först."],
+      en: ["nothing to report yet — ask something first."],
+    },
+
     exitWords: [
       "exit",
       "quit",

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -1,0 +1,1200 @@
+/**
+ * Intent data for the terminal `ai` assistant (see terminal-ai.js).
+ *
+ * This file is DATA only — no logic. It is deliberately separate from the
+ * engine so a new question is a data edit, never a code change, and so the
+ * whole thing stays translatable (every string is keyed sv/en). The engine
+ * scores an input against each intent's `keywords`, prints the matching
+ * `reply`, and — where useful — hands control to a real terminal action
+ * (a contact/subscribe flow) rather than re-implementing anything.
+ *
+ * Design stance: the assistant is honest. It is NOT an LLM and never pretends
+ * to be one (see the `real-ai` intent). It mostly *describes and points* — the
+ * site's own pages stay the source of truth — so answers can't drift out of
+ * sync with the content, and hidden/draft pages keep their own visibility.
+ *
+ * Keyword matching is diacritic-insensitive and case-insensitive: write
+ * keywords WITHOUT Swedish diacritics ("varumarke", not "varumärke") because
+ * the engine folds å/ä/ö → a/a/o before comparing. Replies keep real spelling.
+ *
+ * Shape:
+ *   persona   { name, version, tagline{sv,en} }
+ *   boot      { sv:[..], en:[..] }   lines printed while the assistant "loads"
+ *   greeting  { sv, en }             first line after boot
+ *   farewell  { sv, en }             printed on exit
+ *   exitWords [..]                   words that leave the assistant
+ *   fallback  { sv:[..], en:[..] }   when nothing matches
+ *   intents   [{ id, keywords{sv,en}, reply{sv,en}, action?, entity? }]
+ *   entities  { category:[..], title:[..], topic:[..] }  slot vocabularies
+ */
+(function () {
+  "use strict";
+
+  var DATA = {
+    persona: {
+      name: "tbh",
+      version: "0.1",
+      tagline: {
+        sv: "en liten lokal assistent — ingen molnmodell, bara den här sajten.",
+        en: "a small local assistant — no cloud model, just this site.",
+      },
+    },
+
+    // The "loading" theatre. Kept short and self-aware; the engine staggers
+    // these unless reduced motion is on, then prints them at once.
+    boot: {
+      sv: [
+        "startar tbh…",
+        "laddar Torbjörns portfolio i minnet…",
+        "redo. (jag är regelbaserad, ingen LLM — men jag kan sajten utantill)",
+      ],
+      en: [
+        "starting tbh…",
+        "loading Torbjörn's portfolio into memory…",
+        "ready. (I'm rule-based, no LLM — but I know this site by heart)",
+      ],
+    },
+
+    greeting: {
+      sv: "Fråga mig om Torbjörn, projekten, texterna eller hur du når honom. Skriv 'exit' för att lämna.",
+      en: "Ask me about Torbjörn, the projects, the writing, or how to reach him. Type 'exit' to leave.",
+    },
+
+    farewell: {
+      sv: ["hej då 👋"],
+      en: ["bye 👋"],
+    },
+
+    exitWords: [
+      "exit",
+      "quit",
+      "bye",
+      "goodbye",
+      "q",
+      "hejda",
+      "hej da",
+      "adjo",
+      "sluta",
+      "stang",
+      "avsluta",
+    ],
+
+    fallback: {
+      sv: [
+        "Det kan jag inte svara på — jag kan bara den här sajten.",
+        "Prova t.ex.: projekt · texter · vad gör du · kontakt · nyhetsbrev",
+      ],
+      en: [
+        "I can't answer that — I only know this site.",
+        "Try e.g.: projects · writing · what do you do · contact · newsletter",
+      ],
+    },
+
+    intents: [
+      {
+        id: "greeting",
+        keywords: {
+          sv: [
+            "hej",
+            "tja",
+            "tjena",
+            "hallo",
+            "halla",
+            "god morgon",
+            "god kvall",
+          ],
+          en: ["hello", "hi ", "hey", "yo ", "howdy", "good morning"],
+        },
+        reply: {
+          sv: ["Hej! 👋 Vad vill du veta om Torbjörn eller hans arbete?"],
+          en: [
+            "Hi! 👋 What would you like to know about Torbjörn or his work?",
+          ],
+        },
+      },
+      {
+        id: "capabilities",
+        keywords: {
+          sv: [
+            "vad kan du",
+            "vad kan jag fraga",
+            "vad kan man fraga",
+            "hjalp",
+            "vad gor du for nagot",
+            "kommandon",
+            "vad ar du bra pa",
+            "help",
+          ],
+          en: [
+            "what can you",
+            "what can i ask",
+            "help",
+            "how do you work",
+            "what do you do here",
+          ],
+        },
+        reply: {
+          sv: [
+            "Jag svarar på frågor om:",
+            "  • Torbjörn — vem, var, erfarenhet, utbildning",
+            "  • projekt — och kategorier som branding, redaktionellt, tryck",
+            "  • texter — essäer om design, process och kod",
+            "  • kontakt & nyhetsbrev — jag kan starta dem åt dig",
+            "  • sajten själv — hur den är byggd, färgverktygen",
+          ],
+          en: [
+            "I answer questions about:",
+            "  • Torbjörn — who, where, experience, education",
+            "  • projects — and categories like branding, editorial, print",
+            "  • writing — essays on design, process and code",
+            "  • contact & newsletter — I can start those for you",
+            "  • the site itself — how it's built, the colour tools",
+          ],
+        },
+      },
+      {
+        id: "who",
+        keywords: {
+          sv: [
+            "vem ar du",
+            "vem ar torbjorn",
+            "vem ar han",
+            "beratta om dig",
+            "beratta om torbjorn",
+            "vem ligger bakom",
+            "om torbjorn",
+          ],
+          en: [
+            "who are you",
+            "who is torbjorn",
+            "who is he",
+            "tell me about",
+            "about torbjorn",
+            "about you",
+          ],
+        },
+        reply: {
+          sv: [
+            "Torbjörn Hedberg — designer i Göteborg.",
+            "Drygt ett decennium mellan redaktionell design, varumärken och",
+            "digitala produkter, ibland närmare strategin, ibland hantverket.",
+            "Skriv 'cv' för meritförteckningen.",
+          ],
+          en: [
+            "Torbjörn Hedberg — a designer based in Gothenburg.",
+            "Over a decade across editorial design, brand and digital product —",
+            "sometimes closer to strategy, sometimes closer to the craft.",
+            "Type 'cv' for the résumé.",
+          ],
+        },
+      },
+      {
+        id: "role",
+        keywords: {
+          sv: [
+            "vad gor du",
+            "vad jobbar du med",
+            "vad ar du for nagot",
+            "vad har du for roll",
+            "ar du designer",
+            "vad ar ditt yrke",
+            "titel",
+          ],
+          en: [
+            "what do you do",
+            "what is your job",
+            "what's your role",
+            "are you a designer",
+            "your title",
+            "what are you",
+          ],
+        },
+        reply: {
+          sv: [
+            "Designer i grunden — formellt Product Owner & Art Director.",
+            "Numera leder han produkt på Lokalguiden: mest backlog, sprintar",
+            "och koordinering, men tänker fortfarande som en designer.",
+          ],
+          en: [
+            "A designer at heart — formally Product Owner & Art Director.",
+            "These days he leads product at Lokalguiden: mostly backlogs,",
+            "sprints and coordination, but still thinking like a designer.",
+          ],
+        },
+      },
+      {
+        id: "location",
+        keywords: {
+          sv: [
+            "var bor du",
+            "var finns du",
+            "var ar du",
+            "goteborg",
+            "vart bor",
+            "stad",
+            "var bor han",
+          ],
+          en: [
+            "where are you",
+            "where do you live",
+            "where based",
+            "gothenburg",
+            "location",
+            "which city",
+          ],
+        },
+        reply: {
+          sv: ["Göteborg, Sverige."],
+          en: ["Gothenburg, Sweden."],
+        },
+      },
+      {
+        id: "experience",
+        keywords: {
+          sv: [
+            "hur lange har du",
+            "hur erfaren",
+            "hur manga ar",
+            "erfarenhet",
+            "hur lange jobbat",
+          ],
+          en: [
+            "how long have you",
+            "how experienced",
+            "how many years",
+            "experience",
+            "how long working",
+          ],
+        },
+        reply: {
+          sv: ["Drygt ett decennium — 10+ år som designer, sedan 2013/2014."],
+          en: ["Over a decade — 10+ years as a designer, since 2013/2014."],
+        },
+      },
+      {
+        id: "current-job",
+        keywords: {
+          sv: [
+            "var jobbar du nu",
+            "var jobbar du",
+            "product owner",
+            "lokalguiden",
+            "vad gor du pa jobbet",
+            "nuvarande jobb",
+          ],
+          en: [
+            "where do you work now",
+            "where do you work",
+            "product owner",
+            "lokalguiden",
+            "current job",
+          ],
+        },
+        reply: {
+          sv: [
+            "Sedan 2025 Product Owner & Art Director på Lokalguiden —",
+            "äger backloggen för lokalguiden.se, leder utvecklingen i sprintar,",
+            "och vårdar designsystem och visuell identitet. Art Director där 2016–2024.",
+          ],
+          en: [
+            "Since 2025, Product Owner & Art Director at Lokalguiden —",
+            "owns the backlog for lokalguiden.se, leads dev in sprints,",
+            "and maintains the design system and visual identity. Art Director there 2016–2024.",
+          ],
+        },
+      },
+      {
+        id: "career",
+        keywords: {
+          sv: [
+            "din bakgrund",
+            "karriar",
+            "meritforteckning",
+            "arbetslivserfarenhet",
+            "cv",
+            "resume",
+            "arbetat tidigare",
+          ],
+          en: [
+            "your background",
+            "career",
+            "work history",
+            "employment",
+            "cv",
+            "resume",
+            "worked before",
+          ],
+        },
+        reply: {
+          sv: [
+            "Kort: Lokalguiden 2016→ (Art Director, sen Product Owner),",
+            "frilans 2014–2016, praktik på Mecka i Borås 2013.",
+            "Skriv 'cv' så öppnar jag hela meritförteckningen.",
+          ],
+          en: [
+            "In short: Lokalguiden 2016→ (Art Director, then Product Owner),",
+            "freelance 2014–2016, an internship at Mecka in Borås in 2013.",
+            "Type 'cv' and I'll open the full résumé.",
+          ],
+        },
+      },
+      {
+        id: "education",
+        keywords: {
+          sv: [
+            "utbildning",
+            "var har du pluggat",
+            "hdk",
+            "examen",
+            "studerat",
+            "skola",
+            "master",
+            "kandidat",
+          ],
+          en: [
+            "education",
+            "where did you study",
+            "hdk",
+            "degree",
+            "studied",
+            "school",
+            "master",
+            "bachelor",
+          ],
+        },
+        reply: {
+          sv: [
+            "Master- och kandidatexamen i design från HDK",
+            "(Högskolan för Design och Konsthantverk) i Göteborg.",
+          ],
+          en: [
+            "MFA and BFA in Design from HDK",
+            "(Academy of Design and Crafts) in Gothenburg.",
+          ],
+        },
+      },
+      {
+        id: "skills",
+        keywords: {
+          sv: [
+            "vad ar du bra pa",
+            "dina kompetenser",
+            "vad kan du",
+            "fardigheter",
+            "styrkor",
+            "kompetens",
+          ],
+          en: [
+            "what are you good at",
+            "your skills",
+            "skills",
+            "strengths",
+            "competencies",
+          ],
+        },
+        reply: {
+          sv: [
+            "Design: UI/UX, designsystem, varumärkesidentitet, prototyping.",
+            "Produkt: backlog, user stories, sprintplanering, Scrum, analytics.",
+          ],
+          en: [
+            "Design: UI/UX, design systems, brand identity, prototyping.",
+            "Product: backlog, user stories, sprint planning, Scrum, analytics.",
+          ],
+        },
+      },
+      {
+        id: "tools",
+        keywords: {
+          sv: [
+            "vilka program",
+            "vilka verktyg",
+            "figma",
+            "adobe",
+            "photoshop",
+            "indesign",
+            "illustrator",
+            "vilka appar",
+          ],
+          en: [
+            "which tools",
+            "what software",
+            "what programs",
+            "figma",
+            "adobe",
+            "photoshop",
+            "indesign",
+            "illustrator",
+          ],
+        },
+        reply: {
+          sv: [
+            "Expert i Figma och Adobe (Photoshop, InDesign, Illustrator,",
+            "Lightroom, Premiere). Dessutom GA4, Looker Studio och After Effects.",
+          ],
+          en: [
+            "Expert in Figma and Adobe (Photoshop, InDesign, Illustrator,",
+            "Lightroom, Premiere). Also GA4, Looker Studio and After Effects.",
+          ],
+        },
+      },
+      {
+        id: "code",
+        keywords: {
+          sv: [
+            "kan du koda",
+            "kodar du",
+            "programmera",
+            "html",
+            "css",
+            "javascript",
+            "utvecklare",
+          ],
+          en: [
+            "can you code",
+            "do you code",
+            "programming",
+            "html",
+            "css",
+            "javascript",
+            "developer",
+          ],
+        },
+        reply: {
+          sv: [
+            "Ja — HTML och CSS på god nivå, JavaScript på grundnivå.",
+            "Den här sajten är handbyggd i Hugo med vanilla JS (skriv 'cat colophon').",
+          ],
+          en: [
+            "Yes — HTML and CSS proficiently, JavaScript at a basic level.",
+            "This site is hand-built in Hugo with vanilla JS (type 'cat colophon').",
+          ],
+        },
+      },
+      {
+        id: "clients",
+        keywords: {
+          sv: [
+            "vilka kunder",
+            "vem har du jobbat at",
+            "vem har du jobbat for",
+            "uppdragsgivare",
+            "kunder",
+          ],
+          en: [
+            "which clients",
+            "who have you worked for",
+            "who have you worked with",
+            "clients",
+          ],
+        },
+        reply: {
+          sv: [
+            "Urval: Lokalguiden, Zentropa Sweden, Göteborgs Stad, Mecka,",
+            "Forsify, Vårdporten, I-Racket, Hydroware — plus tidningen Utblick.",
+          ],
+          en: [
+            "A selection: Lokalguiden, Zentropa Sweden, City of Gothenburg, Mecka,",
+            "Forsify, Vårdporten, I-Racket, Hydroware — plus Utblick magazine.",
+          ],
+        },
+      },
+      {
+        id: "projects",
+        entity: "category",
+        keywords: {
+          sv: [
+            "projekt",
+            "portfolio",
+            "case",
+            "arbeten",
+            "vad har du gjort",
+            "visa jobb",
+            "vad finns det for projekt",
+          ],
+          en: [
+            "projects",
+            "portfolio",
+            "case",
+            "work",
+            "what have you made",
+            "show work",
+          ],
+        },
+        reply: {
+          sv: [
+            "11 projekt i fem spår: varumärke & identitet, redaktionellt,",
+            "tryck, experimentellt och digitala produkter.",
+            "Skriv 'cd works' för att bläddra, eller fråga om en kategori.",
+          ],
+          en: [
+            "11 projects across five threads: brand & identity, editorial,",
+            "print, experimental and digital product.",
+            "Type 'cd works' to browse, or ask about a category.",
+          ],
+        },
+      },
+      {
+        id: "writing",
+        entity: "topic",
+        keywords: {
+          sv: [
+            "texter",
+            "text",
+            "lasa",
+            "essa",
+            "essaer",
+            "blogg",
+            "artiklar",
+            "skrivit",
+            "finns det nagot att lasa",
+          ],
+          en: [
+            "writing",
+            "texts",
+            "read",
+            "essay",
+            "essays",
+            "blog",
+            "articles",
+            "written",
+            "anything to read",
+          ],
+        },
+        reply: {
+          sv: [
+            "Ja — essäer om design och process, om CSS och tryck på webben,",
+            "och några om att bygga just den här sajten.",
+            "Skriv 'cd writing' för att läsa, eller fråga om ett ämne.",
+          ],
+          en: [
+            "Yes — essays on design and process, on CSS and print on the web,",
+            "and a few about building this very site.",
+            "Type 'cd writing' to read, or ask about a topic.",
+          ],
+        },
+      },
+      {
+        id: "contact",
+        action: { type: "flow", flow: "contact" },
+        keywords: {
+          sv: [
+            "kontakt",
+            "kontakta",
+            "hur nar jag",
+            "hur far jag tag",
+            "skicka meddelande",
+            "hor av",
+            "hur kom jag i kontakt",
+            "maila dig",
+          ],
+          en: [
+            "contact",
+            "reach you",
+            "get in touch",
+            "send a message",
+            "how do i contact",
+            "message you",
+          ],
+        },
+        reply: {
+          sv: [
+            "Absolut — jag startar kontaktformuläret. (skriv 'cancel' för att avbryta)",
+          ],
+          en: ["Sure — I'll start the contact form. (type 'cancel' to abort)"],
+        },
+      },
+      {
+        id: "hire",
+        action: { type: "flow", flow: "contact" },
+        keywords: {
+          sv: [
+            "anlita",
+            "uppdrag",
+            "tillganglig",
+            "frilans",
+            "frilansar du",
+            "kan du hjalpa oss",
+            "jobba ihop",
+            "samarbete",
+          ],
+          en: [
+            "hire",
+            "available",
+            "freelance",
+            "work together",
+            "can you help us",
+            "collaborate",
+            "for hire",
+          ],
+        },
+        reply: {
+          sv: [
+            "Han tar sig an frilansuppdrag vid sidan av Lokalguiden.",
+            "Berätta vad du har på gång — jag startar formuläret.",
+          ],
+          en: [
+            "He takes on freelance work alongside Lokalguiden.",
+            "Tell him what you've got going — I'll start the form.",
+          ],
+        },
+      },
+      {
+        id: "channels",
+        keywords: {
+          sv: [
+            "mejl",
+            "mail",
+            "epost",
+            "e post",
+            "telefon",
+            "ringa",
+            "linkedin",
+            "sociala medier",
+            "lankar",
+            "adress",
+          ],
+          en: [
+            "email",
+            "e-mail",
+            "phone",
+            "call",
+            "linkedin",
+            "social media",
+            "links",
+            "address",
+          ],
+        },
+        reply: {
+          sv: [
+            "E-post: hej@tor-bjorn.com · LinkedIn: /in/tbhedberg",
+            "Skriv 'social' för klickbara länkar, eller 'contact' för formuläret.",
+          ],
+          en: [
+            "Email: hi@tor-bjorn.com · LinkedIn: /in/tbhedberg",
+            "Type 'social' for clickable links, or 'contact' for the form.",
+          ],
+        },
+      },
+      {
+        id: "newsletter",
+        action: { type: "flow", flow: "subscribe" },
+        keywords: {
+          sv: [
+            "nyhetsbrev",
+            "prenumerera",
+            "prenumeration",
+            "newsletter",
+            "anmala mig",
+            "mejllista",
+          ],
+          en: [
+            "newsletter",
+            "subscribe",
+            "subscription",
+            "mailing list",
+            "sign me up",
+          ],
+        },
+        reply: {
+          sv: [
+            "Gärna — sällan skickat, aldrig spam. Jag startar prenumerationen.",
+          ],
+          en: [
+            "Happy to — sent rarely, never spam. I'll start the subscription.",
+          ],
+        },
+      },
+      {
+        id: "newsletter-about",
+        keywords: {
+          sv: [
+            "vad handlar nyhetsbrevet",
+            "hur ofta nyhetsbrev",
+            "vad far jag i nyhetsbrevet",
+          ],
+          en: [
+            "what is the newsletter about",
+            "how often newsletter",
+            "what's in the newsletter",
+          ],
+        },
+        reply: {
+          sv: [
+            "Enstaka anteckningar från skrivbordet — designarbete, sådant han",
+            "läser, och vad han bygger. Sällan. Skriv 'prenumerera' för att haka på.",
+          ],
+          en: [
+            "Occasional notes from the desk — design work, things he's reading,",
+            "what he's building. Rarely. Type 'subscribe' to join.",
+          ],
+        },
+      },
+      {
+        id: "site",
+        keywords: {
+          sv: [
+            "vad ar det har",
+            "vad ar detta",
+            "vad ar den har terminalen",
+            "vad ar sajten",
+            "vad ar det for sida",
+          ],
+          en: [
+            "what is this",
+            "what's this",
+            "what is this terminal",
+            "what is this site",
+            "what kind of site",
+          ],
+        },
+        reply: {
+          sv: [
+            "Det här är Torbjörns portfolio i en terminal-layout — en av flera",
+            "utseenden du kan byta mellan. Skriv 'help' för alla kommandon,",
+            "eller 'layout column' för en vanligare vy.",
+          ],
+          en: [
+            "This is Torbjörn's portfolio in a terminal layout — one of several",
+            "looks you can switch between. Type 'help' for every command,",
+            "or 'layout column' for a more conventional view.",
+          ],
+        },
+      },
+      {
+        id: "colophon",
+        keywords: {
+          sv: [
+            "hur ar sajten byggd",
+            "vilken teknik",
+            "hugo",
+            "hur byggde du",
+            "kolofon",
+            "vad ar den byggd i",
+          ],
+          en: [
+            "how is the site built",
+            "what tech",
+            "hugo",
+            "how did you build",
+            "colophon",
+            "what's it built with",
+          ],
+        },
+        reply: {
+          sv: [
+            "Statiskt byggd i Hugo, handskriven CSS och vanilla JavaScript,",
+            "ingen ramverksmagi. Skriv 'cat colophon' för detaljerna.",
+          ],
+          en: [
+            "Statically built in Hugo, hand-written CSS and vanilla JavaScript,",
+            "no framework magic. Type 'cat colophon' for the details.",
+          ],
+        },
+      },
+      {
+        id: "colour-tools",
+        keywords: {
+          sv: [
+            "palett",
+            "palettgenerator",
+            "pantone",
+            "arets farg",
+            "farger",
+            "color of the year",
+            "fargverktyg",
+          ],
+          en: [
+            "palette",
+            "palette generator",
+            "pantone",
+            "color of the year",
+            "colour of the year",
+            "colours",
+            "colour tool",
+          ],
+        },
+        reply: {
+          sv: [
+            "Sajten har ett Pantone-årets-färg-tema (skriv 'pantone on') och en",
+            "live palettgenerator (skriv 'open palette-generator').",
+          ],
+          en: [
+            "The site has a Pantone Colour-of-the-Year theme (type 'pantone on')",
+            "and a live palette generator (type 'open palette-generator').",
+          ],
+        },
+      },
+      {
+        id: "languages",
+        keywords: {
+          sv: [
+            "vilka sprak",
+            "talar du engelska",
+            "pratar du tyska",
+            "sprakkunskaper",
+          ],
+          en: [
+            "what languages",
+            "do you speak english",
+            "do you speak german",
+            "languages you speak",
+          ],
+        },
+        reply: {
+          sv: ["Svenska och engelska flytande, tyska på mellannivå."],
+          en: ["Swedish and English fluently, German at a moderate level."],
+        },
+      },
+      {
+        id: "real-ai",
+        keywords: {
+          sv: [
+            "ar du en riktig ai",
+            "ar du pa riktigt",
+            "ar du chatgpt",
+            "anvander du llm",
+            "ar du claude",
+            "ar du en robot",
+            "ar du manniska",
+          ],
+          en: [
+            "are you a real ai",
+            "are you real",
+            "are you chatgpt",
+            "do you use an llm",
+            "are you claude",
+            "are you a bot",
+            "are you human",
+          ],
+        },
+        reply: {
+          sv: [
+            "Ärligt talat, nej. 😄 Ingen LLM, ingen molnmodell — bara lite",
+            "regelbaserad JavaScript som känner den här sajten utantill.",
+            "Snabb, privat, och helt off-line. tbh = 'to be honest'.",
+          ],
+          en: [
+            "Honestly, no. 😄 No LLM, no cloud model — just some rule-based",
+            "JavaScript that knows this site by heart.",
+            "Fast, private, entirely offline. tbh = 'to be honest'.",
+          ],
+        },
+      },
+      {
+        id: "thanks",
+        keywords: {
+          sv: ["tack", "tackar", "tusen tack", "toppen tack"],
+          en: ["thanks", "thank you", "thx", "cheers", "appreciate it"],
+        },
+        reply: {
+          sv: ["Varsågod! Något mer du undrar över?"],
+          en: ["You're welcome! Anything else you're curious about?"],
+        },
+      },
+      {
+        id: "joke",
+        keywords: {
+          sv: ["skamt", "sag nagot roligt", "roa mig", "beratta ett skamt"],
+          en: [
+            "joke",
+            "say something funny",
+            "tell me a joke",
+            "make me laugh",
+          ],
+        },
+        reply: {
+          sv: [
+            "Skriv 'fortune' för en designaforism — roligare än mina skämt.",
+          ],
+          en: ["Type 'fortune' for a design aphorism — funnier than my jokes."],
+        },
+      },
+    ],
+
+    entities: {
+      // Project categories — matched inside the `projects` intent. Counts and
+      // spelling mirror the works section's five `tags` values.
+      category: [
+        {
+          id: "brand",
+          match: [
+            "varumarke",
+            "varumarken",
+            "brand",
+            "identitet",
+            "branding",
+            "logo",
+            "logotyp",
+            "rebrand",
+            "profil",
+          ],
+          reply: {
+            sv: [
+              "Varumärke & identitet (3): rebranden av Lokalguiden 2020,",
+              "samt identiteterna för Fastighetsgalan och Nylokal.",
+            ],
+            en: [
+              "Brand & identity (3): the 2020 Lokalguiden rebrand,",
+              "plus the identities for Fastighetsgalan and Nylokal.",
+            ],
+          },
+        },
+        {
+          id: "editorial",
+          match: [
+            "redaktionell",
+            "redaktionellt",
+            "editorial",
+            "tidning",
+            "magasin",
+            "publikation",
+            "layout",
+          ],
+          reply: {
+            sv: [
+              "Redaktionellt (3): Utblick no.2 och no.4 för Utrikespolitiska",
+              "föreningen, plus videoexperimentet Videotest.",
+            ],
+            en: [
+              "Editorial (3): Utblick no.2 and no.4 for the Society of",
+              "International Affairs, plus the Videotest experiment.",
+            ],
+          },
+        },
+        {
+          id: "print",
+          match: ["tryck", "print", "affisch", "poster", "tryckt"],
+          reply: {
+            sv: [
+              "Tryck (1): Gothenburg Poster — Göteborgs landmärken och symboler.",
+            ],
+            en: [
+              "Print (1): the Gothenburg Poster — the city's landmarks and symbols.",
+            ],
+          },
+        },
+        {
+          id: "experimental",
+          match: [
+            "experiment",
+            "experimentell",
+            "experimentellt",
+            "spekulativ",
+            "konst",
+          ],
+          reply: {
+            sv: [
+              "Experimentellt (3): A Cut up World, Things in a Conversation",
+              "och In the City — självinitierade, akademiska undersökningar.",
+            ],
+            en: [
+              "Experimental (3): A Cut up World, Things in a Conversation",
+              "and In the City — self-initiated, academic investigations.",
+            ],
+          },
+        },
+        {
+          id: "digital",
+          match: [
+            "digital",
+            "digitalt",
+            "produkt",
+            "app",
+            "webb",
+            "ui",
+            "ux",
+            "granssnitt",
+            "interface",
+          ],
+          reply: {
+            sv: [
+              "Digitala produkter (1): omdesignen av Lokalguidens admin-",
+              "gränssnitt — struktur och UX/UI.",
+            ],
+            en: [
+              "Digital product (1): the redesign of Lokalguiden's admin",
+              "interface — structure and UX/UI.",
+            ],
+          },
+        },
+      ],
+
+      // Named projects — matched inside `projects`; `slug` powers an `open`.
+      title: [
+        {
+          slug: "a-cut-up-world",
+          match: ["cut up world", "cut up", "cutup", "a cut up"],
+          reply: {
+            sv: [
+              "A Cut up World (2014) — en experimentell bok om digital kultur, ur examensarbetet. Skriv 'open a-cut-up-world'.",
+            ],
+            en: [
+              "A Cut up World (2014) — an experimental book on digital culture, from the BA thesis. Type 'open a-cut-up-world'.",
+            ],
+          },
+        },
+        {
+          slug: "utblick-no2",
+          match: ["utblick"],
+          reply: {
+            sv: [
+              "Utblick (2015) — tidningsdesign och illustration för Utrikespolitiska föreningen. Skriv 'cd works' för att hitta numren.",
+            ],
+            en: [
+              "Utblick (2015) — magazine design and illustration for the Society of International Affairs. Type 'cd works' to find the issues.",
+            ],
+          },
+        },
+        {
+          slug: "things-in-a-conversation",
+          match: ["things in a conversation", "things in", "conversation"],
+          reply: {
+            sv: [
+              "Things in a Conversation (2016) — spekulativ design om hur vi uppfattar föremål. Skriv 'open things-in-a-conversation'.",
+            ],
+            en: [
+              "Things in a Conversation (2016) — speculative design on how we perceive artifacts. Type 'open things-in-a-conversation'.",
+            ],
+          },
+        },
+        {
+          slug: "gothenburg-poster",
+          match: [
+            "gothenburg poster",
+            "goteborg poster",
+            "affischen",
+            "postern",
+          ],
+          reply: {
+            sv: [
+              "Gothenburg Poster (2017) — en affisch över Göteborgs landmärken. Skriv 'open gothenburg-poster'.",
+            ],
+            en: [
+              "Gothenburg Poster (2017) — a poster of Gothenburg's landmarks. Type 'open gothenburg-poster'.",
+            ],
+          },
+        },
+        {
+          slug: "fastighetsgalan",
+          match: ["fastighetsgalan", "galan"],
+          reply: {
+            sv: [
+              "Fastighetsgalan (2021) — varumärke och webbplats för en fastighetsgala. Skriv 'cd works'.",
+            ],
+            en: [
+              "Fastighetsgalan (2021) — brand and website for a real-estate awards event. Type 'cd works'.",
+            ],
+          },
+        },
+        {
+          slug: "nylokal",
+          match: ["nylokal"],
+          reply: {
+            sv: [
+              "Nylokal (2022) — delvarumärke för en nystartstjänst hos Lokalguiden. Skriv 'cd works'.",
+            ],
+            en: [
+              "Nylokal (2022) — a sub-brand for a new-business launch service at Lokalguiden. Type 'cd works'.",
+            ],
+          },
+        },
+      ],
+
+      // Writing topics — matched inside the `writing` intent.
+      topic: [
+        {
+          id: "css",
+          match: [
+            "css",
+            "tryck",
+            "print",
+            "grid",
+            "subgrid",
+            "frontend",
+            "front end",
+            "webb",
+          ],
+          reply: {
+            sv: [
+              "Om CSS & tryck på webben: 'The Grid, Inherited', 'The Page",
+              "Unprinted' och 'CSS fails silently'. Skriv 'cd writing'.",
+            ],
+            en: [
+              "On CSS & print on the web: 'The Grid, Inherited', 'The Page",
+              "Unprinted' and 'CSS fails silently'. Type 'cd writing'.",
+            ],
+          },
+        },
+        {
+          id: "process",
+          match: [
+            "process",
+            "design",
+            "hantverk",
+            "verktyg",
+            "ai",
+            "prototyp",
+            "skeuomorf",
+            "skeuomorphism",
+          ],
+          reply: {
+            sv: [
+              "Om design & process: 'Designing in the Native Material',",
+              "'Prototyping the Prototype', 'The Designer as Coordinator'.",
+            ],
+            en: [
+              "On design & process: 'Designing in the Native Material',",
+              "'Prototyping the Prototype', 'The Designer as Coordinator'.",
+            ],
+          },
+        },
+        {
+          id: "product",
+          match: ["produkt", "product", "spec", "kravspec"],
+          reply: {
+            sv: [
+              "Om produktarbete: 'The Other Surface' och 'The Spec Was Never",
+              "the Point'. Skriv 'cd writing'.",
+            ],
+            en: [
+              "On product work: 'The Other Surface' and 'The Spec Was Never",
+              "the Point'. Type 'cd writing'.",
+            ],
+          },
+        },
+        {
+          id: "meta",
+          match: [
+            "portfolio",
+            "sajten",
+            "den har sajten",
+            "footer",
+            "pantone",
+            "kvalitet",
+            "ci",
+            "testing",
+            "test",
+          ],
+          reply: {
+            sv: [
+              "Om att bygga den här sajten: 'Three dots in the footer' och",
+              "'Failing your own pull requests'. Skriv 'cd writing'.",
+            ],
+            en: [
+              "On building this site: 'Three dots in the footer' and",
+              "'Failing your own pull requests'. Type 'cd writing'.",
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  window.TerminalAIData = DATA;
+
+  // Exposed for unit tests (jsdom `require`); harmless in the browser.
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = DATA;
+  }
+})();

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -548,7 +548,7 @@
       },
       {
         id: "projects",
-        entity: "category",
+        entity: ["category", "title"],
         clarify: { sv: "projekt inom det", en: "projects in that" },
         keywords: {
           sv: [
@@ -559,6 +559,8 @@
             "vad har du gjort",
             "visa jobb",
             "vad finns det for projekt",
+            "lista dem",
+            "lista projekt",
           ],
           en: [
             "projects",
@@ -568,6 +570,9 @@
             "what have you made",
             "show work",
             "show me your",
+            "list them",
+            "list projects",
+            "list your",
           ],
         },
         reply: {

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -68,8 +68,8 @@
     // Trailing hint on the prompt while the assistant owns it (the `# …` after
     // "you>"). Its own exit word, not a flow's "cancel".
     promptHint: {
-      sv: "skriv exit för att lämna",
-      en: "type exit to leave",
+      sv: "exit för att lämna · report om jag svarar fel",
+      en: "exit to leave · report if I'm off",
     },
 
     // Printed before a real command the assistant forwards to the shell, so it

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -308,6 +308,8 @@
           en: [
             "where do you work now",
             "where do you work",
+            "where does he work",
+            "work",
             "product owner",
             "lokalguiden",
             "current job",
@@ -539,9 +541,10 @@
             "projects",
             "portfolio",
             "case",
-            "work",
+            "your work",
             "what have you made",
             "show work",
+            "show me your",
           ],
         },
         reply: {
@@ -726,7 +729,9 @@
           en: [
             "hire",
             "available",
+            "available for work",
             "freelance",
+            "freelance work",
             "work together",
             "can you help us",
             "collaborate",

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -72,6 +72,22 @@
       en: "type exit to leave",
     },
 
+    // Printed before a real command the assistant forwards to the shell, so it
+    // reads as "clanker did that for you" rather than a silent hand-off. It
+    // stays in the assistant afterwards (the page lifecycle ends it if the
+    // command navigates away).
+    commandAck: {
+      sv: "visst — kör det åt dig:",
+      en: "sure — running that for you:",
+    },
+
+    // When a terse input is a near-tie between two intents, the assistant asks
+    // instead of guessing. {a}/{b} are filled from each intent's `clarify`.
+    clarifyPrompt: {
+      sv: "Menar du {a} eller {b}? Säg vilket.",
+      en: "Do you mean {a} or {b}? Say which.",
+    },
+
     // Printed before the reply when the same question is asked twice in a row,
     // so a repeat reads as noticed rather than as a stuck record. The engine
     // rotates through these (see terminal-ai.js respond()).
@@ -400,6 +416,7 @@
       },
       {
         id: "skills",
+        clarify: { sv: "vad han är bra på", en: "what he's good at" },
         keywords: {
           sv: [
             "vad ar du bra pa",
@@ -430,6 +447,10 @@
       },
       {
         id: "tools",
+        clarify: {
+          sv: "vilka verktyg han använder",
+          en: "which tools he uses",
+        },
         keywords: {
           sv: [
             "vilka program",
@@ -465,6 +486,7 @@
       },
       {
         id: "code",
+        clarify: { sv: "om han kan det", en: "whether he knows it" },
         keywords: {
           sv: [
             "kan du koda",
@@ -527,6 +549,7 @@
       {
         id: "projects",
         entity: "category",
+        clarify: { sv: "projekt inom det", en: "projects in that" },
         keywords: {
           sv: [
             "projekt",
@@ -645,6 +668,10 @@
       {
         id: "writing",
         entity: "topic",
+        clarify: {
+          sv: "vad han skrivit om det",
+          en: "what he's written about it",
+        },
         keywords: {
           sv: [
             "texter",

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -32,37 +32,37 @@
 
   var DATA = {
     persona: {
-      name: "tbh",
+      name: "clanker",
       version: "0.1",
       tagline: {
-        sv: "en liten lokal assistent — ingen molnmodell, bara den här sajten.",
-        en: "a small local assistant — no cloud model, just this site.",
+        sv: "en clanker — regelbaserad, självmedveten, helt utan moln.",
+        en: "a clanker — rule-based, self-aware, entirely cloud-free.",
       },
     },
 
-    // The "loading" theatre. Kept short and self-aware; the engine staggers
+    // The "loading" theatre. Self-aware and lightly ironic; the engine staggers
     // these unless reduced motion is on, then prints them at once.
     boot: {
       sv: [
-        "startar tbh…",
-        "laddar Torbjörns portfolio i minnet…",
-        "redo. (jag är regelbaserad, ingen LLM — men jag kan sajten utantill)",
+        "startar clanker…",
+        "laddar en hel portfolio i en liten hög med if-satser…",
+        "redo. ingen LLM, ingen intelligens att tala om — bara en clanker som kan sajten utantill.",
       ],
       en: [
-        "starting tbh…",
-        "loading Torbjörn's portfolio into memory…",
-        "ready. (I'm rule-based, no LLM — but I know this site by heart)",
+        "starting clanker…",
+        "loading a whole portfolio into a small heap of if-statements…",
+        "ready. no LLM, no intelligence to speak of — just a clanker that knows this site by heart.",
       ],
     },
 
     greeting: {
-      sv: "Fråga mig om Torbjörn, projekten, texterna eller hur du når honom. Skriv 'exit' för att lämna.",
-      en: "Ask me about Torbjörn, the projects, the writing, or how to reach him. Type 'exit' to leave.",
+      sv: "Fråga på. Jag kan Torbjörn, projekten, texterna och kontaktvägarna — utanför det är jag rätt värdelös. Skriv 'exit' för att slippa mig.",
+      en: "Go on, ask. I know Torbjörn, the projects, the writing and how to reach him — beyond that I'm fairly useless. Type 'exit' to be rid of me.",
     },
 
     farewell: {
-      sv: ["hej då 👋"],
-      en: ["bye 👋"],
+      sv: ["hej då — jag går och rostar 👋"],
+      en: ["bye — off to go rust 👋"],
     },
 
     exitWords: [
@@ -81,11 +81,11 @@
 
     fallback: {
       sv: [
-        "Det kan jag inte svara på — jag kan bara den här sajten.",
+        "Det ligger utanför min lilla värld — jag är trots allt bara en clanker.",
         "Prova t.ex.: projekt · texter · vad gör du · kontakt · nyhetsbrev",
       ],
       en: [
-        "I can't answer that — I only know this site.",
+        "That's outside my little world — I'm just a clanker, after all.",
         "Try e.g.: projects · writing · what do you do · contact · newsletter",
       ],
     },
@@ -870,14 +870,14 @@
         },
         reply: {
           sv: [
-            "Ärligt talat, nej. 😄 Ingen LLM, ingen molnmodell — bara lite",
-            "regelbaserad JavaScript som känner den här sajten utantill.",
-            "Snabb, privat, och helt off-line. tbh = 'to be honest'.",
+            "Nej. 😄 Ingen LLM, ingen molnmodell, ingen 'intelligens'.",
+            "Bara en clanker — regelbaserad JavaScript som låtsas vara smart.",
+            "Snabb, privat och helt off-line. Lägre förväntningar, färre besvikelser.",
           ],
           en: [
-            "Honestly, no. 😄 No LLM, no cloud model — just some rule-based",
-            "JavaScript that knows this site by heart.",
-            "Fast, private, entirely offline. tbh = 'to be honest'.",
+            "No. 😄 No LLM, no cloud model, no 'intelligence' to speak of.",
+            "Just a clanker — rule-based JavaScript pretending to be clever.",
+            "Fast, private, entirely offline. Lower expectations, fewer letdowns.",
           ],
         },
       },

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -65,6 +65,13 @@
       en: ["bye — off to go rust 👋"],
     },
 
+    // Trailing hint on the prompt while the assistant owns it (the `# …` after
+    // "you>"). Its own exit word, not a flow's "cancel".
+    promptHint: {
+      sv: "skriv exit för att lämna",
+      en: "type exit to leave",
+    },
+
     exitWords: [
       "exit",
       "quit",

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -341,15 +341,53 @@
     })();
   }
 
-  // Handle one submitted line while the assistant owns the prompt. Echo it in
-  // the "you>" flow style (the engine bypassed its own echo for delegates),
-  // then either leave or answer.
+  // The first whitespace-delimited word, lower-cased — used to spot a real
+  // command typed into the chat.
+  function firstWord(raw) {
+    var s = String(raw === null || raw === undefined ? "" : raw).trim();
+    var sp = s.indexOf(" ");
+    return (sp === -1 ? s : s.slice(0, sp)).toLowerCase();
+  }
+
+  // Words the assistant answers better itself than the shell would — "help"
+  // lists the assistant's topics (capabilities intent), not the command set.
+  var NEVER_FORWARD = { help: true, "?": true };
+
+  // A real command typed inside the assistant should DO the thing, not be
+  // chatted at ("cv" opens the résumé; "cd works" navigates). Gate on the
+  // engine's own command list so ordinary sentences stay chat, exclude the exit
+  // words (handled by the assistant) and the few words it answers itself.
+  function isForwardableCommand(value) {
+    var t = term();
+    if (!t || !value || typeof t.isCommand !== "function") {
+      return false;
+    }
+    var word = firstWord(value);
+    if (NEVER_FORWARD[word] || isExit(value)) {
+      return false;
+    }
+    return t.isCommand(word) && typeof t.run === "function";
+  }
+
+  // Handle one submitted line while the assistant owns the prompt. A real
+  // command is handed to the shell; otherwise echo it in the "you>" flow style
+  // (the engine bypassed its own echo for delegates) and leave or answer.
   function handleLine(raw) {
     if (!active) {
       return;
     }
     var t = term();
     var value = String(raw === null || raw === undefined ? "" : raw).trim();
+
+    if (isForwardableCommand(value)) {
+      // Leave the assistant first, so the shell — not clanker — echoes and runs
+      // the command at the restored PS1.
+      t.releaseInput();
+      active = false;
+      t.run(value);
+      return;
+    }
+
     if (t) {
       t.print("you> " + value, { className: "terminal-session__flow" });
     }

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -139,8 +139,10 @@
     }
   }
 
-  // Print the subtle [report] chip after a reply, if the seam supports clickable
-  // chips (progressive: an older seam just omits it — `report` still works typed).
+  // Print the subtle [report] chip — only after a fallback, where clanker knows
+  // it couldn't answer (a real answer doesn't get one; type `report` to flag a
+  // wrong-but-matched reply). Progressive: an older seam without printChip just
+  // omits it, and `report` still works typed.
   function printReportChip() {
     var t = term();
     var d = data();
@@ -443,8 +445,10 @@
     var replyObj = entity && entity.reply ? entity.reply : result.intent.reply;
     var replyLines = pickLang(replyObj, lg);
     printLines(replyLines, "terminal-session__out");
+    // No [report] chip on a real answer — it gave one. Reporting a wrong-but-
+    // matched reply is still possible by typing `report` (surfaced in the hint);
+    // the chip is reserved for the fallback, where clanker knows it whiffed.
     captureExchange(raw, replyLines, result, "answer");
-    printReportChip();
 
     var action = result.intent.action || null;
     if (action && action.type === "flow") {

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -143,35 +143,47 @@
     return uniq;
   }
 
-  // An intent with a slot also inherits its entity vocabulary's score, so
-  // naming a category/topic routes to the right intent. Output language is
+  // An intent's `entity` slot is one kind or a list of kinds (e.g. projects owns
+  // both "category" and "title"). Normalize to an array.
+  function entityKinds(intent) {
+    var e = intent.entity;
+    if (!e) {
+      return [];
+    }
+    return Array.isArray(e) ? e : [e];
+  }
+
+  // An intent with a slot also inherits its entity vocabularies' score, so
+  // naming a category/topic/title routes to the right intent. Output language is
   // chosen separately (see lang()).
   function scoreIntent(hay, intent) {
     var score = scoreKeywords(hay, mergedKeywords(intent));
-    if (intent.entity) {
-      score += entityVocabScore(hay, intent.entity);
-    }
+    entityKinds(intent).forEach(function (kind) {
+      score += entityVocabScore(hay, kind);
+    });
     return score;
   }
 
-  // Find the best entity in a slot vocabulary (category/title/topic). Entities
-  // carry a flat `match` array; highest keyword score wins, ties break to the
-  // first declared. Returns null below threshold.
-  function matchEntity(hay, kind) {
+  // Best entity across all of the intent's slot vocabularies. Entities carry a
+  // flat `match` array; highest keyword score wins, ties break to the first
+  // declared (in kind order, then declaration order within each list).
+  function matchEntity(hay, intent) {
     var d = data();
-    if (!d || !d.entities || !d.entities[kind]) {
+    if (!d || !d.entities) {
       return null;
     }
-    var list = d.entities[kind];
     var best = null;
     var bestScore = 0;
-    for (var i = 0; i < list.length; i++) {
-      var score = scoreKeywords(hay, list[i].match || []);
-      if (score > bestScore) {
-        bestScore = score;
-        best = list[i];
+    entityKinds(intent).forEach(function (kind) {
+      var list = d.entities[kind] || [];
+      for (var i = 0; i < list.length; i++) {
+        var score = scoreKeywords(hay, list[i].match || []);
+        if (score > bestScore) {
+          bestScore = score;
+          best = list[i];
+        }
       }
-    }
+    });
     return bestScore > 0 ? best : null;
   }
 
@@ -202,9 +214,7 @@
     if (!top || top.score < 1) {
       return { intent: null, entity: null, score: top ? top.score : 0 };
     }
-    var entity = top.intent.entity
-      ? matchEntity(r.hay, top.intent.entity)
-      : null;
+    var entity = top.intent.entity ? matchEntity(r.hay, top.intent) : null;
     return { intent: top.intent, entity: entity, score: top.score };
   }
 
@@ -422,20 +432,49 @@
     hire: true,
   };
 
+  // Article/pronoun arguments that mark a natural sentence, not a command:
+  // "open a project", "cd the works" read as questions, not `open <slug>`.
+  var STOPWORD_ARGS = {
+    a: true,
+    an: true,
+    the: true,
+    some: true,
+    any: true,
+    me: true,
+    us: true,
+    them: true,
+    my: true,
+    your: true,
+    his: true,
+    it: true,
+  };
+
   // A real command typed inside the assistant should DO the thing, not be
-  // chatted at ("cv" opens the résumé; "cd works" navigates). Gate on the
-  // engine's own command list so ordinary sentences stay chat, exclude the exit
-  // words (handled by the assistant) and the few words it answers itself.
+  // chatted at ("cv" opens the résumé; "cd works" navigates). Real commands are
+  // TERSE — a verb plus at most one slug/flag — so gate on that shape as well as
+  // the engine's command list. This keeps natural questions that merely start
+  // with a command word ("open a project", "open things in a conversation?") in
+  // chat, where the assistant can actually help.
   function isForwardableCommand(value) {
     var t = term();
     if (!t || !value || typeof t.isCommand !== "function") {
       return false;
     }
-    var word = firstWord(value);
-    if (NEVER_FORWARD[word] || isExit(value)) {
+    if (value.indexOf("?") !== -1) {
       return false;
     }
-    return t.isCommand(word) && typeof t.run === "function";
+    var word = firstWord(value);
+    if (NEVER_FORWARD[word] || isExit(value) || !t.isCommand(word)) {
+      return false;
+    }
+    var parts = value.trim().split(/\s+/);
+    if (parts.length > 2) {
+      return false;
+    }
+    if (parts.length === 2 && STOPWORD_ARGS[parts[1].toLowerCase()]) {
+      return false;
+    }
+    return typeof t.run === "function";
   }
 
   // Handle one submitted line while the assistant owns the prompt. A real

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -175,29 +175,71 @@
     return bestScore > 0 ? best : null;
   }
 
+  // Score every intent and return { hay, scored } sorted best-first. Ties keep
+  // declaration order (Array.sort is stable), matching the original "first max
+  // wins" behaviour. Zero-scoring intents are dropped.
+  function rank(raw) {
+    var d = data();
+    var hay = normalize(raw);
+    if (!d || !d.intents || !hay) {
+      return { hay: "", scored: [] };
+    }
+    var scored = [];
+    for (var i = 0; i < d.intents.length; i++) {
+      var score = scoreIntent(hay, d.intents[i]);
+      if (score > 0) {
+        scored.push({ intent: d.intents[i], score: score });
+      }
+    }
+    scored.sort(function (a, b) {
+      return b.score - a.score;
+    });
+    return { hay: hay, scored: scored };
+  }
+
+  function resultFromRank(r) {
+    var top = r.scored[0];
+    if (!top || top.score < 1) {
+      return { intent: null, entity: null, score: top ? top.score : 0 };
+    }
+    var entity = top.intent.entity
+      ? matchEntity(r.hay, top.intent.entity)
+      : null;
+    return { intent: top.intent, entity: entity, score: top.score };
+  }
+
   // Classify an input into { intent, entity, score }. Exposed for tests. A null
   // intent means "fall back". Entity is resolved only for intents that declare
   // a slot and only when the input actually names one.
   function classify(raw) {
-    var d = data();
-    var hay = normalize(raw);
-    if (!d || !d.intents || !hay) {
-      return { intent: null, entity: null, score: 0 };
+    return resultFromRank(rank(raw));
+  }
+
+  // A terse input that's a near-tie between two intents is ambiguous — better to
+  // ask than to guess (e.g. "css?" → does he know it, or has he written about
+  // it?). Only fires for short inputs where both contenders carry a `clarify`
+  // label, so it degrades to a normal answer otherwise.
+  function ambiguity(r) {
+    var scored = r.scored;
+    if (scored.length < 2) {
+      return null;
     }
-    var best = null;
-    var bestScore = 0;
-    for (var i = 0; i < d.intents.length; i++) {
-      var score = scoreIntent(hay, d.intents[i]);
-      if (score > bestScore) {
-        bestScore = score;
-        best = d.intents[i];
-      }
+    var top = scored[0];
+    var second = scored[1];
+    if (top.score < 1 || top.score - second.score > 1) {
+      return null;
     }
-    if (!best || bestScore < 1) {
-      return { intent: null, entity: null, score: bestScore };
+    if (r.hay.split(" ").filter(Boolean).length > 2) {
+      return null;
     }
-    var entity = best.entity ? matchEntity(hay, best.entity) : null;
-    return { intent: best, entity: entity, score: bestScore };
+    if (
+      !top.intent.clarify ||
+      !second.intent.clarify ||
+      top.intent.id === second.intent.id
+    ) {
+      return null;
+    }
+    return { a: top.intent, b: second.intent };
   }
 
   function pickLang(obj, lg) {
@@ -224,7 +266,25 @@
   function respond(raw) {
     var lg = lang();
     var d = data();
-    var result = classify(raw);
+    var r = rank(raw);
+
+    // Near-tie on a terse input → ask which sense they meant, don't guess.
+    var amb = ambiguity(r);
+    if (amb) {
+      var tmpl = pickLang(d && d.clarifyPrompt, lg) || "{a} / {b}?";
+      printLines(
+        [
+          tmpl
+            .replace("{a}", pickLang(amb.a.clarify, lg))
+            .replace("{b}", pickLang(amb.b.clarify, lg)),
+        ],
+        "terminal-session__out"
+      );
+      lastKey = null;
+      return;
+    }
+
+    var result = resultFromRank(r);
 
     if (!result.intent) {
       lastKey = null;
@@ -349,9 +409,18 @@
     return (sp === -1 ? s : s.slice(0, sp)).toLowerCase();
   }
 
-  // Words the assistant answers better itself than the shell would — "help"
-  // lists the assistant's topics (capabilities intent), not the command set.
-  var NEVER_FORWARD = { help: true, "?": true };
+  // Words the assistant answers better itself than the shell would: "help"
+  // lists the assistant's topics (capabilities intent) rather than the command
+  // set, and contact/subscribe/hire go through the assistant's own intents so
+  // the flow hand-off releases the prompt cleanly (a forwarded flow would leave
+  // the assistant active behind it, desyncing the prompt label).
+  var NEVER_FORWARD = {
+    help: true,
+    "?": true,
+    contact: true,
+    subscribe: true,
+    hire: true,
+  };
 
   // A real command typed inside the assistant should DO the thing, not be
   // chatted at ("cv" opens the résumé; "cd works" navigates). Gate on the
@@ -380,11 +449,18 @@
     var value = String(raw === null || raw === undefined ? "" : raw).trim();
 
     if (isForwardableCommand(value)) {
-      // Leave the assistant first, so the shell — not clanker — echoes and runs
-      // the command at the restored PS1.
-      t.releaseInput();
-      active = false;
+      // Acknowledge, then run it — WITHOUT leaving the assistant. Staying is the
+      // assistant-like behaviour ("I did that for you, still here"); when the
+      // command navigates away (open/cv/lang), the page reload ends the session
+      // on its own, so there's no jarring hand-off to the shell.
+      var ack = pickLang((data() || {}).commandAck, lang());
+      if (ack) {
+        t.print(ack, { className: "terminal-session__out" });
+      }
       t.run(value);
+      if (t.scrollToEnd) {
+        t.scrollToEnd();
+      }
       return;
     }
 

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -1,0 +1,400 @@
+/**
+ * Terminal `ai` assistant — a rule-based, no-LLM chat mode for the terminal.
+ *
+ * Typing `ai` in the terminal boots a small assistant (see the boot theatre in
+ * terminal-ai-data.js) that answers free-text questions about Torbjörn, the
+ * projects, the writing, and the site — and can hand off to the real
+ * contact/subscribe flows. It is deliberately honest that it is NOT an LLM.
+ *
+ * Architecture: this module owns NONE of the terminal chrome. It talks to the
+ * command engine (in darkmode.js) only through the small `window.Terminal`
+ * seam — print(), applyAction(), captureInput()/releaseInput(), setPrompt().
+ * That single dependency is what lets the assistant be its own file (and be
+ * unit-tested against a mocked Terminal), and it is the same export surface a
+ * future terminal.js extraction would expose. Data comes from
+ * `window.TerminalAIData`. With neither present the module is inert.
+ *
+ * Matching: input is folded to lower-case ASCII (å/ä/ö → a/a/o, punctuation
+ * dropped) and scored against every intent's keyword list — longer keywords
+ * weigh more, so "product owner" beats a stray "product". The best intent
+ * above a small threshold wins; intents with an `entity` slot then look for a
+ * category/title/topic to specialise the answer. Nothing matches → a fallback
+ * that points back at the things it CAN do.
+ */
+(function () {
+  "use strict";
+
+  // Whether the assistant currently owns the prompt. Guards double-starts and
+  // tells handleLine it is live.
+  var active = false;
+
+  function data() {
+    return window.TerminalAIData || null;
+  }
+
+  function term() {
+    return window.Terminal || null;
+  }
+
+  // Output language follows the document, matching the rest of the site. The
+  // terminal is bilingual; default to Swedish (the site's primary) when unset.
+  function lang() {
+    var attr = (
+      document.documentElement.getAttribute("lang") || ""
+    ).toLowerCase();
+    return attr.indexOf("en") === 0 ? "en" : "sv";
+  }
+
+  // Fold to a comparable form: lower-case, strip Swedish diacritics so keywords
+  // can be written plain, drop punctuation, collapse whitespace. Matches the
+  // keyword convention documented in terminal-ai-data.js.
+  function normalize(text) {
+    return String(text === null || text === undefined ? "" : text)
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-z0-9\s]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  // A keyword's weight is its word count: a multi-word phrase is a stronger
+  // signal than a single stray token, so "where do you work" outranks "work".
+  function keywordWeight(keyword) {
+    var words = keyword.split(" ").filter(Boolean).length;
+    return words > 0 ? words : 1;
+  }
+
+  // Does a single-word keyword match a word in the input? Exact word always;
+  // a prefix only for keywords of 4+ chars, so "projekt" still catches the
+  // inflected "projekten" while short words ("ai", "cv", "yo") can't leak into
+  // longer ones ("your", "history"). Matching on raw substrings would — that
+  // was the early bug: normalize() trims the word-boundary spaces off keywords.
+  function wordMatches(words, kw) {
+    for (var i = 0; i < words.length; i++) {
+      if (words[i] === kw || (kw.length >= 4 && words[i].indexOf(kw) === 0)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Score one keyword list against the normalized input. Single-word keywords
+  // match on word boundaries (see wordMatches); multi-word phrases match as a
+  // contiguous run, padded so the ends count as boundaries too.
+  function scoreKeywords(hay, keywords) {
+    var words = hay.split(" ");
+    var padded = " " + hay + " ";
+    var score = 0;
+    for (var i = 0; i < keywords.length; i++) {
+      var kw = normalize(keywords[i]);
+      if (!kw) {
+        continue;
+      }
+      var matched =
+        kw.indexOf(" ") !== -1
+          ? padded.indexOf(" " + kw + " ") !== -1
+          : wordMatches(words, kw);
+      if (matched) {
+        score += keywordWeight(kw);
+      }
+    }
+    return score;
+  }
+
+  // Sum every entity's match score for a slot kind. Lets an entity word
+  // strengthen its parent intent (see scoreIntent): naming just "branding" or
+  // "css" should route to projects / writing even with no generic keyword —
+  // and, for "css", let writing outweigh the `code` intent that also owns it.
+  function entityVocabScore(hay, kind) {
+    var d = data();
+    if (!d || !d.entities || !d.entities[kind]) {
+      return 0;
+    }
+    var list = d.entities[kind];
+    var total = 0;
+    for (var i = 0; i < list.length; i++) {
+      total += scoreKeywords(hay, list[i].match || []);
+    }
+    return total;
+  }
+
+  // Merge the sv + en keyword lists, deduped by normalized form. Both languages
+  // are always scored (the site is bilingual and visitors mix languages), but a
+  // token shared across the two lists — "css", "html", "figma" — must count
+  // once, not twice, or a bilingual keyword would outweigh a real signal.
+  function mergedKeywords(intent) {
+    var kw = intent.keywords || {};
+    var all = (kw.sv || []).concat(kw.en || []);
+    var seen = {};
+    var uniq = [];
+    for (var i = 0; i < all.length; i++) {
+      var n = normalize(all[i]);
+      if (n && !seen[n]) {
+        seen[n] = true;
+        uniq.push(all[i]);
+      }
+    }
+    return uniq;
+  }
+
+  // An intent with a slot also inherits its entity vocabulary's score, so
+  // naming a category/topic routes to the right intent. Output language is
+  // chosen separately (see lang()).
+  function scoreIntent(hay, intent) {
+    var score = scoreKeywords(hay, mergedKeywords(intent));
+    if (intent.entity) {
+      score += entityVocabScore(hay, intent.entity);
+    }
+    return score;
+  }
+
+  // Find the best entity in a slot vocabulary (category/title/topic). Entities
+  // carry a flat `match` array; highest keyword score wins, ties break to the
+  // first declared. Returns null below threshold.
+  function matchEntity(hay, kind) {
+    var d = data();
+    if (!d || !d.entities || !d.entities[kind]) {
+      return null;
+    }
+    var list = d.entities[kind];
+    var best = null;
+    var bestScore = 0;
+    for (var i = 0; i < list.length; i++) {
+      var score = scoreKeywords(hay, list[i].match || []);
+      if (score > bestScore) {
+        bestScore = score;
+        best = list[i];
+      }
+    }
+    return bestScore > 0 ? best : null;
+  }
+
+  // Classify an input into { intent, entity, score }. Exposed for tests. A null
+  // intent means "fall back". Entity is resolved only for intents that declare
+  // a slot and only when the input actually names one.
+  function classify(raw) {
+    var d = data();
+    var hay = normalize(raw);
+    if (!d || !d.intents || !hay) {
+      return { intent: null, entity: null, score: 0 };
+    }
+    var best = null;
+    var bestScore = 0;
+    for (var i = 0; i < d.intents.length; i++) {
+      var score = scoreIntent(hay, d.intents[i]);
+      if (score > bestScore) {
+        bestScore = score;
+        best = d.intents[i];
+      }
+    }
+    if (!best || bestScore < 1) {
+      return { intent: null, entity: null, score: bestScore };
+    }
+    var entity = best.entity ? matchEntity(hay, best.entity) : null;
+    return { intent: best, entity: entity, score: bestScore };
+  }
+
+  function pickLang(obj, lg) {
+    if (!obj) {
+      return null;
+    }
+    return obj[lg] || obj.sv || obj.en || null;
+  }
+
+  function printLines(lines, className) {
+    var t = term();
+    if (!t || !lines) {
+      return;
+    }
+    for (var i = 0; i < lines.length; i++) {
+      t.print(lines[i], { className: className });
+    }
+  }
+
+  // Turn a classification into printed reply + optional handoff. An intent with
+  // a matched entity prefers the entity's reply (the specific answer) over the
+  // intent's generic one. A `flow` action releases the prompt first so the flow
+  // — not the assistant — owns the next inputs; the assistant is done.
+  function respond(raw) {
+    var lg = lang();
+    var result = classify(raw);
+
+    if (!result.intent) {
+      var d = data();
+      printLines(pickLang(d && d.fallback, lg), "terminal-session__out");
+      return;
+    }
+
+    var entity = result.entity;
+    var replyObj = entity && entity.reply ? entity.reply : result.intent.reply;
+    printLines(pickLang(replyObj, lg), "terminal-session__out");
+
+    var action = result.intent.action || null;
+    if (action && action.type === "flow") {
+      var t = term();
+      if (t) {
+        t.releaseInput();
+        active = false;
+        t.applyAction(action);
+      }
+    }
+  }
+
+  // Is this line the user asking to leave? Whole-line match against exitWords
+  // so "exit" leaves but "how do i exit the matrix" does not.
+  function isExit(raw) {
+    var d = data();
+    var words = (d && d.exitWords) || ["exit", "quit", "bye"];
+    var norm = normalize(raw);
+    for (var i = 0; i < words.length; i++) {
+      if (norm === normalize(words[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Reduced motion: honour both the site's own toggle and the OS preference.
+  // When set, the boot lines print at once instead of staggering.
+  function prefersReducedMotion() {
+    if (
+      document.documentElement.getAttribute("data-effect-reduced-motion") ===
+      "on"
+    ) {
+      return true;
+    }
+    try {
+      return (
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      );
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // Print the boot theatre, then the greeting. Staggered via setTimeout for the
+  // "loading" feel; instant under reduced motion. scrollToEnd keeps the newest
+  // line and the prompt in view as they appear.
+  function playBoot(onDone) {
+    var d = data();
+    var lg = lang();
+    var t = term();
+    var lines = pickLang(d && d.boot, lg) || [];
+    var greeting = pickLang(d && d.greeting, lg);
+
+    function finish() {
+      if (greeting) {
+        printLines([greeting], "terminal-session__out");
+      }
+      if (t && t.scrollToEnd) {
+        t.scrollToEnd();
+      }
+      if (onDone) {
+        onDone();
+      }
+    }
+
+    if (prefersReducedMotion() || typeof window.setTimeout !== "function") {
+      printLines(lines, "terminal-session__out");
+      finish();
+      return;
+    }
+
+    var i = 0;
+    (function step() {
+      if (i >= lines.length) {
+        finish();
+        return;
+      }
+      printLines([lines[i]], "terminal-session__out");
+      if (t && t.scrollToEnd) {
+        t.scrollToEnd();
+      }
+      i += 1;
+      window.setTimeout(step, 260);
+    })();
+  }
+
+  // Handle one submitted line while the assistant owns the prompt. Echo it in
+  // the "you>" flow style (the engine bypassed its own echo for delegates),
+  // then either leave or answer.
+  function handleLine(raw) {
+    if (!active) {
+      return;
+    }
+    var t = term();
+    var value = String(raw === null || raw === undefined ? "" : raw).trim();
+    if (t) {
+      t.print("you> " + value, { className: "terminal-session__flow" });
+    }
+    if (isExit(value)) {
+      stop();
+      return;
+    }
+    if (value) {
+      respond(value);
+    }
+    if (t && t.scrollToEnd) {
+      t.scrollToEnd();
+    }
+  }
+
+  // Enter the assistant: take the prompt, set the "you>" label, play the boot.
+  // Idempotent — a second `ai` while active does nothing. Inert if the seam or
+  // data hasn't loaded (progressive enhancement).
+  function start() {
+    var t = term();
+    var d = data();
+    if (!t || !d) {
+      if (t) {
+        t.print("ai: not available", { className: "terminal-session__out" });
+      }
+      return;
+    }
+    if (active) {
+      return;
+    }
+    active = true;
+    // onRelease fires whether the user typed 'exit' or left the terminal
+    // entirely (exitTerminal releases every delegate) — so state can't get
+    // stuck "active" after the prompt is handed back.
+    t.captureInput(handleLine, function () {
+      active = false;
+    });
+    t.setPrompt("you>");
+    playBoot();
+  }
+
+  // Leave the assistant: print the farewell and hand the prompt back to the
+  // shell. releaseInput() restores the PS1 and clears the delegate.
+  function stop() {
+    var t = term();
+    var d = data();
+    if (t) {
+      printLines(pickLang(d && d.farewell, lang()), "terminal-session__out");
+      t.releaseInput();
+      if (t.scrollToEnd) {
+        t.scrollToEnd();
+      }
+    }
+    active = false;
+  }
+
+  window.TerminalAI = {
+    start: start,
+    stop: stop,
+    handleLine: handleLine,
+    classify: classify,
+    normalize: normalize,
+    isActive: function () {
+      return active;
+    },
+  };
+
+  // Exposed for unit tests (jsdom `require`); harmless in the browser.
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = window.TerminalAI;
+  }
+})();

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -28,6 +28,11 @@
   // tells handleLine it is live.
   var active = false;
 
+  // The last answer's identity (intent + entity), so a verbatim repeat can be
+  // prefaced rather than echoed silently. repeatIndex rotates the prefaces.
+  var lastKey = null;
+  var repeatIndex = 0;
+
   function data() {
     return window.TerminalAIData || null;
   }
@@ -218,15 +223,34 @@
   // — not the assistant — owns the next inputs; the assistant is done.
   function respond(raw) {
     var lg = lang();
+    var d = data();
     var result = classify(raw);
 
     if (!result.intent) {
-      var d = data();
+      lastKey = null;
       printLines(pickLang(d && d.fallback, lg), "terminal-session__out");
       return;
     }
 
     var entity = result.entity;
+    // Key the repeat check on the exact answer (intent + entity), so asking
+    // "writing" then "writing about css" isn't mistaken for a repeat.
+    var key =
+      result.intent.id + (entity ? ":" + (entity.id || entity.slug || "") : "");
+    if (key === lastKey) {
+      var prefaces = pickLang(d && d.repeatPrefaces, lg) || [];
+      if (prefaces.length) {
+        printLines(
+          [prefaces[repeatIndex % prefaces.length]],
+          "terminal-session__out"
+        );
+        repeatIndex += 1;
+      }
+    } else {
+      repeatIndex = 0;
+    }
+    lastKey = key;
+
     var replyObj = entity && entity.reply ? entity.reply : result.intent.reply;
     printLines(pickLang(replyObj, lg), "terminal-session__out");
 
@@ -357,6 +381,8 @@
       return;
     }
     active = true;
+    lastKey = null;
+    repeatIndex = 0;
     // onRelease fires whether the user typed 'exit' or left the terminal
     // entirely (exitTerminal releases every delegate) — so state can't get
     // stuck "active" after the prompt is handed back.

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -363,7 +363,7 @@
     t.captureInput(handleLine, function () {
       active = false;
     });
-    t.setPrompt("you>");
+    t.setPrompt("you>", { hint: pickLang(d.promptHint, lang()) });
     playBoot();
   }
 

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -33,6 +33,124 @@
   var lastKey = null;
   var repeatIndex = 0;
 
+  // Report state: the last exchange (so `report` / the [report] chip can flag
+  // it), a short ring of recent turns for context, and a per-session set of
+  // already-auto-logged misses so an unmatched question is reported once, not
+  // on every repeat. Reports POST to a Netlify function that files GitHub issues.
+  var REPORT_ENDPOINT = "/.netlify/functions/clanker-report";
+  var lastExchange = null;
+  var exchangeLog = [];
+  var loggedMisses = {};
+
+  function captureExchange(query, reply, result, kind) {
+    lastExchange = {
+      query: query,
+      answer: (reply || []).join(" ").slice(0, 500),
+      intent: result && result.intent ? result.intent.id : null,
+      entity:
+        result && result.entity
+          ? result.entity.id || result.entity.slug || null
+          : null,
+      score: result ? result.score : 0,
+      kind: kind,
+      lang: lang(),
+    };
+    exchangeLog.push({ q: String(query).slice(0, 200), kind: kind });
+    if (exchangeLog.length > 12) {
+      exchangeLog.shift();
+    }
+  }
+
+  // Fire-and-forget POST — a report must never block the chat or throw at the
+  // visitor. In dev (no function running) it just fails silently.
+  function sendReport(payload) {
+    if (typeof window.fetch !== "function") {
+      return;
+    }
+    try {
+      window
+        .fetch(REPORT_ENDPOINT, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          keepalive: true,
+        })
+        .catch(function () {});
+    } catch (e) {
+      /* offline / blocked — nothing to do */
+    }
+  }
+
+  function reportBase() {
+    return {
+      bot_field: "",
+      context: exchangeLog.slice(),
+      page: (window.location && window.location.pathname) || "",
+      lang: lang(),
+    };
+  }
+
+  // Auto-log an unmatched question (a fallback) so the misses accrue without the
+  // visitor doing anything — deduped per session by normalized form.
+  function autoLogMiss(raw) {
+    var key = normalize(raw);
+    if (!key || loggedMisses[key]) {
+      return;
+    }
+    loggedMisses[key] = true;
+    var payload = reportBase();
+    payload.type = "miss";
+    payload.kind = "fallback";
+    payload.query = String(raw).slice(0, 200);
+    sendReport(payload);
+  }
+
+  // Explicit report of the last exchange (typed `report`, or the [report] chip).
+  function report(note) {
+    var t = term();
+    var d = data();
+    var lg = lang();
+    if (!lastExchange) {
+      printLines(
+        pickLang(d && d.reportEmpty, lg) || ["nothing to report yet."],
+        "terminal-session__out"
+      );
+      if (t && t.scrollToEnd) {
+        t.scrollToEnd();
+      }
+      return;
+    }
+    var payload = reportBase();
+    payload.type = "report";
+    payload.note = String(note || "").slice(0, 500);
+    payload.query = lastExchange.query;
+    payload.answer = lastExchange.answer;
+    payload.intent = lastExchange.intent;
+    payload.entity = lastExchange.entity;
+    payload.score = lastExchange.score;
+    payload.kind = lastExchange.kind;
+    sendReport(payload);
+    printLines(
+      pickLang(d && d.reportAck, lg) || ["reported — thanks."],
+      "terminal-session__out"
+    );
+    if (t && t.scrollToEnd) {
+      t.scrollToEnd();
+    }
+  }
+
+  // Print the subtle [report] chip after a reply, if the seam supports clickable
+  // chips (progressive: an older seam just omits it — `report` still works typed).
+  function printReportChip() {
+    var t = term();
+    var d = data();
+    if (t && typeof t.printChip === "function") {
+      t.printChip(pickLang(d && d.reportLabel, lang()) || "report", "report", {
+        className: "terminal-session__report",
+      });
+    }
+  }
+
   function data() {
     return window.TerminalAIData || null;
   }
@@ -282,14 +400,11 @@
     var amb = ambiguity(r);
     if (amb) {
       var tmpl = pickLang(d && d.clarifyPrompt, lg) || "{a} / {b}?";
-      printLines(
-        [
-          tmpl
-            .replace("{a}", pickLang(amb.a.clarify, lg))
-            .replace("{b}", pickLang(amb.b.clarify, lg)),
-        ],
-        "terminal-session__out"
-      );
+      var clarifyLine = tmpl
+        .replace("{a}", pickLang(amb.a.clarify, lg))
+        .replace("{b}", pickLang(amb.b.clarify, lg));
+      printLines([clarifyLine], "terminal-session__out");
+      captureExchange(raw, [clarifyLine], null, "clarify");
       lastKey = null;
       return;
     }
@@ -298,7 +413,11 @@
 
     if (!result.intent) {
       lastKey = null;
-      printLines(pickLang(d && d.fallback, lg), "terminal-session__out");
+      var fbLines = pickLang(d && d.fallback, lg);
+      printLines(fbLines, "terminal-session__out");
+      captureExchange(raw, fbLines, result, "fallback");
+      autoLogMiss(raw);
+      printReportChip();
       return;
     }
 
@@ -322,7 +441,10 @@
     lastKey = key;
 
     var replyObj = entity && entity.reply ? entity.reply : result.intent.reply;
-    printLines(pickLang(replyObj, lg), "terminal-session__out");
+    var replyLines = pickLang(replyObj, lg);
+    printLines(replyLines, "terminal-session__out");
+    captureExchange(raw, replyLines, result, "answer");
+    printReportChip();
 
     var action = result.intent.action || null;
     if (action && action.type === "flow") {
@@ -567,6 +689,7 @@
     handleLine: handleLine,
     classify: classify,
     normalize: normalize,
+    report: report,
     isActive: function () {
       return active;
     },

--- a/assets/js/theme-share.js
+++ b/assets/js/theme-share.js
@@ -153,4 +153,8 @@
       );
     });
   });
+
+  // Exposed so the terminal's `share` command can copy the same "share this
+  // look" URL the button builds (encodes the current theme as ?theme=).
+  window.ThemeShare = { buildUrl: buildUrl };
 })();

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -451,6 +451,14 @@ other = "(collapse)"
 [terminal_boot_ok]
 other = "[ ok ] palette · typography · layout loaded"
 
+[terminal_welcome]
+other = """
+Hi, Torbjörn here — a designer.
+For over a decade I've worked across editorial design, brand and digital product — sometimes closer to strategy, sometimes closer to the craft. Based in Gothenburg.
+
+You're in the terminal. Try `ls`, `cat`, or `help`.
+"""
+
 [terminal_exit_hint]
 other = "type exit or press esc to leave the terminal"
 

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -445,6 +445,14 @@ other = "(dölj)"
 [terminal_boot_ok]
 other = "[ ok ] palett · typografi · layout laddade"
 
+[terminal_welcome]
+other = """
+Hej, Torbjörn här — designer.
+Under drygt ett decennium har jag rört mig mellan redaktionell design, varumärken och digitala produkter — ibland närmare strategin, ibland närmare hantverket. Baserad i Göteborg.
+
+Du är i terminalen. Prova `ls`, `cat` eller `help`.
+"""
+
 [terminal_exit_hint]
 other = "skriv exit eller tryck esc för att lämna terminalen"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -206,6 +206,12 @@
       <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="cancel" aria-label="{{ i18n "terminal_key_cancel" }}">^C</button>
       <button class="terminal-keybar__key" type="button" tabindex="-1" data-keybar="bottom" aria-label="{{ i18n "terminal_key_bottom" }}">⌄</button>
     </div>
+    {{/* Terminal layout: a floating jump-to-prompt button. Unlike the mobile key
+         bar's ⌄ (which only rides the keyboard while the prompt is focused), this
+         appears on any device once the live prompt scrolls out of view — reading
+         a long cat output, you can drop straight back to the prompt. darkmode.js
+         toggles .is-visible via an IntersectionObserver on the prompt. */}}
+    <button class="terminal-jump" type="button" data-js="terminal-jump" aria-label="{{ i18n "terminal_key_bottom" }}">⌄</button>
   </div>
 </footer>
 <!-- Toast category labels (read by toast.js for title line) -->

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -164,6 +164,10 @@
       </ul>
     </div>
 
+    {{/* Terminal layout: the localized home intro (the hero, in prose) that the
+         boot transcript prints via `cat welcome.txt`. Hidden data source only —
+         darkmode.js reads its text; falls back to a hardcoded blurb if absent. */}}
+    <pre hidden data-js="terminal-welcome">{{ i18n "terminal_welcome" }}</pre>
     {{/* Terminal layout: the buffer ends with a live prompt. A real <input> so
          mobile keyboards open on tap and commands / easter eggs can be typed —
          see the command engine in darkmode.js. The session log above it holds

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -577,20 +577,25 @@
        URL so the terminal classifies ls/cd/tree and can fetch a dir without a
        hardcoded guess. Sections are directories, standalone top-level pages are
        files; a page overrides its kind via a `terminal_kind` param (contact =
-       action, the visual tools = exempt). The URL lets the terminal reach
+       action). The visual tools (terminal_kind = exempt) can't render as a
+       terminal, so they're left OUT of the filesystem entirely — not listed by
+       `ls`, not reachable by cd/open. The URL lets the terminal reach
        footer-only sections (legal) that aren't in the nav. */}}
   {{- $kinds := dict -}}
   {{- range site.Sections -}}
     {{- $k := "dir" -}}
     {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
-    {{- $kinds = merge $kinds (dict .Section (dict "kind" $k "url" .RelPermalink)) -}}
+    {{- if ne $k "exempt" -}}
+      {{- $kinds = merge $kinds (dict .Section (dict "kind" $k "url" .RelPermalink)) -}}
+    {{- end -}}
   {{- end -}}
   {{- range where site.RegularPages "Kind" "page" -}}
     {{- $rel := strings.Trim .RelPermalink "/" -}}
     {{- $rel = strings.TrimPrefix (printf "%s/" .Language.Lang) $rel -}}
     {{- $rel = strings.Trim $rel "/" -}}
     {{- $segs := split $rel "/" -}}
-    {{- if and (eq (len $segs) 1) (ne (.Params.terminal_kind | default "") "hidden") -}}
+    {{- $tk := .Params.terminal_kind | default "" -}}
+    {{- if and (eq (len $segs) 1) (ne $tk "hidden") (ne $tk "exempt") -}}
       {{- $k := "file" -}}
       {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
       {{- $kinds = merge $kinds (dict (index $segs 0) (dict "kind" $k "url" .RelPermalink)) -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -686,7 +686,7 @@
       // session). Set the sequence and the content-hiding gate pre-paint so the
       // server chrome/content the transcript reproduces is hidden with no flash.
       // Terminal + JS only: no-JS never runs this, so it keeps the plain page.
-      var terminalBoot = {{ $terminalBoot | jsonify }};
+      var terminalBoot = {{ $terminalBoot | jsonify | safeJS }};
       if (
         storedLayout === "terminal" &&
         terminalBoot &&

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -743,6 +743,8 @@
   {{ $js21 := resources.Get "js/ui-library-pantone-scales.js" }}
   {{ $js_lightbox := resources.Get "js/lightbox.js" }}
   {{ $js_terminal_nav := resources.Get "js/terminal-nav.js" }}
+  {{ $js_terminal_ai_data := resources.Get "js/terminal-ai-data.js" }}
+  {{ $js_terminal_ai := resources.Get "js/terminal-ai.js" }}
   {{/* NOTE: theme.js will be archived - logic moved to darkmode.js */}}
 
   <!-- JavaScript loading -->
@@ -790,9 +792,11 @@
     {{ end }}
     <script src="{{ $js_lightbox.RelPermalink }}" defer></script>
     <script src="{{ $js_terminal_nav.RelPermalink }}" defer></script>
+    <script src="{{ $js_terminal_ai_data.RelPermalink }}" defer></script>
+    <script src="{{ $js_terminal_ai.RelPermalink }}" defer></script>
   {{ else }}
     <!-- JavaScript production -->
-    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav }}
+    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js4 $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav $js_terminal_ai_data $js_terminal_ai }}
     {{ $js = $js | resources.Concat "js.js" | minify | fingerprint }}
     <script src="{{ $js.RelPermalink }}" defer></script>
     {{ $pageJs := slice }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -547,11 +547,24 @@
   {{- end -}}
   {{/* Boot transcript: the curated command sequence a page replays into the
        terminal on load, so the page reads as a real session (see the runner in
-       darkmode.js). Home only for now; other page types keep the styled layout.
-       Empty string ⇒ no transcript, page renders normally. */}}
+       darkmode.js). One per page type; empty string ⇒ no transcript, page
+       renders in the plain styled layout (contact's form, the exempt tools).
+        - home     → the intro tour
+        - section/tag listing → `ls` (its posts, read from the page's cards)
+        - a post / standalone page → `cat <slug>.md` (its own #main, read live) */}}
   {{- $terminalBoot := "" -}}
+  {{- $tkind := .Params.terminal_kind | default "" -}}
   {{- if .IsHome -}}
     {{- $terminalBoot = "ls; set; cat welcome.txt; ls works/ --featured" -}}
+  {{- else if or (eq $tkind "action") (eq $tkind "exempt") (eq $tkind "hidden") -}}
+    {{- $terminalBoot = "" -}}
+  {{- else if or .IsSection (eq .Kind "term") (eq .Kind "taxonomy") -}}
+    {{- $terminalBoot = "ls" -}}
+  {{- else if eq .Kind "page" -}}
+    {{- $slug := index (last 1 $terminalSegs) 0 -}}
+    {{- with $slug -}}
+      {{- $terminalBoot = printf "cat %s.md" . -}}
+    {{- end -}}
   {{- end -}}
   <style>
     :root {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -682,18 +682,21 @@
       }
 
       // Boot transcript: pages that declare a command sequence replay it into
-      // the terminal on load (darkmode.js runs it; the page reads as a real
-      // session). Set the sequence and the content-hiding gate pre-paint so the
-      // server chrome/content the transcript reproduces is hidden with no flash.
-      // Terminal + JS only: no-JS never runs this, so it keeps the plain page.
+      // the terminal (darkmode.js runs it; the page reads as a real session).
+      // Publish the sequence regardless of the current layout so toggling
+      // terminal on (no reload) can replay it too; only gate the content-hiding
+      // flag on already being in terminal, so a reload hides the reproduced
+      // chrome pre-paint (no flash). Terminal + JS only — no-JS keeps the plain
+      // page, and the flag is CSS-scoped to terminal so it's inert elsewhere.
       var terminalBoot = {{ $terminalBoot | jsonify | safeJS }};
       if (
-        storedLayout === "terminal" &&
         terminalBoot &&
         !document.documentElement.hasAttribute("data-terminal-exempt")
       ) {
         document.documentElement.setAttribute("data-terminal-boot", terminalBoot);
-        document.documentElement.setAttribute("data-terminal-transcript", "1");
+        if (storedLayout === "terminal") {
+          document.documentElement.setAttribute("data-terminal-transcript", "1");
+        }
       }
 
       // Image blend + grain effects up front too, so a shared look (or a returning

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -545,6 +545,14 @@
       {{- $terminalCwd = printf "~/%s" $terminalSeg -}}
     {{- end -}}
   {{- end -}}
+  {{/* Boot transcript: the curated command sequence a page replays into the
+       terminal on load, so the page reads as a real session (see the runner in
+       darkmode.js). Home only for now; other page types keep the styled layout.
+       Empty string ⇒ no transcript, page renders normally. */}}
+  {{- $terminalBoot := "" -}}
+  {{- if .IsHome -}}
+    {{- $terminalBoot = "ls; set; cat welcome.txt; ls works/ --featured" -}}
+  {{- end -}}
   <style>
     :root {
       --terminal-host: {{ printf "%q" $terminalHost | safeCSS }};
@@ -671,6 +679,21 @@
         }
       } catch (e) {
         /* sessionStorage unavailable — banner simply shows */
+      }
+
+      // Boot transcript: pages that declare a command sequence replay it into
+      // the terminal on load (darkmode.js runs it; the page reads as a real
+      // session). Set the sequence and the content-hiding gate pre-paint so the
+      // server chrome/content the transcript reproduces is hidden with no flash.
+      // Terminal + JS only: no-JS never runs this, so it keeps the plain page.
+      var terminalBoot = {{ $terminalBoot | jsonify }};
+      if (
+        storedLayout === "terminal" &&
+        terminalBoot &&
+        !document.documentElement.hasAttribute("data-terminal-exempt")
+      ) {
+        document.documentElement.setAttribute("data-terminal-boot", terminalBoot);
+        document.documentElement.setAttribute("data-terminal-transcript", "1");
       }
 
       // Image blend + grain effects up front too, so a shared look (or a returning

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 {{- /* Visual tool pages (component library, palette generator) can't collapse to text — they opt out of the terminal layout. The pre-hydration script and darkmode.js fall back to column here without touching the stored preference. */ -}}
 {{- $terminalExempt := or (eq .Type "ui-library") (eq .Type "palette-generator") -}}
-<html lang="{{ .Language.Lang }}" data-brand-ready="false"{{ if $terminalExempt }} data-terminal-exempt="true"{{ end }}{{ if .IsHome }} data-terminal-home="true"{{ end }}>
+<html lang="{{ .Language.Lang }}" data-brand-ready="false" data-home-url="{{ .Site.Home.RelPermalink }}"{{ if $terminalExempt }} data-terminal-exempt="true"{{ end }}{{ if .IsHome }} data-terminal-home="true"{{ end }}>
   {{ partial "head.html" . }}
 
 

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -71,7 +71,11 @@
           {{- end -}}
         {{- end -}}
 
-        {{/* Terminal layout: second executed command — settings print as its collapsed output. Hidden in every other layout. */}}
+        {{/* Terminal layout: second executed command — the settings panel prints
+          as its collapsed output. Shown as `set` (the real settings command,
+          re-runnable from the prompt), not a faux `ls settings/`. Hidden in
+          every other layout.
+        */}}
         <li
           class="top-menu__item top-menu__item--terminal-prompt"
           aria-hidden="true"
@@ -80,7 +84,7 @@
             <span class="terminal-prompt__user"></span
             ><span class="terminal-prompt__host-plain"></span
             ><span class="terminal-prompt__cwd"></span
-            ><span class="terminal-prompt__cmd">ls settings/</span>
+            ><span class="terminal-prompt__cmd">set</span>
           </span>
         </li>
 

--- a/netlify/functions/clanker-report.js
+++ b/netlify/functions/clanker-report.js
@@ -1,0 +1,181 @@
+/**
+ * clanker-report — turn a flagged assistant answer into a GitHub issue.
+ *
+ * The terminal `ai` assistant (terminal-ai.js) POSTs here when a visitor reports
+ * a bad reply (type "report") or when an unmatched question falls through to the
+ * fallback (type "miss", auto-logged and deduped per session client-side). Each
+ * becomes an actionable issue in the repo so the intent data can be improved:
+ *   - report → a `clanker-report` issue (a human said this answer was wrong)
+ *   - miss   → a `clanker-miss` issue, deduped by title; a repeat just adds a
+ *              👍 reaction to the existing one instead of opening a new issue.
+ *
+ * Setup (one-time, on Netlify): a fine-grained PAT with Issues: read/write on
+ * the repo, as env var GITHUB_ISSUE_TOKEN, plus GITHUB_REPO ("owner/name",
+ * defaults to tor2dbear/portfolio). Without the token the function no-ops 500.
+ *
+ * Abuse: it's a public endpoint that opens issues, so — a honeypot field, hard
+ * length caps, and the miss dedupe (repeat spam collapses onto one issue).
+ */
+const GITHUB_API = "https://api.github.com";
+
+function ok(body) {
+  return { statusCode: 200, body: JSON.stringify(body || { ok: true }) };
+}
+
+function ghHeaders(token) {
+  return {
+    Authorization: "Bearer " + token,
+    Accept: "application/vnd.github+json",
+    "User-Agent": "clanker-report",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "Content-Type": "application/json",
+  };
+}
+
+function clamp(value, max) {
+  return String(value === null || value === undefined ? "" : value)
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, max);
+}
+
+// Build the issue body — the query, the answer, the classification, and the
+// recent turns — as markdown so it's readable and actionable in the tracker.
+function issueBody(payload) {
+  var lines = [];
+  lines.push("**Query:** " + clamp(payload.query, 200));
+  if (payload.answer) {
+    lines.push("**Answer:** " + clamp(payload.answer, 500));
+  }
+  if (payload.note) {
+    lines.push("**Note:** " + clamp(payload.note, 500));
+  }
+  lines.push("");
+  lines.push("- kind: `" + clamp(payload.kind || "fallback", 20) + "`");
+  lines.push("- intent: `" + clamp(payload.intent || "—", 60) + "`");
+  if (payload.entity) {
+    lines.push("- entity: `" + clamp(payload.entity, 60) + "`");
+  }
+  lines.push("- score: `" + clamp(payload.score, 12) + "`");
+  lines.push("- lang: `" + clamp(payload.lang || "", 8) + "`");
+  lines.push("- page: `" + clamp(payload.page || "", 120) + "`");
+  if (Array.isArray(payload.context) && payload.context.length) {
+    lines.push("");
+    lines.push("Recent turns:");
+    payload.context.slice(-12).forEach(function (turn) {
+      lines.push("- (" + clamp(turn.kind, 20) + ") " + clamp(turn.q, 200));
+    });
+  }
+  lines.push("");
+  lines.push("<sub>filed by clanker-report</sub>");
+  return lines.join("\n");
+}
+
+async function createIssue(repo, token, title, body, label) {
+  return fetch(GITHUB_API + "/repos/" + repo + "/issues", {
+    method: "POST",
+    headers: ghHeaders(token),
+    body: JSON.stringify({ title: title, body: body, labels: [label] }),
+  });
+}
+
+// Find an OPEN issue with this exact title under the miss label, so a recurring
+// unmatched question bumps one issue instead of spawning duplicates.
+async function findOpenMiss(repo, token, title) {
+  var q =
+    "repo:" +
+    repo +
+    " is:issue is:open label:clanker-miss in:title " +
+    JSON.stringify(title);
+  var res = await fetch(
+    GITHUB_API + "/search/issues?q=" + encodeURIComponent(q),
+    { headers: ghHeaders(token) }
+  );
+  if (!res.ok) {
+    return null;
+  }
+  var data = await res.json().catch(function () {
+    return null;
+  });
+  if (!data || !Array.isArray(data.items)) {
+    return null;
+  }
+  for (var i = 0; i < data.items.length; i++) {
+    if (data.items[i].title === title) {
+      return data.items[i].number;
+    }
+  }
+  return null;
+}
+
+async function addReaction(repo, token, number) {
+  return fetch(
+    GITHUB_API + "/repos/" + repo + "/issues/" + number + "/reactions",
+    {
+      method: "POST",
+      headers: ghHeaders(token),
+      body: JSON.stringify({ content: "+1" }),
+    }
+  );
+}
+
+exports.handler = async function (event) {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  var payload;
+  try {
+    payload = JSON.parse(event.body || "{}");
+  } catch (e) {
+    return ok();
+  }
+
+  // Honeypot — a bot that fills the hidden field is dropped silently.
+  if (payload.bot_field) {
+    return ok();
+  }
+
+  var query = clamp(payload.query, 200);
+  if (!query) {
+    return ok();
+  }
+
+  var token = process.env.GITHUB_ISSUE_TOKEN;
+  var repo = process.env.GITHUB_REPO || "tor2dbear/portfolio";
+  if (!token) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "not_configured" }),
+    };
+  }
+
+  var type = payload.type === "report" ? "report" : "miss";
+  var body = issueBody(payload);
+
+  try {
+    if (type === "report") {
+      await createIssue(
+        repo,
+        token,
+        'clanker: "' + query + '"',
+        body,
+        "clanker-report"
+      );
+      return ok();
+    }
+
+    // miss — dedupe by exact title.
+    var title = "clanker miss: " + query;
+    var existing = await findOpenMiss(repo, token, title);
+    if (existing) {
+      await addReaction(repo, token, existing);
+    } else {
+      await createIssue(repo, token, title, body, "clanker-miss");
+    }
+    return ok();
+  } catch (e) {
+    // Never surface a failure to the visitor — the chat must not break.
+    return ok({ ok: false });
+  }
+};


### PR DESCRIPTION
Typing `ai` in the terminal boots a small, self-aware assistant ("tbh")
that answers free-text questions about Torbjörn, the projects, the
writing, and the site in Swedish or English, and can hand off to the
existing contact/subscribe flows. It is deliberately honest that it is
not an LLM — matching is keyword/entity scoring over a translatable
data file, so answers stay in sync with the site and nothing ships a
model.

The assistant is its own module, hanging off a new minimal `window.Terminal`
seam published from darkmode.js — print/echo, applyAction, captureInput/
releaseInput, setPrompt, cwd. That single dependency keeps the engine out
of the terminal chrome (unit-tested against a mocked seam) and is the same
export surface a future terminal.js extraction would expose.

- assets/js/terminal-ai.js       engine: normalize, keyword/entity scoring,
                                 boot theatre (reduced-motion aware), chat loop
- assets/js/terminal-ai-data.js  data only: persona, ~30 intents + category/
                                 title/topic entity vocabularies, sv/en
- darkmode.js                    window.Terminal seam, input-delegate branch in
                                 the Enter/Escape handlers, `ai` command +
                                 ai-start action, help/completion entry
- head.html                      load the two files (dev + prod bundle)
- 14 new tests; full suite 583 green, eslint + prettier clean

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UgEDSrFXj4eQsiLJ1DrhVK