### PR TITLE
Consolidate the terminal site-model into one full-tree manifest (Väg 3, step 1)

### DIFF
--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -37,6 +37,7 @@ describe("terminal command line", () => {
       require("../theme.js");
       require("../theme-pantone.js");
       require("../terminal-data.js");
+      require("../terminal-fs.js");
       require("../terminal.js");
       require("../terminal-flows.js");
     });
@@ -100,7 +101,7 @@ describe("terminal command line", () => {
 
     document.documentElement.innerHTML = `
       <head><meta name="theme-color" content="#ffffff">
-        <script type="application/json" data-js="terminal-manifest">{"works":{"kind":"dir","url":"/works/"},"writing":{"kind":"dir","url":"/writing/"},"about":{"kind":"file","url":"/about/"},"contact":{"kind":"action","url":"/contact/"},"legal":{"kind":"dir","url":"/legal/"},"ui-library":{"kind":"exempt","url":"/ui-library/"},"palette-generator":{"kind":"exempt","url":"/palette-generator/"}}</script>
+        <script type="application/json" data-js="terminal-manifest">{"works":{"kind":"dir","url":"/works/"},"works/a-cut-up-world":{"kind":"file","url":"/works/a-cut-up-world/"},"works/things-in-a-conversation":{"kind":"file","url":"/works/things-in-a-conversation/"},"writing":{"kind":"dir","url":"/writing/"},"writing/the-grid-inherited":{"kind":"file","url":"/writing/the-grid-inherited/"},"about":{"kind":"file","url":"/about/"},"contact":{"kind":"action","url":"/contact/"},"legal":{"kind":"dir","url":"/legal/"},"legal/license":{"kind":"file","url":"/legal/license/"},"ui-library":{"kind":"exempt","url":"/ui-library/"},"palette-generator":{"kind":"exempt","url":"/palette-generator/"}}</script>
       </head>
       <body>
         <div class="terminal-boot">
@@ -375,57 +376,26 @@ describe("terminal command line", () => {
     );
   });
 
-  test("Tab completes files in a cd'd-into directory once ls has cached them", async () => {
-    // Live cwd sits in a tag dir the page never loaded (page cwd is ~), so a
-    // bare `ls` remote-fetches it.
-    window.getComputedStyle = () => ({
-      getPropertyValue: (prop) =>
-        prop === "--terminal-live-cwd"
-          ? "~/works/tags/experimental"
-          : prop === "--terminal-cwd"
-          ? "~"
-          : "#ffffff",
-    });
-    window.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          '<div class="summary-card"><a href="/works/things-in-a-conversation/">x</a></div>' +
-            '<div class="summary-card"><a href="/works/a-cut-up-world/">y</a></div>'
-        ),
-    });
-    loadModule();
-    typeCommand("ls"); // remote-ls fetches the tag dir and caches its files
-    await flush();
-    const input = document.querySelector('[data-js="terminal-input"]');
-    // Before, Tab had nothing here; now the cached filename completes.
-    input.value = "cat thin";
-    keydown({ key: "Tab" });
-    expect(input.value).toBe("cat things-in-a-conversation.md");
-  });
-
-  test("Tab completes a post in an unvisited directory once the page index warms", async () => {
-    // From the home page ~/works's projects were never listed, so completion
-    // has nothing for them — until the prompt is focused and the site's page
-    // index (index.json) warms the ls cache.
-    window.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          items: [
-            { url: "https://tor-bjorn.com/works/things-in-a-conversation/" },
-            { url: "https://tor-bjorn.com/works/a-cut-up-world/" },
-          ],
-        }),
-    });
+  test("Tab completes a post in any section synchronously — no fetch, no cache", () => {
+    // The full-tree manifest knows every post the instant the page loads, so a
+    // qualified path completes with no `ls`, no focus, no index.json prefetch.
+    window.fetch = jest.fn();
     loadModule();
     const input = document.querySelector('[data-js="terminal-input"]');
-    input.dispatchEvent(new window.Event("focus")); // warms the cache
-    await flush();
-    expect(window.fetch.mock.calls[0][0]).toContain("/index.json");
     input.value = "cat ~/works/thin";
     keydown({ key: "Tab" });
     expect(input.value).toBe("cat ~/works/things-in-a-conversation.md");
+    expect(window.fetch).not.toHaveBeenCalled();
+  });
+
+  test("Tab completes a post as a bare name for cd (a file is .md only for cat)", () => {
+    // Kind-aware completion: cat/open complete a file as `name.md`; cd/ls
+    // complete it bare (you cat a file, you cd a dir).
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "cd ~/works/thin";
+    keydown({ key: "Tab" });
+    expect(input.value).toBe("cd ~/works/things-in-a-conversation");
   });
 
   test("cat prints a known pseudo-file and 404s unknown ones", () => {
@@ -642,9 +612,11 @@ describe("terminal command line", () => {
     expect(sessionText()).not.toContain("the-grid-inherited/");
   });
 
-  test("ls of another section hints at cd instead of printing nothing", () => {
+  test("ls of another section lists its posts from the manifest, from anywhere", () => {
     loadModule();
-    // Sitting on /works/, ask for a different section's contents.
+    // Sitting on /works/, ask for a different section's contents. The manifest
+    // knows the whole tree, so a remote section lists its posts directly instead
+    // of the old "(cd writing to list it)" hint that a DOM-only model needed.
     window.getComputedStyle = jest.fn(() => ({
       getPropertyValue: jest.fn((prop) =>
         prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
@@ -653,7 +625,7 @@ describe("terminal command line", () => {
       ),
     }));
     typeCommand("ls ~/writing");
-    expect(sessionText()).toContain("cd writing");
+    expect(sessionText()).toContain("the-grid-inherited.md");
   });
 
   test("ls lists several paths with per-directory headers", () => {
@@ -1286,10 +1258,11 @@ describe("terminal command line", () => {
     );
   });
 
-  test("append-only ls renders the fetched section's posts as clickable files", async () => {
+  test("ls in a cd'd-into section lists it synchronously from the manifest — no fetch", () => {
     // After `cd writing` (append-only: the live cwd moves, the loaded page
-    // doesn't), a bare `ls` can't read the DOM — it fetches /writing/ and lists
-    // it below. Those posts must be clickable too, just like a local `ls`.
+    // doesn't), a bare `ls` no longer needs to fetch the section — the full-tree
+    // manifest already knows its posts, so it lists them as clickable files at
+    // once, without a round-trip.
     loadModule();
     // Page cwd is home (~); the live cwd has moved into ~/writing.
     window.getComputedStyle = jest.fn(() => ({
@@ -1303,27 +1276,16 @@ describe("terminal command line", () => {
     }));
     window.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      text: () =>
-        Promise.resolve(
-          '<div class="summary-card"><a href="/writing/the-grid-inherited/">The grid</a></div>' +
-            '<div class="summary-card"><a href="/writing/another-post/">Another</a></div>'
-        ),
+      text: () => Promise.resolve(""),
     });
     typeCommand("ls");
-    // The remote-ls handler is async (fetch → parse → print); flush its chain.
-    for (let i = 0; i < 6; i++) {
-      await Promise.resolve();
-    }
 
     const post = document.querySelector(
       '.terminal-session__ls-entry[data-cmd="cat the-grid-inherited.md"]'
     );
     expect(post).not.toBeNull();
-    expect(
-      document.querySelector(
-        '.terminal-session__ls-entry[data-cmd="cat another-post.md"]'
-      )
-    ).not.toBeNull();
+    // The listing came from the manifest, not a fetch.
+    expect(window.fetch).not.toHaveBeenCalled();
 
     const before = sessionText();
     post.dispatchEvent(new window.Event("click", { bubbles: true }));
@@ -1331,6 +1293,40 @@ describe("terminal command line", () => {
     expect(sessionText().slice(before.length)).toContain(
       "cat the-grid-inherited.md"
     );
+  });
+
+  test("ls in a tag term dir the manifest doesn't enumerate falls back to remote-ls", async () => {
+    // Tag term dirs (works/tags/<term>) aren't in the flat manifest — their
+    // posts are symlinks whose canonical file lives up in the section. Listing
+    // one you've cd'd into but not loaded still fetches the term page and prints
+    // its posts as clickable symlinks (the retained defensive fallback).
+    loadModule();
+    window.getComputedStyle = jest.fn(() => ({
+      getPropertyValue: jest.fn((prop) =>
+        prop === "--terminal-live-cwd"
+          ? "~/works/tags/experimental"
+          : prop === "--terminal-cwd"
+          ? "~"
+          : "#ffffff"
+      ),
+    }));
+    window.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<div class="summary-card"><a href="/works/things-in-a-conversation/">x</a></div>'
+        ),
+    });
+    typeCommand("ls");
+    // The remote-ls handler is async (fetch → parse → print); flush its chain.
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve();
+    }
+    expect(window.fetch).toHaveBeenCalled();
+    const post = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cat things-in-a-conversation.md"]'
+    );
+    expect(post).not.toBeNull();
   });
 
   test("clicking a directory entry in transcript mode opens it (cd then ls)", () => {

--- a/assets/js/terminal-fs.js
+++ b/assets/js/terminal-fs.js
@@ -1,0 +1,141 @@
+/**
+ * terminal-fs.js — the terminal's filesystem model (window.TerminalFS).
+ *
+ * One authoritative source for "what the site contains": the full-tree manifest
+ * Hugo emits into <script data-js="terminal-manifest"> (see
+ * layouts/partials/terminal-manifest.html). Every reachable node — sections,
+ * every post, standalone pages, a section's tags/ dir — is keyed by its LOGICAL
+ * path (`works`, `works/a-cut-up-world`, `legal/license`), independent of the
+ * real URL slug (works posts live at /englishwork/…, but the terminal dir is
+ * `works/`). The manifest carries the real `url` for fetching; the logical key
+ * is what `ls`/`cd`/`tree`/completion walk.
+ *
+ * This module reads that blob lazily (cached on first use, like the old
+ * terminalManifest()) and exposes a small, pure API the engine reroutes onto.
+ * It replaces the terminal's former scattered model — the top-level-only
+ * manifest, the nav-link-harvested dir tree, the per-cwd ls cache, the
+ * index.json prefetch/seed, and the live-DOM card scrape — all of which were
+ * incrementally rebuilding this same thing at runtime.
+ *
+ * Same data-module pattern as terminal-data.js: an IIFE that publishes a single
+ * window global. Load BEFORE terminal.js, which aliases it at init.
+ */
+(function () {
+  "use strict";
+
+  var manifestCache = null;
+  var treeCache = null;
+
+  // Decode a single path segment the way terminal.js reads hrefs: percent-escapes
+  // resolved (a localized slug g%c3%b6teborgsaffisch → göteborgsaffisch) and
+  // lowercased, so a manifest key matches a typed/derived path exactly.
+  function decodeSeg(seg) {
+    try {
+      return decodeURIComponent(String(seg)).toLowerCase();
+    } catch (e) {
+      return String(seg).toLowerCase(); // malformed escape — keep the raw segment
+    }
+  }
+
+  function normalizeKey(key) {
+    return String(key).split("/").filter(Boolean).map(decodeSeg).join("/");
+  }
+
+  // The raw manifest map, keyed by normalized logical path → {kind, url, title,
+  // tags}. Cached; a malformed/absent blob yields {} (the engine then defaults
+  // unknown nodes to `dir`, exactly as before).
+  function manifest() {
+    if (manifestCache) {
+      return manifestCache;
+    }
+    manifestCache = {};
+    var el = document.querySelector('[data-js="terminal-manifest"]');
+    if (el && el.textContent) {
+      try {
+        var raw = JSON.parse(el.textContent) || {};
+        Object.keys(raw).forEach(function (key) {
+          var norm = normalizeKey(key);
+          if (norm) {
+            manifestCache[norm] = raw[key];
+          }
+        });
+      } catch (e) {
+        /* malformed manifest — fall back to the empty default */
+      }
+    }
+    return manifestCache;
+  }
+
+  function makeNode(name) {
+    return {
+      name: name,
+      kind: "dir",
+      url: null,
+      href: null,
+      title: null,
+      tags: null,
+      children: {},
+    };
+  }
+
+  // The nested tree, built once from the flat manifest by splitting each key on
+  // "/". Intermediate segments that are themselves keys (e.g. `works` under
+  // `works/tags`) get their data when their own key is processed; order doesn't
+  // matter because nodes are create-then-assign.
+  function tree() {
+    if (treeCache) {
+      return treeCache;
+    }
+    var root = makeNode("~");
+    var m = manifest();
+    Object.keys(m).forEach(function (key) {
+      var entry = m[key] || {};
+      var segs = key.split("/").filter(Boolean);
+      if (!segs.length) {
+        return;
+      }
+      var node = root;
+      segs.forEach(function (seg) {
+        if (!node.children[seg]) {
+          node.children[seg] = makeNode(seg);
+        }
+        node = node.children[seg];
+      });
+      node.kind = entry.kind || node.kind || "dir";
+      node.url = entry.url || node.url || null;
+      node.href = node.url; // alias: terminal.js reads node.href for "(cd to list)"
+      node.title = entry.title || node.title || null;
+      node.tags = entry.tags || node.tags || null;
+    });
+    treeCache = root;
+    return root;
+  }
+
+  // Walk the tree to the node at the given (already-normalized) segments, or null.
+  function node(segments) {
+    var n = tree();
+    var segs = segments || [];
+    for (var i = 0; i < segs.length; i++) {
+      n = n.children[segs[i]];
+      if (!n) {
+        return null;
+      }
+    }
+    return n;
+  }
+
+  // Drop the caches so a re-read picks up a fresh manifest — used after an
+  // in-place page swap replaces the manifest blob (Step 2+ of the plan; a no-op
+  // seam today).
+  function refresh() {
+    manifestCache = null;
+    treeCache = null;
+  }
+
+  window.TerminalFS = {
+    manifest: manifest,
+    tree: tree,
+    node: node,
+    refresh: refresh,
+  };
+})();

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -340,73 +340,12 @@
     var terminalHistory = [];
     var TERMINAL_HISTORY_MAX = 100;
 
-    // Entry labels a remote `ls` fetched, keyed by cwd segments ("works/tags").
-    // An append-only `cd` moves the prompt without loading the directory, so Tab
-    // completion (synchronous, reads only the loaded page + the static tree) has
-    // nothing to offer there. Once you `ls` such a directory we cache what it
-    // held, so completing within it works — matching how you'd naturally `ls`
-    // first, then Tab.
-    var terminalLsDirCache = {};
-
-    // Prefetch the site's JSON feed (index.json — every published page in the
-    // main sections, with its URL) once, and fold each page into the ls cache
-    // under its parent directory. A real shell can complete a path you've never
-    // `cd`'d into because the filesystem is local; this gives the terminal the
-    // same reach, so `cat ~/works/thi⇥` completes from any page, not just from
-    // inside ~/works. Best-effort and purely additive: a real `ls` still
-    // overwrites the cache (fresh wins), and a missing/failed feed just leaves
-    // completion as lazy as it was before.
-    var terminalContentIndexSeeded = false;
-    function terminalSeedContentIndex() {
-      if (terminalContentIndexSeeded || typeof window.fetch !== "function") {
-        return;
-      }
-      terminalContentIndexSeeded = true;
-      var url = terminalHomeUrl().replace(/\/+$/, "") + "/index.json";
-      var pending;
-      try {
-        pending = window.fetch(url, { credentials: "same-origin" });
-      } catch (e) {
-        return; // fetch threw synchronously — leave completion lazy
-      }
-      if (!pending || typeof pending.then !== "function") {
-        return; // not a real fetch (e.g. a bare stub) — nothing to await
-      }
-      pending
-        .then(function (res) {
-          return res.ok ? res.json() : Promise.reject();
-        })
-        .then(function (feed) {
-          ((feed && feed.items) || []).forEach(function (item) {
-            var href = String(item && item.url ? item.url : "").replace(
-              /^[a-z]+:\/\/[^/]+/i,
-              ""
-            );
-            var segs = terminalHrefSegments(href);
-            // A top-level page (segs.length < 2) is already in the tree/manifest
-            // — only the nested posts need seeding.
-            if (!segs || segs.length < 2) {
-              return;
-            }
-            var dirKey = segs.slice(0, -1).join("/");
-            var file = segs[segs.length - 1] + ".md";
-            var list =
-              terminalLsDirCache[dirKey] || (terminalLsDirCache[dirKey] = []);
-            var exists = list.some(function (label) {
-              return label.replace(/[/@*]+$/, "").toLowerCase() === file;
-            });
-            if (!exists) {
-              list.push(file);
-            }
-          });
-          // A ghost the user is already looking at should pick up the newly
-          // known posts without waiting for the next keystroke.
-          terminalUpdateGhost();
-        })
-        .catch(function () {
-          /* no feed / offline — completion stays lazy, exactly as before */
-        });
-    }
+    // The site model — what `ls`/`cd`/`tree`/completion treat as the filesystem
+    // — lives in terminal-fs.js (window.TerminalFS): one full-tree manifest,
+    // read synchronously. It replaced the old scattered model (a top-level-only
+    // manifest, a per-cwd ls cache, and an index.json prefetch that folded posts
+    // into it). Completion now knows every post the instant the page loads, with
+    // no fetch to await, so the former warm-the-cache seed is gone.
 
     // Literal tables — help text, Tab-completion vocabulary, cat-able
     // pseudo-files, fortunes, the easter-egg index, the konami sequence and
@@ -623,28 +562,28 @@
       });
     }
 
-    // A small nested directory tree built from every nav + footer link path,
-    // so `ls`, `tree`, `cd` and Tab completion share one data-driven model of
-    // the "filesystem". Cached like terminalNavTargets — the links are static.
+    // The nested directory tree `ls`, `tree`, `cd` and Tab completion walk.
+    // The authoritative structure — sections, every post, standalone pages —
+    // comes from the full-tree manifest via window.TerminalFS (one synchronous
+    // source, no per-page scraping). Then the nav/footer links are harvested for
+    // the one thing the flat manifest doesn't enumerate: a section's `tags/`
+    // taxonomy dir (works has real tag term pages; the term contents are listed
+    // on demand by remote-ls). Cached — both the manifest and the links are
+    // static for the page's lifetime.
     var terminalDirTreeCache = null;
     function terminalDirTree() {
       if (terminalDirTreeCache) {
         return terminalDirTreeCache;
       }
-      var root = { name: "~", href: terminalHomeUrl(), children: {} };
-      // Seed the top level from the manifest — the authoritative list of what's
-      // in ~ (including footer-only sections like legal that carry no nav link,
-      // and without the noise of harvesting every footer href e.g. index.xml).
-      var manifest = terminalManifest();
-      Object.keys(manifest).forEach(function (seg) {
-        root.children[seg] = {
-          name: seg,
-          href: manifest[seg].url || null,
-          children: {},
-        };
-      });
-      // Then harvest the (relative) nav links for deeper structure — a section's
-      // tags/ and the like.
+      var root = (window.TerminalFS && window.TerminalFS.tree()) || {
+        name: "~",
+        href: terminalHomeUrl(),
+        kind: "dir",
+        children: {},
+      };
+      // Graft the (relative) nav/footer links for a section's tags/ hierarchy —
+      // idempotent: sections and posts are already in the manifest tree, so this
+      // only adds the taxonomy dirs the manifest leaves out.
       var links = document.querySelectorAll(
         ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href]"
       );
@@ -656,7 +595,12 @@
         var node = root;
         segs.forEach(function (seg) {
           if (!node.children[seg]) {
-            node.children[seg] = { name: seg, href: null, children: {} };
+            node.children[seg] = {
+              name: seg,
+              href: null,
+              kind: "dir",
+              children: {},
+            };
           }
           node = node.children[seg];
         });
@@ -736,67 +680,25 @@
       return node;
     }
 
-    // Slugs of the current page's own content links (article / summary cards)
-    // that live under the given section — so `ls` inside e.g. ~/writing lists
-    // the actual posts, which the nav tree can't know about.
-    function terminalPageContentSlugs(sectionSegments) {
-      if (!sectionSegments.length) {
-        return [];
-      }
-      var section = sectionSegments[0];
-      var out = [];
-      var seen = {};
-      document
-        .querySelectorAll(".article-card a[href], .summary-card a[href]")
-        .forEach(function (link) {
-          var segs = terminalHrefSegments(link.getAttribute("href"));
-          if (!segs || segs.length < 2 || segs[0] !== section) {
-            return;
-          }
-          var slug = segs[segs.length - 1];
-          if (seen[slug]) {
-            return;
-          }
-          seen[slug] = true;
-          out.push(slug);
-        });
-      return out;
-    }
-
-    // List a single directory. Structural children come from the nav/footer
-    // tree; for the current directory, the page's own content links are merged
-    // in. Unknown path → an ls-style error; a real page whose contents can't
-    // be listed from here (a different section) → a `cd` hint rather than a
-    // bare empty result.
     // The terminal presents the site as a filesystem, and Hugo tells it what
-    // each top-level thing IS via the manifest emitted in head.html: a section
-    // is a `dir`, a standalone page a `file`, the contact form an `action`, a
-    // visual tool `exempt`. Parsed once; the client no longer guesses.
-    var terminalManifestCache = null;
+    // each thing IS via the full-tree manifest emitted in head.html: a section
+    // is a `dir`, a post/standalone page a `file`, the contact form an `action`,
+    // a visual tool `exempt`. window.TerminalFS parses it once (keys normalized
+    // to decoded, lowercased logical paths); this is the flat map, for the
+    // callers that look a node up by name (cd/cat classification, slug stamping).
     function terminalManifest() {
-      if (terminalManifestCache) {
-        return terminalManifestCache;
-      }
-      terminalManifestCache = {};
-      var el = document.querySelector('[data-js="terminal-manifest"]');
-      if (el && el.textContent) {
-        try {
-          terminalManifestCache = JSON.parse(el.textContent) || {};
-        } catch (e) {
-          /* malformed manifest — fall back to the dir default below */
-        }
-      }
-      return terminalManifestCache;
+      return (window.TerminalFS && window.TerminalFS.manifest()) || {};
     }
 
-    // A top-level segment's kind. Deeper structural nodes (e.g. a section's
-    // `tags/`) aren't in the manifest and default to `dir` — they list children.
+    // A node's kind by its logical path (`works` or `works/a-cut-up-world`).
+    // A path not in the manifest (e.g. a nav-grafted `tags/` dir) defaults to
+    // `dir` — it lists children.
     function terminalNodeKind(name) {
       var e = terminalManifest()[String(name || "").toLowerCase()];
       return (e && e.kind) || "dir";
     }
 
-    // A top-level segment's URL from the manifest — lets the terminal reach a
+    // A logical path's URL from the manifest — lets the terminal reach a
     // footer-only section (legal) that has no nav link to resolve against.
     function terminalManifestUrl(name) {
       var e = terminalManifest()[String(name || "").toLowerCase()];
@@ -805,8 +707,19 @@
 
     // How an entry renders in a listing: dir → `name/`, file → `name.md`,
     // action → `name` (a command), exempt → `name*` (a tool you `open`).
-    function terminalEntryLabel(name) {
-      switch (terminalNodeKind(name)) {
+    // Takes a tree node (kind carried per node, so nested posts label as files)
+    // or a bare top-level name (kind looked up in the manifest).
+    function terminalEntryLabel(nameOrNode) {
+      var name;
+      var kind;
+      if (nameOrNode && typeof nameOrNode === "object") {
+        name = nameOrNode.name;
+        kind = nameOrNode.kind || "dir";
+      } else {
+        name = nameOrNode;
+        kind = terminalNodeKind(name);
+      }
+      switch (kind) {
         case "file":
           return name + ".md";
         case "action":
@@ -1191,27 +1104,16 @@
 
     // A directory's entry labels, kind-formatted (dir → `name/`, file →
     // `name.md`, action → `name`, exempt → `name*`). Shared by the text `ls`
-    // and the clickable `ls` so the two can never list different things.
-    function terminalLsEntryLabels(node, targetSegs, isCwd, showHidden) {
+    // and the clickable `ls` so the two can never list different things. The
+    // children — sections, and each section's posts as files — come straight
+    // from the manifest tree, so a section lists its posts whether or not the
+    // page they live on is the one loaded.
+    function terminalLsEntryLabels(node, showHidden) {
       var entries = Object.keys(node.children)
         .sort()
         .map(function (k) {
-          return terminalEntryLabel(node.children[k].name);
+          return terminalEntryLabel(node.children[k]);
         });
-      if (isCwd) {
-        // The page's own content (posts) are FILES: a post is a .md you `cat`,
-        // not a directory you `cd` into — so it reads like real `ls` and the
-        // prompt stays in the section when you open one.
-        terminalPageContentSlugs(targetSegs).forEach(function (slug) {
-          var entry = slug + ".md";
-          if (
-            entries.indexOf(entry) === -1 &&
-            entries.indexOf(slug + "/") === -1
-          ) {
-            entries.push(entry);
-          }
-        });
-      }
       if (showHidden) {
         entries = [".secret", ".config"].concat(entries);
       }
@@ -1276,7 +1178,7 @@
         ];
       }
       var isCwd = targetSegs.join("/") === terminalCwdSegments().join("/");
-      var entries = terminalLsEntryLabels(node, targetSegs, isCwd, showHidden);
+      var entries = terminalLsEntryLabels(node, showHidden);
       if (!entries.length) {
         // A real page (has an href) that we're not currently on: its contents
         // live on that page, so point there instead of printing nothing.
@@ -1326,14 +1228,19 @@
           out.push(
             keys
               .map(function (k) {
-                return n.children[k].name + "/";
+                return terminalEntryLabel(n.children[k]);
               })
               .join("  ")
           );
         }
         out.push("");
+        // Recurse into directories only (a section, or its tags/ dir — printed
+        // even when empty). A post is a file: it's a leaf, not its own header.
         keys.forEach(function (k) {
-          walk(n.children[k], p + "/" + n.children[k].name);
+          var child = n.children[k];
+          if ((child.kind || "dir") === "dir") {
+            walk(child, p + "/" + child.name);
+          }
         });
       }
       walk(node, path);
@@ -1354,7 +1261,7 @@
           lines.push(
             prefix +
               (last ? "└── " : "├── ") +
-              terminalEntryLabel(node.children[key].name)
+              terminalEntryLabel(node.children[key])
           );
           walk(node.children[key], prefix + (last ? "    " : "│   "));
         });
@@ -2212,16 +2119,19 @@
               action: null,
             };
           }
-          // Append-only: listing the section (or a nested tags dir) you've cd'd
-          // into but haven't loaded (cd only moved the prompt) — fetch it and
-          // print below, without touching anything above.
+          // Append-only fallback: listing a directory the manifest tree can't
+          // resolve — a tag term dir (its posts are symlinks listed on the term
+          // page) or a node absent from the manifest — that you've cd'd into but
+          // haven't loaded. Fetch it and print below, without touching anything
+          // above. A section or any other dir the manifest knows lists
+          // synchronously from the tree in the clickable branch, no fetch.
           if (!lsPaths.length && !lsLong.length) {
             var lsSegs = terminalCwdSegments();
-            // You've cd'd away from the loaded page (live cwd ≠ page cwd), so the
-            // current DOM can't list here → fetch that path and print it below.
+            var lsCwdNode = terminalNodeAt(lsSegs);
             if (
               lsSegs.length &&
-              lsSegs.join("/") !== terminalPageCwdSegments().join("/")
+              lsSegs.join("/") !== terminalPageCwdSegments().join("/") &&
+              (!lsCwdNode || !Object.keys(lsCwdNode.children).length)
             ) {
               var lsUrl = terminalCwdUrl(lsSegs);
               if (lsUrl) {
@@ -2254,12 +2164,7 @@
               var lsTokSegs = terminalResolveSegments(lsPaths[0] || "");
               var lsTokNode = terminalNodeAt(lsTokSegs);
               if (lsTokNode) {
-                var lsTokLabels = terminalLsEntryLabels(
-                  lsTokNode,
-                  lsTokSegs,
-                  lsTokSegs.join("/") === terminalCwdSegments().join("/"),
-                  false
-                );
+                var lsTokLabels = terminalLsEntryLabels(lsTokNode, false);
                 if (lsTokLabels.length) {
                   return {
                     echo: input,
@@ -3345,10 +3250,6 @@
               var doc = new DOMParser().parseFromString(html, "text/html");
               var files = terminalRemoteLsEntries(doc, action.cwd);
               if (files.length) {
-                // Remember what this directory held, so Tab completion works in
-                // it even though the `cd` never loaded its page.
-                terminalLsDirCache[terminalSegmentsOf(action.cwd).join("/")] =
-                  files;
                 // Clickable, like the local `ls` — each post cats itself, each
                 // tag dir cds into it.
                 printTerminalLsList(
@@ -4347,40 +4248,23 @@
             ? terminalCwdSegments()
             : terminalResolveSegments(dirPart);
         var node = terminalNodeAt(dirSegs);
-        var names = node
-          ? Object.keys(node.children).filter(function (name) {
-              return name.indexOf(filePart) === 0;
-            })
-          : [];
-        // cat/open reach the page's posts too — complete them as .md files.
-        if (verb === "cat" || verb === "open") {
-          terminalPageContentSlugs(dirSegs).forEach(function (slug) {
-            var file = slug + ".md";
-            if (file.indexOf(filePart) === 0 && names.indexOf(file) === -1) {
-              names.push(file);
+        // The manifest tree knows the whole directory synchronously — sections,
+        // and each section's posts as files — so completion reaches any post the
+        // instant the page loads, with no cache to warm. cat/open complete a post
+        // as `name.md` (you cat a file); cd/ls complete it bare.
+        var names = [];
+        if (node) {
+          Object.keys(node.children).forEach(function (name) {
+            var child = node.children[name];
+            var display =
+              (verb === "cat" || verb === "open") && child.kind === "file"
+                ? name + ".md"
+                : name;
+            if (display.toLowerCase().indexOf(filePart) === 0) {
+              names.push(display);
             }
           });
         }
-        // A directory you `cd`'d into but never loaded isn't in the tree or the
-        // live DOM — but if you `ls`'d it, its entries are cached. Offer dir
-        // names to cd, and (for cat/open) its files as .md, stripping the
-        // classify markers (`/`, `@`) so they complete like real names.
-        (terminalLsDirCache[dirSegs.join("/")] || []).forEach(function (label) {
-          if (/\/$/.test(label)) {
-            var dir = label.slice(0, -1).toLowerCase();
-            if (dir.indexOf(filePart) === 0 && names.indexOf(dir) === -1) {
-              names.push(dir);
-            }
-          } else if (
-            (verb === "cat" || verb === "open") &&
-            /\.md@?$/i.test(label)
-          ) {
-            var file = label.replace(/@$/, "").toLowerCase();
-            if (file.indexOf(filePart) === 0 && names.indexOf(file) === -1) {
-              names.push(file);
-            }
-          }
-        });
         candidates = names.map(function (name) {
           return dirPart + name;
         });
@@ -4394,9 +4278,6 @@
       if (!terminalInput) {
         return;
       }
-      // An explicit completion request is a hard signal to warm the page-index
-      // cache, in case the prompt was never focused first (e.g. a key-bar Tab).
-      terminalSeedContentIndex();
       var candidates = terminalCompletionFor(terminalInput.value).candidates;
       if (candidates.length === 1) {
         var parts = terminalInput.value.split(/\s+/);
@@ -4491,11 +4372,7 @@
       });
       // The inline suggestion is only meaningful while typing: refresh it on
       // focus, clear it on blur so it doesn't linger under the idle caret.
-      // Focusing the prompt is also the first sign the user is about to type,
-      // so warm the page-index cache now — the completion for an unvisited
-      // directory needs it, and it's a one-shot fetch.
       terminalInput.addEventListener("focus", function () {
-        terminalSeedContentIndex();
         terminalUpdateGhost();
       });
       terminalInput.addEventListener("blur", function () {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -792,6 +792,7 @@
   {{ $js21 := resources.Get "js/ui-library-pantone-scales.js" }}
   {{ $js_lightbox := resources.Get "js/lightbox.js" }}
   {{ $js_terminal_data := resources.Get "js/terminal-data.js" }}
+  {{ $js_terminal_fs := resources.Get "js/terminal-fs.js" }}
   {{ $js_terminal := resources.Get "js/terminal.js" }}
   {{ $js_terminal_flows := resources.Get "js/terminal-flows.js" }}
   {{ $js_terminal_nav := resources.Get "js/terminal-nav.js" }}
@@ -820,6 +821,7 @@
     <script src="{{ $js4.RelPermalink }}" defer></script>
     <script src="{{ $js_theme_pantone.RelPermalink }}" defer></script>
     <script src="{{ $js_terminal_data.RelPermalink }}" defer></script>
+    <script src="{{ $js_terminal_fs.RelPermalink }}" defer></script>
     <script src="{{ $js_terminal.RelPermalink }}" defer></script>
     <script src="{{ $js_terminal_flows.RelPermalink }}" defer></script>
     <script src="{{ $js5.RelPermalink }}" defer></script>
@@ -857,7 +859,7 @@
     <script src="{{ $js_terminal_ai.RelPermalink }}" defer></script>
   {{ else }}
     <!-- JavaScript production -->
-    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js_custom_palette $js4 $js_theme_pantone $js_terminal_data $js_terminal $js_terminal_flows $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav $js_terminal_ai_data $js_terminal_ai }}
+    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js_custom_palette $js4 $js_theme_pantone $js_terminal_data $js_terminal_fs $js_terminal $js_terminal_flows $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav $js_terminal_ai_data $js_terminal_ai }}
     {{ $js = $js | resources.Concat "js.js" | minify | fingerprint }}
     <script src="{{ $js.RelPermalink }}" defer></script>
     {{ $pageJs := slice }}

--- a/layouts/partials/terminal-manifest.html
+++ b/layouts/partials/terminal-manifest.html
@@ -1,22 +1,33 @@
-{{/* Terminal filesystem manifest: maps each top-level segment to its kind and
-  URL so the terminal classifies ls/cd/tree and can fetch a dir without a
-  hardcoded guess. Sections are directories, standalone top-level pages are
-  files; a page overrides its kind via a `terminal_kind` param (contact =
-  action). The visual tools (terminal_kind = exempt) can't render as a
-  terminal, so they're left OUT of the filesystem entirely — not listed by
-  `ls`, not reachable by cd/open. The URL lets the terminal reach
-  footer-only sections (legal) that aren't in the nav.
+{{/* Terminal filesystem manifest: the full site tree the terminal treats as its
+  filesystem, keyed by LOGICAL path so `ls`/`cd`/`tree`/completion know every
+  node synchronously (no runtime scraping — see assets/js/terminal-fs.js).
+
+  Each entry maps a logical path → {kind, url, title, tags?}:
+  - Sections are `dir`s (works, writing, newsletter, legal).
+  - Every post / standalone page is a `file`; a page overrides its kind via a
+  `terminal_kind` param (contact = action). `hidden`/`exempt` pages are left
+  OUT entirely — not listed by ls, not reachable by cd/open.
+  - The `url` is the real RelPermalink (used to fetch a post's body); the key
+  is the LOGICAL path, which can differ (works posts live at /englishwork/…
+  but the terminal dir is `works/`). We rebuild the logical path from
+  `.Section` + the tail of the URL, so the renamed section slug never leaks
+  into the tree.
+
+  Section `tags/` taxonomy dirs aren't enumerated here — the terminal grafts
+  those from nav/footer links, and term contents load on demand via remote-ls.
 
   A returning partial so head.html emits it as the terminal-manifest JSON and
   the template-render tests can assert the mapping without rendering all of
   head.html.
 */}}
 {{- $kinds := dict -}}
+{{- $sectionNames := slice -}}
 {{- range site.Sections -}}
   {{- $k := "dir" -}}
   {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
   {{- if ne $k "exempt" -}}
-    {{- $kinds = merge $kinds (dict .Section (dict "kind" $k "url" .RelPermalink)) -}}
+    {{- $sectionNames = append .Section $sectionNames -}}
+    {{- $kinds = merge $kinds (dict .Section (dict "kind" $k "url" .RelPermalink "title" .Title)) -}}
   {{- end -}}
 {{- end -}}
 {{- range where site.RegularPages "Kind" "page" -}}
@@ -24,11 +35,39 @@
   {{- $rel = strings.TrimPrefix (printf "%s/" .Language.Lang) $rel -}}
   {{- $rel = strings.Trim $rel "/" -}}
   {{- $segs := split $rel "/" -}}
+  {{- $section := .Section -}}
   {{- $tk := .Params.terminal_kind | default "" -}}
-  {{- if and (eq (len $segs) 1) (ne $tk "hidden") (ne $tk "exempt") -}}
+  {{/* Include a page only when it belongs to a real (non-exempt) content
+    section, or is a standalone top-level page. This keeps taxonomy/term
+    bundles (clients, employers) out of the filesystem, as before.
+  */}}
+  {{- $include := false -}}
+  {{- if $section -}}
+    {{- if in $sectionNames $section -}}{{ $include = true }}{{- end -}}
+  {{- else if eq (len $segs) 1 -}}
+    {{- $include = true -}}
+  {{- end -}}
+  {{- if and $include (ne $tk "hidden") (ne $tk "exempt") -}}
     {{- $k := "file" -}}
     {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
-    {{- $kinds = merge $kinds (dict (index $segs 0) (dict "kind" $k "url" .RelPermalink)) -}}
+    {{/* Logical path: the section name (not its URL slug) + the URL tail, built
+      as a string so the renamed section slug never leaks into the key. A
+      standalone top-level page keeps its single segment.
+    */}}
+    {{- $key := delimit $segs "/" -}}
+    {{- if $section -}}
+      {{- $tail := after 1 $segs -}}
+      {{- if gt (len $tail) 0 -}}
+        {{- $key = printf "%s/%s" $section (delimit $tail "/") -}}
+      {{- else -}}
+        {{- $key = $section -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $entry := dict "kind" $k "url" .RelPermalink "title" .Title -}}
+    {{- with .Params.tags }}
+      {{ $entry = merge $entry (dict "tags" .) }}
+    {{ end -}}
+    {{- $kinds = merge $kinds (dict $key $entry) -}}
   {{- end -}}
 {{- end -}}
 {{- return $kinds -}}

--- a/test/hugo-render.test.js
+++ b/test/hugo-render.test.js
@@ -181,6 +181,19 @@ describeOrSkip("Hugo template rendering", () => {
       expect(manifest()["docs"]).toMatchObject({ kind: "action" });
     });
 
+    test("widened to the full tree: a section's nested post is a file, keyed by its logical path", () => {
+      const m = manifest();
+      // sample-work lives at employer-fixture/sample-work/ — a depth-2 page the
+      // old top-level-only manifest never emitted. It's now a file under its
+      // section, keyed by the logical path (section name + tail), not flattened
+      // to a bare slug.
+      expect(m["employer-fixture/sample-work"]).toMatchObject({
+        kind: "file",
+        url: "/employer-fixture/sample-work/",
+      });
+      expect(m).not.toHaveProperty("sample-work");
+    });
+
     test("exempt sections and hidden pages are left out entirely", () => {
       const m = manifest();
       expect(m).not.toHaveProperty("tools"); // terminal_kind: exempt


### PR DESCRIPTION
Step 1 of the terminal persistent-session plan (docs/terminal-architecture-
plan.md): replace the terminal's several ad-hoc, partly-async client-side
models of the site with one authoritative full-tree manifest, read by a new
terminal-fs.js data-module. UX-neutral — ls/cd/tree/completion now know the
whole tree synchronously where the old prefetch gave that asynchronously.

- Widen terminal-manifest.html from a top-level-only map to every reachable
  node (sections + every post + standalone pages), keyed by LOGICAL path so a
  renamed section slug (works posts live at /englishwork/…) never leaks into
  the tree — the URL rides along for fetching. Taxonomy/term bundles stay out.
- Add assets/js/terminal-fs.js (window.TerminalFS): lazily reads the manifest
  blob and exposes manifest()/tree()/node(), normalizing keys to decoded,
  lowercased logical paths. Registered before terminal.js in head.html.
- Reroute terminal.js's tree onto TerminalFS and retire the machinery a
  complete synchronous manifest makes redundant: the per-cwd ls cache, the
  index.json prefetch/seed (+ its Tab/focus triggers), and the live-DOM card
  scrape. remote-cat stays for content; remote-ls is kept only as a defensive
  fallback for a node the manifest doesn't enumerate (tag term dirs). A
  section's tags/ dir still comes from the nav/footer graft.

Tests: widen the fixture manifest to the full tree; rework the retired-
mechanism tests (cache-warms-Tab and index.json-seed are gone; a cd'd-into
section now lists synchronously, a tag term dir exercises the remote-ls
fallback); add a Hugo render assertion for the nested-manifest shape.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017xPBvh4MwvD4pgm5MnttSB