### PR TITLE
Test: verify Codex review + audit surfacing flow

### DIFF
--- a/docs/codex-flow-check.md
+++ b/docs/codex-flow-check.md
@@ -1,0 +1,11 @@
+# Codex flow check (temporary)
+
+Throwaway PR to verify the review/CI surfacing wired up in #245:
+
+- `quality` CI job posts the sticky comment with the `🔒 Dependency audit` line.
+- Codex reviews the PR on open; `codex-review-surface` pins a `🔎 Codex review`
+  comment if Codex has feedback.
+- Adding the `codex-review` label posts `@codex review` (tests the re-review
+  path, and whether a `CODEX_TRIGGER_TOKEN` PAT is needed).
+
+Close this PR without merging once verified — delete the branch.


### PR DESCRIPTION
Temporary PR to verify the review/CI surfacing wired up in #245:

- `quality` CI job posts the sticky comment with the `🔒 Dependency audit` line.
- Codex reviews the PR on open; `codex-review-surface` pins a `🔎 Codex review` comment if Codex has feedback.
- Adding the `codex-review` label posts `@codex review` (tests the re-review path, and whether a `CODEX_TRIGGER_TOKEN` PAT is needed).

Close without merging once verified — delete the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017m4YtBGGEhjWTftfWuxHnu)_