### PR TITLE
Teach clanker to switch language and answer more misses

### DIFF
--- a/assets/js/__tests__/terminal-ai.test.js
+++ b/assets/js/__tests__/terminal-ai.test.js
@@ -189,6 +189,53 @@ describe("classify", () => {
     const ai = loadAi();
     expect(ai.normalize("Vänner, Öländska!")).toBe("vanner olandska");
   });
+
+  test("routes switch-language requests to the switch intents", () => {
+    const ai = loadAi();
+    expect(ai.classify("switch to swedish").intent.id).toBe("switch-swedish");
+    expect(ai.classify("language swedish").intent.id).toBe("switch-swedish");
+    expect(ai.classify("kan du byta språk till svenska?").intent.id).toBe(
+      "switch-swedish"
+    );
+    expect(ai.classify("switch to english").intent.id).toBe("switch-english");
+    expect(ai.classify("kan vi ta det på engelska?").intent.id).toBe(
+      "switch-english"
+    );
+  });
+
+  test("a German request is handled honestly, not routed to switch", () => {
+    const ai = loadAi();
+    expect(ai.classify("okej. kan du säga nånting på tyska?").intent.id).toBe(
+      "german"
+    );
+    expect(ai.classify("switch to german").intent.id).toBe("german");
+  });
+
+  test("'do you speak X' still describes languages, not a switch", () => {
+    const ai = loadAi();
+    // The question about ability stays with the `languages` intent even though
+    // the switch intents own the bare language names.
+    expect(ai.classify("what languages do you speak?").intent.id).toBe(
+      "languages"
+    );
+    expect(ai.classify("do you speak german?").intent.id).toBe("languages");
+  });
+
+  test("time and date questions point at the date command", () => {
+    const ai = loadAi();
+    expect(ai.classify("what time is it?").intent.id).toBe("time");
+    expect(ai.classify("vad är klockan?").intent.id).toBe("time");
+    expect(ai.classify("what date is it?").intent.id).toBe("time");
+  });
+
+  test("'how is this page built' reaches the colophon", () => {
+    const ai = loadAi();
+    expect(ai.classify("how is this page build?").intent.id).toBe("colophon");
+    expect(ai.classify("how is this page built?").intent.id).toBe("colophon");
+    expect(ai.classify("hur är den här sidan byggd?").intent.id).toBe(
+      "colophon"
+    );
+  });
 });
 
 describe("start / handleLine loop", () => {
@@ -278,6 +325,37 @@ describe("start / handleLine loop", () => {
     expect(m.text()).toContain("visst");
     expect(m.text()).not.toContain("you> cd works");
     expect(m.t.releaseInput).not.toHaveBeenCalled();
+    expect(ai.isActive()).toBe(true);
+  });
+
+  test("a switch-to-swedish request runs `lang sv` and stays put", () => {
+    setLang("en");
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("switch to swedish");
+
+    // The reply is printed, then the real command runs — the page load that
+    // follows ends the session, so the assistant does not release input here.
+    expect(m.text()).toContain("switching to Swedish");
+    expect(m.t.run).toHaveBeenCalledWith("lang sv");
+    expect(m.t.releaseInput).not.toHaveBeenCalled();
+    expect(ai.isActive()).toBe(true);
+  });
+
+  test("a German request replies honestly and runs no command", () => {
+    const ai = loadAi();
+    const m = mockTerminal();
+    window.Terminal = m.t;
+    ai.start();
+
+    m.feed("kan du säga nånting på tyska?");
+
+    expect(m.text().toLowerCase()).toContain("tyskan");
+    expect(m.t.run).not.toHaveBeenCalled();
+    expect(m.t.applyAction).not.toHaveBeenCalled();
     expect(ai.isActive()).toBe(true);
   });
 

--- a/assets/js/terminal-ai-data.js
+++ b/assets/js/terminal-ai-data.js
@@ -925,6 +925,11 @@
         keywords: {
           sv: [
             "hur ar sajten byggd",
+            "hur ar sidan byggd",
+            "hur ar den har sidan byggd",
+            "hur ar den byggd",
+            "hur byggdes sidan",
+            "hur ar det byggt",
             "vilken teknik",
             "hugo",
             "hur byggde du",
@@ -933,6 +938,13 @@
           ],
           en: [
             "how is the site built",
+            "how is this page built",
+            "how is this page build",
+            "how is this page made",
+            "how is this built",
+            "how is this made",
+            "how did you make this",
+            "how was this made",
             "what tech",
             "hugo",
             "how did you build",
@@ -1003,6 +1015,152 @@
         reply: {
           sv: ["Svenska och engelska flytande, tyska på mellannivå."],
           en: ["Swedish and English fluently, German at a moderate level."],
+        },
+      },
+      {
+        // Switch the *site* to Swedish. Runs the real `lang sv` command (see the
+        // `command` action in terminal-ai.js), which loads the translated page.
+        // Distinct from `languages` (which describes the languages he speaks):
+        // the phrasing here is a request to change, not a question.
+        id: "switch-swedish",
+        action: { type: "command", command: "lang sv" },
+        keywords: {
+          sv: [
+            "byt till svenska",
+            "byta till svenska",
+            "byt sprak till svenska",
+            "byt sprak svenska",
+            "pa svenska",
+            "prata svenska",
+            "skriv pa svenska",
+            "svenska tack",
+            "kan vi ta det pa svenska",
+            "svenska",
+          ],
+          en: [
+            "switch to swedish",
+            "change to swedish",
+            "in swedish",
+            "speak swedish",
+            "swedish please",
+            "language swedish",
+            "set language to swedish",
+            "swedish",
+          ],
+        },
+        reply: {
+          sv: ["Visst — byter till svenska. (kör 'lang sv' åt dig)"],
+          en: ["Sure — switching to Swedish. (running 'lang sv' for you)"],
+        },
+      },
+      {
+        // Switch the site to English. Mirror of switch-swedish.
+        id: "switch-english",
+        action: { type: "command", command: "lang en" },
+        keywords: {
+          sv: [
+            "byt till engelska",
+            "byta till engelska",
+            "byt sprak till engelska",
+            "byt sprak engelska",
+            "pa engelska",
+            "prata engelska",
+            "skriv pa engelska",
+            "engelska tack",
+            "kan vi ta det pa engelska",
+            "engelska",
+          ],
+          en: [
+            "switch to english",
+            "change to english",
+            "in english",
+            "speak english",
+            "english please",
+            "language english",
+            "set language to english",
+            "english",
+          ],
+        },
+        reply: {
+          sv: ["Visst — byter till engelska. (kör 'lang en' åt dig)"],
+          en: ["Sure — switching to English. (running 'lang en' for you)"],
+        },
+      },
+      {
+        // Asked to switch to (or speak) German. Honest: the site is only built
+        // in Swedish and English, so there's nothing to switch to — even though
+        // Torbjörn himself speaks some German (see the `languages` intent, which
+        // still owns "do you speak German?").
+        id: "german",
+        keywords: {
+          sv: [
+            "byt till tyska",
+            "pa tyska",
+            "prata tyska",
+            "sag nagot pa tyska",
+            "saga nagot pa tyska",
+            "nagot pa tyska",
+            "tyska",
+          ],
+          en: [
+            "switch to german",
+            "in german",
+            "speak german",
+            "say something in german",
+            "something in german",
+            "auf deutsch",
+            "deutsch",
+            "german",
+          ],
+        },
+        reply: {
+          sv: [
+            "Tyskan får du ta med Torbjörn själv — sajten finns bara på",
+            "svenska och engelska, så det finns inget att byta till. Skriv",
+            "'lang sv' eller 'lang en'.",
+          ],
+          en: [
+            "German you'll have to take up with Torbjörn himself — this site",
+            "only exists in Swedish and English, so there's nothing to switch",
+            "to. Type 'lang sv' or 'lang en'.",
+          ],
+        },
+      },
+      {
+        // A clanker has no clock — but the terminal does. Point at `date`
+        // rather than inventing a time (the shell's `date` prints both).
+        id: "time",
+        keywords: {
+          sv: [
+            "vad ar klockan",
+            "hur mycket ar klockan",
+            "vad ar det for tid",
+            "vad ar tiden",
+            "klockan",
+            "vilket datum ar det",
+            "vad ar det for datum",
+            "vilken dag ar det",
+          ],
+          en: [
+            "what time is it",
+            "whats the time",
+            "what is the time",
+            "current time",
+            "the time now",
+            "what date is it",
+            "todays date",
+            "what day is it",
+          ],
+        },
+        reply: {
+          sv: [
+            "Jag har ingen klocka i mig — men skriv 'date' så visar",
+            "terminalen tid och datum.",
+          ],
+          en: [
+            "I've no clock of my own — type 'date' for the terminal's",
+            "time and date.",
+          ],
         },
       },
       {

--- a/assets/js/terminal-ai.js
+++ b/assets/js/terminal-ai.js
@@ -458,6 +458,15 @@
         active = false;
         t.applyAction(action);
       }
+    } else if (action && action.type === "command" && action.command) {
+      // A data intent that maps to a real command ("switch to Swedish" →
+      // `lang sv`). Run it through the same seam a typed command uses, and
+      // stay in the assistant: a navigating command like `lang` ends the
+      // session via the page load, exactly as if the visitor had typed it.
+      var tc = term();
+      if (tc && typeof tc.run === "function") {
+        tc.run(action.command);
+      }
     }
   }
 


### PR DESCRIPTION
Address the clanker-miss / clanker-report issues logged from real terminal
sessions:

- Language switching (#251–256): add `switch-swedish` / `switch-english`
  intents that run the real `lang sv` / `lang en` command via a new
  `command` action type in the assistant engine, so "switch to swedish",
  "byt språk till svenska", "language swedish" etc. actually change the
  site language instead of falling back. A `german` intent answers honestly
  that the site only exists in Swedish and English, while the existing
  `languages` intent keeps owning "do you speak German?".
- Time/date (#250): a `time` intent points "what time is it?" at the
  shell's `date` command rather than falling back.
- Colophon (#232–233): widen keywords so "how is this page built/build?"
  reaches the colophon answer.

Covered by new classify() and start()/handleLine() tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VJocjAiNCbbPTfWCzCbDwq