### PR TITLE
Väg 3 (steg 1–4b): terminal persistent session — combined preview/review

### DIFF
--- a/assets/js/__tests__/language-dropdown.test.js
+++ b/assets/js/__tests__/language-dropdown.test.js
@@ -1,0 +1,57 @@
+/**
+ * Language navigation (language-dropdown.js): the settings-panel language radio.
+ * In the terminal layout it routes through the terminal's in-place swap seam
+ * (no reload); everywhere else it does the normal full navigation.
+ */
+describe("language navigation", () => {
+  function load() {
+    jest.isolateModules(() => {
+      require("../language-dropdown.js");
+    });
+    document.dispatchEvent(new window.Event("DOMContentLoaded"));
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-layout");
+    delete window.Terminal;
+    document.body.innerHTML =
+      '<label class="language-option">' +
+      '<input type="radio" data-language-code="sv" data-language-name="Svenska"' +
+      ' data-language-href="/sv/writing/" /></label>';
+  });
+
+  function fireChange() {
+    document
+      .querySelector('input[data-language-code="sv"]')
+      .dispatchEvent(new window.Event("change"));
+  }
+
+  test("in terminal layout, routes through the terminal swap seam (no reload toast)", () => {
+    document.documentElement.setAttribute("data-layout", "terminal");
+    window.Terminal = { switchLanguage: jest.fn() };
+    load();
+    fireChange();
+    expect(window.Terminal.switchLanguage).toHaveBeenCalledWith("/sv/writing/");
+    // The seam prints its own confirmation/toast, so no reload-only pending toast.
+    expect(localStorage.getItem("pending-toast")).toBeNull();
+  });
+
+  test("in terminal layout without the seam, falls back to a full navigation", () => {
+    document.documentElement.setAttribute("data-layout", "terminal");
+    // window.Terminal absent (older engine) → the normal reload path.
+    load();
+    fireChange();
+    expect(localStorage.getItem("pending-toast")).toContain("Svenska");
+  });
+
+  test("outside terminal layout, sets the pending toast and navigates as before", () => {
+    window.Terminal = { switchLanguage: jest.fn() };
+    load();
+    fireChange();
+    // Non-terminal pages are untouched: no swap, the reload-toast is stored.
+    expect(window.Terminal.switchLanguage).not.toHaveBeenCalled();
+    expect(localStorage.getItem("pending-toast")).toContain("Svenska");
+  });
+});

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -94,6 +94,7 @@ describe("terminal command line", () => {
       "data-terminal-replaying",
       "data-terminal-exempt",
       "data-terminal-booted",
+      "lang",
     ].forEach((attr) => document.documentElement.removeAttribute(attr));
     // A test may pushState to a deeper path; reset so location-derived logic
     // (the current-page slug) starts from home each case.
@@ -1874,6 +1875,99 @@ describe("terminal command line", () => {
     window.Terminal.rehydrate();
     typeCommand("ls");
     expect(sessionText()).toContain("notes/");
+  });
+
+  test("rehydrate(doc) transplants a translated document's chrome (language swap)", () => {
+    // The live page starts English, with an English catalog.
+    const cat = document.createElement("script");
+    cat.type = "application/json";
+    cat.setAttribute("data-js", "terminal-i18n");
+    cat.textContent = JSON.stringify({
+      help: "commands:\n  help      this list",
+    });
+    document.body.appendChild(cat);
+    loadModule();
+    typeCommand("help");
+    expect(sessionText()).toContain("this list");
+
+    // A fetched Swedish document: sv <html lang>, sv manifest, sv i18n catalog,
+    // and a nav whose anchor count mirrors the live nav (so the in-place link
+    // transplant runs — see the length guard).
+    const svHtml =
+      '<!doctype html><html lang="sv" data-home-url="/sv/"><head>' +
+      '<script type="application/json" data-js="terminal-manifest">' +
+      '{"arbeten":{"kind":"dir","url":"/sv/arbeten/"}}</script></head><body>' +
+      '<nav class="top-menu__nav">' +
+      '<a class="terminal-prompt__host" href="/sv/"></a>' +
+      '<a class="top-menu__link" href="/sv/arbeten/">Arbeten</a>' +
+      '<a class="top-menu__link" href="/sv/arbeten/tags/">Taggar</a>' +
+      '<a class="top-menu__link" href="/sv/texter/">Texter</a>' +
+      '<a class="top-menu__link" href="/sv/om/">Om</a>' +
+      '<a class="terminal-quick terminal-quick--lang" href="/writing/" lang="en">en</a>' +
+      "</nav>" +
+      '<script type="application/json" data-js="terminal-i18n">' +
+      JSON.stringify({ help: "kommandon:\n  help      den här listan" }) +
+      "</script></body></html>";
+    const doc = new DOMParser().parseFromString(svHtml, "text/html");
+    window.Terminal.rehydrate(doc);
+
+    // <html lang> flipped, the engine speaks Swedish, and the fs model + nav
+    // reflect the Swedish tree.
+    expect(document.documentElement.getAttribute("lang")).toBe("sv");
+    typeCommand("help");
+    expect(sessionText()).toContain("den här listan");
+    typeCommand("ls");
+    expect(sessionText()).toContain("arbeten/");
+    typeCommand("ls nav");
+    expect(sessionText()).toContain("om/");
+  });
+
+  test("lang swaps in place via TerminalNav instead of reloading", async () => {
+    // A content page (cwd ~/writing) whose Swedish translation is a real page.
+    window.getComputedStyle = () => ({
+      getPropertyValue: (prop) =>
+        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
+          ? "~/writing"
+          : "#ffffff",
+    });
+    document.documentElement.setAttribute("data-layout", "terminal");
+    // go being called at all proves the swap path was taken — a full reload
+    // (fullReloadNavigate) never calls TerminalNav.go.
+    window.TerminalNav = { go: jest.fn(() => Promise.resolve(true)) };
+    document
+      .querySelector('.language-option input[data-language-code="sv"]')
+      .setAttribute("data-language-href", "/sv/writing/");
+    loadModule();
+    typeCommand("lang sv");
+    expect(window.TerminalNav.go).toHaveBeenCalledWith(
+      "/sv/writing/",
+      expect.objectContaining({ cwd: "~/writing" })
+    );
+    await flush();
+    // The swap resolved, so the confirmation prints (in the new language).
+    expect(sessionText()).toContain("language →");
+    delete window.TerminalNav;
+  });
+
+  test("lang falls back to a full reload when the swap declines", async () => {
+    window.getComputedStyle = () => ({
+      getPropertyValue: (prop) =>
+        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
+          ? "~/writing"
+          : "#ffffff",
+    });
+    document.documentElement.setAttribute("data-layout", "terminal");
+    window.TerminalNav = { go: jest.fn(() => Promise.resolve(false)) };
+    document
+      .querySelector('.language-option input[data-language-code="sv"]')
+      .setAttribute("data-language-href", "/sv/writing/");
+    loadModule();
+    typeCommand("lang sv");
+    await flush();
+    // The swap declined → fullReloadNavigate runs; no in-place confirmation.
+    expect(window.TerminalNav.go).toHaveBeenCalled();
+    expect(sessionText()).not.toContain("language →");
+    delete window.TerminalNav;
   });
 
   test("a localized (percent-encoded) slug lists by its real, decoded name", () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1922,8 +1922,27 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("om/");
   });
 
-  test("lang swaps in place via TerminalNav instead of reloading", async () => {
-    // A content page (cwd ~/writing) whose Swedish translation is a real page.
+  // A language switch is a chrome-only in-place swap: fetch the translated page,
+  // hydrate from it, push history, confirm. No visible #main swap, so it works in
+  // transcript mode and on home — where the #main-swap route can't. These helpers
+  // set up a content cwd, a live English catalog to transplant into, and a fetch
+  // that returns the Swedish page.
+  function svPageHtml() {
+    const manifest =
+      '<script type="application/json" data-js="terminal-manifest">{}</script>';
+    const i18n =
+      '<script type="application/json" data-js="terminal-i18n">' +
+      JSON.stringify({ help: "kommandon:\n  help      den här listan" }) +
+      "</script>";
+    return (
+      '<!doctype html><html lang="sv"><head>' +
+      manifest +
+      "</head><body>" +
+      i18n +
+      "</body></html>"
+    );
+  }
+  function setupLangSwap() {
     window.getComputedStyle = () => ({
       getPropertyValue: (prop) =>
         prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
@@ -1931,72 +1950,72 @@ describe("terminal command line", () => {
           : "#ffffff",
     });
     document.documentElement.setAttribute("data-layout", "terminal");
-    // go being called at all proves the swap path was taken — a full reload
-    // (fullReloadNavigate) never calls TerminalNav.go.
-    window.TerminalNav = { go: jest.fn(() => Promise.resolve(true)) };
+    const cat = document.createElement("script");
+    cat.type = "application/json";
+    cat.setAttribute("data-js", "terminal-i18n");
+    cat.textContent = JSON.stringify({
+      help: "commands:\n  help      this list",
+    });
+    document.body.appendChild(cat);
     document
       .querySelector('.language-option input[data-language-code="sv"]')
       .setAttribute("data-language-href", "/sv/writing/");
+    window.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve(svPageHtml()) })
+    );
+  }
+  function fetchedSvWriting() {
+    return window.fetch.mock.calls.some((c) => c[0] === "/sv/writing/");
+  }
+
+  test("lang swaps in place by fetching + hydrating (no reload)", async () => {
+    setupLangSwap();
     loadModule();
     typeCommand("lang sv");
-    expect(window.TerminalNav.go).toHaveBeenCalledWith(
-      "/sv/writing/",
-      expect.objectContaining({ cwd: "~/writing" })
-    );
     await flush();
-    // The swap resolved, so the confirmation prints (in the new language).
-    expect(sessionText()).toContain("language →");
-    delete window.TerminalNav;
+    // Fetched the translation and hydrated from it — the engine now speaks
+    // Swedish, no reload.
+    expect(fetchedSvWriting()).toBe(true);
+    expect(document.documentElement.getAttribute("lang")).toBe("sv");
+    typeCommand("help");
+    expect(sessionText()).toContain("den här listan");
   });
 
-  test("lang falls back to a full reload when the swap declines", async () => {
-    window.getComputedStyle = () => ({
-      getPropertyValue: (prop) =>
-        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
-          ? "~/writing"
-          : "#ffffff",
-    });
-    document.documentElement.setAttribute("data-layout", "terminal");
-    window.TerminalNav = { go: jest.fn(() => Promise.resolve(false)) };
-    document
-      .querySelector('.language-option input[data-language-code="sv"]')
-      .setAttribute("data-language-href", "/sv/writing/");
+  test("lang swaps in place even in transcript mode (the default) — no reload", async () => {
+    // Regression: the real terminal boots in transcript mode (head.html sets
+    // data-terminal-transcript), where the old #main-swap gate forced a full
+    // reload. The chrome-only swap runs regardless.
+    setupLangSwap();
+    document.documentElement.setAttribute("data-terminal-transcript", "1");
     loadModule();
     typeCommand("lang sv");
     await flush();
-    // The swap declined → fullReloadNavigate runs; no in-place confirmation.
-    expect(window.TerminalNav.go).toHaveBeenCalled();
-    expect(sessionText()).not.toContain("language →");
-    delete window.TerminalNav;
+    expect(fetchedSvWriting()).toBe(true);
+    expect(document.documentElement.getAttribute("lang")).toBe("sv");
+  });
+
+  test("lang falls back to a full reload when the fetch fails", async () => {
+    setupLangSwap();
+    window.fetch = jest.fn(() => Promise.reject(new Error("network")));
+    loadModule();
+    typeCommand("lang sv");
+    await flush();
+    // Fetch failed → fullReloadNavigate; the in-place swap did not happen.
+    expect(window.fetch).toHaveBeenCalled();
+    expect(document.documentElement.getAttribute("lang")).not.toBe("sv");
   });
 
   test("Terminal.switchLanguage swaps in place (toggle / panel-radio seam)", async () => {
-    window.getComputedStyle = () => ({
-      getPropertyValue: (prop) =>
-        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
-          ? "~/writing"
-          : "#ffffff",
-    });
-    window.TerminalNav = { go: jest.fn(() => Promise.resolve(true)) };
+    setupLangSwap();
     loadModule();
     window.Terminal.switchLanguage("/sv/writing/");
-    expect(window.TerminalNav.go).toHaveBeenCalledWith(
-      "/sv/writing/",
-      expect.objectContaining({ cwd: "~/writing" })
-    );
     await flush();
-    expect(sessionText()).toContain("language →");
-    delete window.TerminalNav;
+    expect(fetchedSvWriting()).toBe(true);
+    expect(document.documentElement.getAttribute("lang")).toBe("sv");
   });
 
-  test("clicking the statusbar language toggle swaps in place, not a reload", () => {
-    window.getComputedStyle = () => ({
-      getPropertyValue: (prop) =>
-        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
-          ? "~/writing"
-          : "#ffffff",
-    });
-    window.TerminalNav = { go: jest.fn(() => Promise.resolve(true)) };
+  test("clicking the statusbar language toggle swaps in place, not a reload", async () => {
+    setupLangSwap();
     loadModule();
     // The fixture nav carries a .terminal-quick--lang toggle to /sv/writing/.
     const toggle = document.querySelector(".terminal-quick--lang");
@@ -2007,11 +2026,9 @@ describe("terminal command line", () => {
     });
     toggle.dispatchEvent(evt);
     expect(evt.defaultPrevented).toBe(true);
-    expect(window.TerminalNav.go).toHaveBeenCalledWith(
-      "/sv/writing/",
-      expect.objectContaining({ cwd: "~/writing" })
-    );
-    delete window.TerminalNav;
+    await flush();
+    expect(fetchedSvWriting()).toBe(true);
+    expect(document.documentElement.getAttribute("lang")).toBe("sv");
   });
 
   test("a modifier-click on the language toggle is left to the browser", () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1922,6 +1922,55 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("om/");
   });
 
+  test("rehydrate(doc) relocalizes the prompt line + the UI-string catalog", () => {
+    // The engine's own prompt line (the exit hint, a CSS ::after reading
+    // data-exit-hint) and its UI strings (errors, the lang-switch confirmation)
+    // must flip with the language too — not just help/ls. Otherwise the terminal
+    // keeps whispering the boot language after an in-place swap.
+    const cat = document.createElement("script");
+    cat.type = "application/json";
+    cat.setAttribute("data-js", "terminal-i18n");
+    cat.textContent = JSON.stringify({
+      ui: { notFound: "%s: kommandot hittades inte" },
+    });
+    document.body.appendChild(cat);
+    // The live prompt line carries an English exit hint + input label.
+    const liveTail = document.querySelector(".terminal-tail");
+    liveTail.setAttribute("data-exit-hint", "type exit to leave");
+    const liveLabel = document.createElement("label");
+    liveLabel.className = "sr-only";
+    liveLabel.setAttribute("for", "terminal-input");
+    liveLabel.textContent = "Type a command";
+    liveTail.insertBefore(liveLabel, liveTail.firstChild);
+    loadModule();
+
+    const svHtml =
+      '<!doctype html><html lang="sv"><head></head><body>' +
+      '<p class="terminal-tail" data-exit-hint="skriv exit för att lämna">' +
+      '<label class="sr-only" for="terminal-input">Skriv ett kommando</label>' +
+      '<input id="terminal-input" data-js="terminal-input" /></p>' +
+      '<script type="application/json" data-js="terminal-i18n">' +
+      JSON.stringify({ ui: { notFound: "%s: kommandot hittades inte" } }) +
+      "</script></body></html>";
+    const doc = new DOMParser().parseFromString(svHtml, "text/html");
+    window.Terminal.rehydrate(doc);
+
+    // The prompt line's exit hint + input label are now Swedish, in place (the
+    // live <input> node is preserved, not replaced).
+    const tail = document.querySelector(".terminal-tail");
+    expect(tail.getAttribute("data-exit-hint")).toBe(
+      "skriv exit för att lämna"
+    );
+    expect(tail.querySelector('label[for="terminal-input"]').textContent).toBe(
+      "Skriv ett kommando"
+    );
+    expect(document.querySelector('[data-js="terminal-input"]')).not.toBeNull();
+
+    // And a UI string (command-not-found) now renders from the Swedish catalog.
+    typeCommand("frobnicate");
+    expect(sessionText()).toContain("frobnicate: kommandot hittades inte");
+  });
+
   // A language switch is a chrome-only in-place swap: fetch the translated page,
   // hydrate from it, push history, confirm. No visible #main swap, so it works in
   // transcript mode and on home — where the #main-swap route can't. These helpers
@@ -1932,7 +1981,10 @@ describe("terminal command line", () => {
       '<script type="application/json" data-js="terminal-manifest">{}</script>';
     const i18n =
       '<script type="application/json" data-js="terminal-i18n">' +
-      JSON.stringify({ help: "kommandon:\n  help      den här listan" }) +
+      JSON.stringify({
+        help: "kommandon:\n  help      den här listan",
+        ui: { langSwitched: "språk → %s" },
+      }) +
       "</script>";
     return (
       '<!doctype html><html lang="sv"><head>' +
@@ -1977,6 +2029,9 @@ describe("terminal command line", () => {
     // Swedish, no reload.
     expect(fetchedSvWriting()).toBe(true);
     expect(document.documentElement.getAttribute("lang")).toBe("sv");
+    // The confirmation itself reads from the freshly-transplanted catalog — it's
+    // Swedish ("språk →"), not the English "language →" fallback.
+    expect(sessionText()).toContain("språk →");
     typeCommand("help");
     expect(sessionText()).toContain("den här listan");
   });

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1970,6 +1970,66 @@ describe("terminal command line", () => {
     delete window.TerminalNav;
   });
 
+  test("Terminal.switchLanguage swaps in place (toggle / panel-radio seam)", async () => {
+    window.getComputedStyle = () => ({
+      getPropertyValue: (prop) =>
+        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
+          ? "~/writing"
+          : "#ffffff",
+    });
+    window.TerminalNav = { go: jest.fn(() => Promise.resolve(true)) };
+    loadModule();
+    window.Terminal.switchLanguage("/sv/writing/");
+    expect(window.TerminalNav.go).toHaveBeenCalledWith(
+      "/sv/writing/",
+      expect.objectContaining({ cwd: "~/writing" })
+    );
+    await flush();
+    expect(sessionText()).toContain("language →");
+    delete window.TerminalNav;
+  });
+
+  test("clicking the statusbar language toggle swaps in place, not a reload", () => {
+    window.getComputedStyle = () => ({
+      getPropertyValue: (prop) =>
+        prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
+          ? "~/writing"
+          : "#ffffff",
+    });
+    window.TerminalNav = { go: jest.fn(() => Promise.resolve(true)) };
+    loadModule();
+    // The fixture nav carries a .terminal-quick--lang toggle to /sv/writing/.
+    const toggle = document.querySelector(".terminal-quick--lang");
+    const evt = new window.MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    });
+    toggle.dispatchEvent(evt);
+    expect(evt.defaultPrevented).toBe(true);
+    expect(window.TerminalNav.go).toHaveBeenCalledWith(
+      "/sv/writing/",
+      expect.objectContaining({ cwd: "~/writing" })
+    );
+    delete window.TerminalNav;
+  });
+
+  test("a modifier-click on the language toggle is left to the browser", () => {
+    window.TerminalNav = { go: jest.fn() };
+    loadModule();
+    const toggle = document.querySelector(".terminal-quick--lang");
+    const evt = new window.MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      metaKey: true,
+    });
+    toggle.dispatchEvent(evt);
+    expect(evt.defaultPrevented).toBe(false);
+    expect(window.TerminalNav.go).not.toHaveBeenCalled();
+    delete window.TerminalNav;
+  });
+
   test("a localized (percent-encoded) slug lists by its real, decoded name", () => {
     loadModule();
     // A Swedish post card whose href carries a percent-encoded slug.

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -37,6 +37,7 @@ describe("terminal command line", () => {
       require("../theme.js");
       require("../theme-pantone.js");
       require("../terminal-data.js");
+      require("../terminal-fs.js");
       require("../terminal.js");
       require("../terminal-flows.js");
     });
@@ -100,7 +101,7 @@ describe("terminal command line", () => {
 
     document.documentElement.innerHTML = `
       <head><meta name="theme-color" content="#ffffff">
-        <script type="application/json" data-js="terminal-manifest">{"works":{"kind":"dir","url":"/works/"},"writing":{"kind":"dir","url":"/writing/"},"about":{"kind":"file","url":"/about/"},"contact":{"kind":"action","url":"/contact/"},"legal":{"kind":"dir","url":"/legal/"},"ui-library":{"kind":"exempt","url":"/ui-library/"},"palette-generator":{"kind":"exempt","url":"/palette-generator/"}}</script>
+        <script type="application/json" data-js="terminal-manifest">{"works":{"kind":"dir","url":"/works/"},"works/a-cut-up-world":{"kind":"file","url":"/works/a-cut-up-world/"},"works/things-in-a-conversation":{"kind":"file","url":"/works/things-in-a-conversation/"},"writing":{"kind":"dir","url":"/writing/"},"writing/the-grid-inherited":{"kind":"file","url":"/writing/the-grid-inherited/"},"about":{"kind":"file","url":"/about/"},"contact":{"kind":"action","url":"/contact/"},"legal":{"kind":"dir","url":"/legal/"},"legal/license":{"kind":"file","url":"/legal/license/"},"ui-library":{"kind":"exempt","url":"/ui-library/"},"palette-generator":{"kind":"exempt","url":"/palette-generator/"}}</script>
       </head>
       <body>
         <div class="terminal-boot">
@@ -375,57 +376,26 @@ describe("terminal command line", () => {
     );
   });
 
-  test("Tab completes files in a cd'd-into directory once ls has cached them", async () => {
-    // Live cwd sits in a tag dir the page never loaded (page cwd is ~), so a
-    // bare `ls` remote-fetches it.
-    window.getComputedStyle = () => ({
-      getPropertyValue: (prop) =>
-        prop === "--terminal-live-cwd"
-          ? "~/works/tags/experimental"
-          : prop === "--terminal-cwd"
-          ? "~"
-          : "#ffffff",
-    });
-    window.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          '<div class="summary-card"><a href="/works/things-in-a-conversation/">x</a></div>' +
-            '<div class="summary-card"><a href="/works/a-cut-up-world/">y</a></div>'
-        ),
-    });
-    loadModule();
-    typeCommand("ls"); // remote-ls fetches the tag dir and caches its files
-    await flush();
-    const input = document.querySelector('[data-js="terminal-input"]');
-    // Before, Tab had nothing here; now the cached filename completes.
-    input.value = "cat thin";
-    keydown({ key: "Tab" });
-    expect(input.value).toBe("cat things-in-a-conversation.md");
-  });
-
-  test("Tab completes a post in an unvisited directory once the page index warms", async () => {
-    // From the home page ~/works's projects were never listed, so completion
-    // has nothing for them — until the prompt is focused and the site's page
-    // index (index.json) warms the ls cache.
-    window.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          items: [
-            { url: "https://tor-bjorn.com/works/things-in-a-conversation/" },
-            { url: "https://tor-bjorn.com/works/a-cut-up-world/" },
-          ],
-        }),
-    });
+  test("Tab completes a post in any section synchronously — no fetch, no cache", () => {
+    // The full-tree manifest knows every post the instant the page loads, so a
+    // qualified path completes with no `ls`, no focus, no index.json prefetch.
+    window.fetch = jest.fn();
     loadModule();
     const input = document.querySelector('[data-js="terminal-input"]');
-    input.dispatchEvent(new window.Event("focus")); // warms the cache
-    await flush();
-    expect(window.fetch.mock.calls[0][0]).toContain("/index.json");
     input.value = "cat ~/works/thin";
     keydown({ key: "Tab" });
     expect(input.value).toBe("cat ~/works/things-in-a-conversation.md");
+    expect(window.fetch).not.toHaveBeenCalled();
+  });
+
+  test("Tab completes a post as a bare name for cd (a file is .md only for cat)", () => {
+    // Kind-aware completion: cat/open complete a file as `name.md`; cd/ls
+    // complete it bare (you cat a file, you cd a dir).
+    loadModule();
+    const input = document.querySelector('[data-js="terminal-input"]');
+    input.value = "cd ~/works/thin";
+    keydown({ key: "Tab" });
+    expect(input.value).toBe("cd ~/works/things-in-a-conversation");
   });
 
   test("cat prints a known pseudo-file and 404s unknown ones", () => {
@@ -642,9 +612,11 @@ describe("terminal command line", () => {
     expect(sessionText()).not.toContain("the-grid-inherited/");
   });
 
-  test("ls of another section hints at cd instead of printing nothing", () => {
+  test("ls of another section lists its posts from the manifest, from anywhere", () => {
     loadModule();
-    // Sitting on /works/, ask for a different section's contents.
+    // Sitting on /works/, ask for a different section's contents. The manifest
+    // knows the whole tree, so a remote section lists its posts directly instead
+    // of the old "(cd writing to list it)" hint that a DOM-only model needed.
     window.getComputedStyle = jest.fn(() => ({
       getPropertyValue: jest.fn((prop) =>
         prop === "--terminal-cwd" || prop === "--terminal-live-cwd"
@@ -653,7 +625,7 @@ describe("terminal command line", () => {
       ),
     }));
     typeCommand("ls ~/writing");
-    expect(sessionText()).toContain("cd writing");
+    expect(sessionText()).toContain("the-grid-inherited.md");
   });
 
   test("ls lists several paths with per-directory headers", () => {
@@ -1286,10 +1258,11 @@ describe("terminal command line", () => {
     );
   });
 
-  test("append-only ls renders the fetched section's posts as clickable files", async () => {
+  test("ls in a cd'd-into section lists it synchronously from the manifest — no fetch", () => {
     // After `cd writing` (append-only: the live cwd moves, the loaded page
-    // doesn't), a bare `ls` can't read the DOM — it fetches /writing/ and lists
-    // it below. Those posts must be clickable too, just like a local `ls`.
+    // doesn't), a bare `ls` no longer needs to fetch the section — the full-tree
+    // manifest already knows its posts, so it lists them as clickable files at
+    // once, without a round-trip.
     loadModule();
     // Page cwd is home (~); the live cwd has moved into ~/writing.
     window.getComputedStyle = jest.fn(() => ({
@@ -1303,27 +1276,16 @@ describe("terminal command line", () => {
     }));
     window.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      text: () =>
-        Promise.resolve(
-          '<div class="summary-card"><a href="/writing/the-grid-inherited/">The grid</a></div>' +
-            '<div class="summary-card"><a href="/writing/another-post/">Another</a></div>'
-        ),
+      text: () => Promise.resolve(""),
     });
     typeCommand("ls");
-    // The remote-ls handler is async (fetch → parse → print); flush its chain.
-    for (let i = 0; i < 6; i++) {
-      await Promise.resolve();
-    }
 
     const post = document.querySelector(
       '.terminal-session__ls-entry[data-cmd="cat the-grid-inherited.md"]'
     );
     expect(post).not.toBeNull();
-    expect(
-      document.querySelector(
-        '.terminal-session__ls-entry[data-cmd="cat another-post.md"]'
-      )
-    ).not.toBeNull();
+    // The listing came from the manifest, not a fetch.
+    expect(window.fetch).not.toHaveBeenCalled();
 
     const before = sessionText();
     post.dispatchEvent(new window.Event("click", { bubbles: true }));
@@ -1331,6 +1293,40 @@ describe("terminal command line", () => {
     expect(sessionText().slice(before.length)).toContain(
       "cat the-grid-inherited.md"
     );
+  });
+
+  test("ls in a tag term dir the manifest doesn't enumerate falls back to remote-ls", async () => {
+    // Tag term dirs (works/tags/<term>) aren't in the flat manifest — their
+    // posts are symlinks whose canonical file lives up in the section. Listing
+    // one you've cd'd into but not loaded still fetches the term page and prints
+    // its posts as clickable symlinks (the retained defensive fallback).
+    loadModule();
+    window.getComputedStyle = jest.fn(() => ({
+      getPropertyValue: jest.fn((prop) =>
+        prop === "--terminal-live-cwd"
+          ? "~/works/tags/experimental"
+          : prop === "--terminal-cwd"
+          ? "~"
+          : "#ffffff"
+      ),
+    }));
+    window.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<div class="summary-card"><a href="/works/things-in-a-conversation/">x</a></div>'
+        ),
+    });
+    typeCommand("ls");
+    // The remote-ls handler is async (fetch → parse → print); flush its chain.
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve();
+    }
+    expect(window.fetch).toHaveBeenCalled();
+    const post = document.querySelector(
+      '.terminal-session__ls-entry[data-cmd="cat things-in-a-conversation.md"]'
+    );
+    expect(post).not.toBeNull();
   });
 
   test("clicking a directory entry in transcript mode opens it (cd then ls)", () => {

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1840,6 +1840,42 @@ describe("terminal command line", () => {
     expect(sessionText()).toContain("this list");
   });
 
+  test("rehydrate re-reads a swapped-in i18n catalog (no stale-language replies)", () => {
+    const cat = document.createElement("script");
+    cat.type = "application/json";
+    cat.setAttribute("data-js", "terminal-i18n");
+    cat.textContent = JSON.stringify({
+      help: "kommandon:\n  help      den här listan",
+    });
+    document.body.appendChild(cat);
+    loadModule();
+    typeCommand("help");
+    expect(sessionText()).toContain("den här listan");
+    // An in-place swap replaces the catalog under the live prompt; rehydrate()
+    // must re-read it so the engine stops answering in the old language.
+    cat.textContent = JSON.stringify({
+      help: "commands:\n  help      this exact list",
+    });
+    window.Terminal.rehydrate();
+    typeCommand("help");
+    expect(sessionText()).toContain("this exact list");
+  });
+
+  test("rehydrate resets the fs/tree model to a swapped-in manifest", () => {
+    loadModule();
+    typeCommand("ls");
+    expect(sessionText()).not.toContain("notes/");
+    // A swap replaces the manifest blob (a page with a different tree). rehydrate
+    // clears the dir-tree + TerminalFS caches so ls reflects the new tree.
+    const man = document.querySelector('[data-js="terminal-manifest"]');
+    man.textContent = JSON.stringify({
+      notes: { kind: "dir", url: "/notes/" },
+    });
+    window.Terminal.rehydrate();
+    typeCommand("ls");
+    expect(sessionText()).toContain("notes/");
+  });
+
   test("a localized (percent-encoded) slug lists by its real, decoded name", () => {
     loadModule();
     // A Swedish post card whose href carries a percent-encoded slug.

--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -2099,12 +2099,97 @@ describe("terminal command line", () => {
 
   // ---- Nav "cd" feedback ------------------------------------------------
 
-  test("clicking a nav link stashes a cd command for the next page", () => {
+  // These assert on shared, current-DOM outcomes — the `--terminal-live-cwd`
+  // inline var (a `cd` sets it) and a fetch mock (a `cat` fetches) — rather than
+  // the scrollback text, because terminal.js binds its click handler on
+  // `document`, and jsdom keeps one document across the file so re-requiring the
+  // module (loadModule) leaves extra handlers that would muddy a text assertion.
+  function liveCwd() {
+    return document.documentElement.style.getPropertyValue(
+      "--terminal-live-cwd"
+    );
+  }
+  function leftClick(el) {
+    const evt = new window.MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    });
+    el.dispatchEvent(evt);
+    return evt;
+  }
+
+  test("clicking a known nav link runs its command (cd) in place", () => {
     loadModule();
-    sessionStorage.removeItem("terminal-cd");
-    document.querySelector('.top-menu__link[href="/writing/"]').click();
-    const stashed = JSON.parse(sessionStorage.getItem("terminal-cd"));
-    expect(stashed.cmd).toBe("cd ~/writing");
+    document.documentElement.style.removeProperty("--terminal-live-cwd");
+    const evt = leftClick(
+      document.querySelector('.top-menu__link[href="/writing/"]')
+    );
+    // Intercepted and run as `cd writing` (append-only move), not a browser nav.
+    expect(evt.defaultPrevented).toBe(true);
+    expect(liveCwd()).toContain("writing");
+  });
+
+  test("clicking a content card cats the post inline (fetches its page)", () => {
+    window.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve("") })
+    );
+    loadModule();
+    // A stamped project card: data-slug marks it a post (a .md file → cat).
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      '<div class="summary-card"><a class="summary-card__title" ' +
+        'href="/works/foo/" data-slug="foo">Foo</a></div>'
+    );
+    const evt = leftClick(document.querySelector(".summary-card a[data-slug]"));
+    expect(evt.defaultPrevented).toBe(true);
+    // `cat foo.md` resolves to the card's href and remote-cats it.
+    expect(
+      window.fetch.mock.calls.some((c) => String(c[0]).includes("foo"))
+    ).toBe(true);
+  });
+
+  test("clicking a section card cds into it", () => {
+    loadModule();
+    document.documentElement.style.removeProperty("--terminal-live-cwd");
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      '<div class="summary-card"><a class="summary-card__title" ' +
+        'href="/works/" data-dir="works">Works</a></div>'
+    );
+    const evt = leftClick(document.querySelector(".summary-card a[data-dir]"));
+    expect(evt.defaultPrevented).toBe(true);
+    expect(liveCwd()).toContain("works");
+  });
+
+  test("an unstamped card link is left to the browser (no interception)", () => {
+    loadModule();
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      '<div class="summary-card"><a href="/works/bar/">Bar</a></div>'
+    );
+    const evt = leftClick(
+      document.querySelector('.summary-card a[href="/works/bar/"]')
+    );
+    // No data-slug/data-dir → the terminal can't map it → the browser handles it.
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  test("a modifier-click on a nav link is left to the browser", () => {
+    window.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve("") })
+    );
+    loadModule();
+    const el = document.querySelector('.top-menu__link[href="/writing/"]');
+    const evt = new window.MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      metaKey: true,
+    });
+    el.dispatchEvent(evt);
+    // Cmd/ctrl-click → open in new tab → the terminal must not intercept.
+    expect(evt.defaultPrevented).toBe(false);
   });
 
   test("clicking the statusbar language toggle does NOT stash a cd echo", () => {

--- a/assets/js/__tests__/terminal-nav.test.js
+++ b/assets/js/__tests__/terminal-nav.test.js
@@ -101,7 +101,11 @@ describe("terminal in-place navigation", () => {
       cwd: "~/writing",
     });
     expect(swapped).toBe(true);
-    expect(window.Terminal.rehydrate).toHaveBeenCalled();
+    // Called WITH the fetched document, so hydrate can transplant the language
+    // chrome (i18n/manifest/nav) on a language swap.
+    expect(window.Terminal.rehydrate).toHaveBeenCalledWith(
+      expect.any(window.Document)
+    );
     delete window.Terminal;
   });
 

--- a/assets/js/__tests__/terminal-nav.test.js
+++ b/assets/js/__tests__/terminal-nav.test.js
@@ -90,6 +90,21 @@ describe("terminal in-place navigation", () => {
     jest.spyOn(window.history, "pushState");
   });
 
+  test("a swap re-hydrates the terminal engine via window.Terminal.rehydrate", async () => {
+    // After swapping #main the engine must re-read the page chrome (i18n, the
+    // fs/tree/nav model, card slugs) — terminal-nav delegates that to the
+    // terminal.js rehydrate seam.
+    window.Terminal = { rehydrate: jest.fn() };
+    mockFetch(pageHtml());
+    loadModule();
+    const swapped = await window.TerminalNav.go("/writing/", {
+      cwd: "~/writing",
+    });
+    expect(swapped).toBe(true);
+    expect(window.Terminal.rehydrate).toHaveBeenCalled();
+    delete window.Terminal;
+  });
+
   test("go() swaps #main, patches the title + cwd, and pushes state", async () => {
     mockFetch(pageHtml());
     loadModule();

--- a/assets/js/language-dropdown.js
+++ b/assets/js/language-dropdown.js
@@ -8,38 +8,66 @@
  * present in the DOM.
  */
 
-(function() {
-  'use strict';
+(function () {
+  "use strict";
 
-  document.addEventListener('DOMContentLoaded', function() {
-    const toggle = document.querySelector('.language-toggle');
-    const panel = document.querySelector('.language-panel');
-    const overlay = document.querySelector('.language-overlay');
+  document.addEventListener("DOMContentLoaded", function () {
+    const toggle = document.querySelector(".language-toggle");
+    const panel = document.querySelector(".language-panel");
+    const overlay = document.querySelector(".language-overlay");
 
     function setPendingToast(languageName) {
-      if (!languageName) {return;}
+      if (!languageName) {
+        return;
+      }
       try {
-        localStorage.setItem('pending-toast', JSON.stringify({
-          category: 'language',
-          value: languageName.trim(),
-          icon: 'icon-language-micro'
-        }));
+        localStorage.setItem(
+          "pending-toast",
+          JSON.stringify({
+            category: "language",
+            value: languageName.trim(),
+            icon: "icon-language-micro",
+          })
+        );
       } catch (e) {}
     }
 
     function navigateByInput(input) {
-      if (!input) {return;}
-      const href = input.getAttribute('data-language-href');
-      if (!href) {return;}
-      const name = input.getAttribute('data-language-name') || '';
+      if (!input) {
+        return;
+      }
+      const href = input.getAttribute("data-language-href");
+      if (!href) {
+        return;
+      }
+      const name = input.getAttribute("data-language-name") || "";
+      // In the terminal layout, switch language in place (no reload) via the
+      // terminal's seam — it prints its own confirmation + toast, so skip the
+      // reload-only pending toast. Everywhere else, the normal full navigation.
+      const inTerminal =
+        document.documentElement.getAttribute("data-layout") === "terminal";
+      if (
+        inTerminal &&
+        window.Terminal &&
+        typeof window.Terminal.switchLanguage === "function"
+      ) {
+        window.Terminal.switchLanguage(href);
+        return;
+      }
       setPendingToast(name);
       window.location.href = href;
     }
 
     function navigateByLanguageCode(code) {
-      if (!code) {return;}
-      const input = document.querySelector(`input[type="radio"][data-language-code="${code}"][data-language-href]`);
-      if (!input) {return;}
+      if (!code) {
+        return;
+      }
+      const input = document.querySelector(
+        `input[type="radio"][data-language-code="${code}"][data-language-href]`
+      );
+      if (!input) {
+        return;
+      }
       navigateByInput(input);
     }
 
@@ -47,30 +75,40 @@
     // inputs live in the settings panel.
     window.LanguageActions = { setLanguage: navigateByLanguageCode };
 
-    document.querySelectorAll('input[type="radio"][data-language-href]').forEach(function(input) {
-      input.addEventListener('change', function() {
-        navigateByInput(input);
+    document
+      .querySelectorAll('input[type="radio"][data-language-href]')
+      .forEach(function (input) {
+        input.addEventListener("change", function () {
+          navigateByInput(input);
+        });
       });
-    });
 
     // Everything below drives the standalone language dropdown panel, which is
     // optional. When it is absent (unified settings panel), we stop here.
-    if (!toggle || !panel) {return;}
+    if (!toggle || !panel) {
+      return;
+    }
 
     function isGridActive() {
-      const value = document.documentElement.getAttribute('data-grid-overlay');
-      return value !== null && value !== 'closing';
+      const value = document.documentElement.getAttribute("data-grid-overlay");
+      return value !== null && value !== "closing";
     }
 
     function shouldUsePanelPortal() {
-      if (panel.hasAttribute('hidden')) {return false;}
-      if (!window.matchMedia('(min-width: 30em)').matches) {return false;}
+      if (panel.hasAttribute("hidden")) {
+        return false;
+      }
+      if (!window.matchMedia("(min-width: 30em)").matches) {
+        return false;
+      }
       return isGridActive();
     }
 
     function ensurePanelPortalOrigin() {
-      if (panel.__portalPlaceholder) {return;}
-      const placeholder = document.createComment('dropdown-portal-anchor');
+      if (panel.__portalPlaceholder) {
+        return;
+      }
+      const placeholder = document.createComment("dropdown-portal-anchor");
       panel.parentNode.insertBefore(placeholder, panel);
       panel.__portalPlaceholder = placeholder;
     }
@@ -83,7 +121,9 @@
       const gutter = 8;
 
       let left = toggleRect.right - panelWidth;
-      if (left < gutter) {left = gutter;}
+      if (left < gutter) {
+        left = gutter;
+      }
       if (left + panelWidth > viewportWidth - gutter) {
         left = viewportWidth - panelWidth - gutter;
       }
@@ -91,8 +131,8 @@
       panel.style.top = `${toggleRect.bottom + 8}px`;
       panel.style.left = `${Math.max(left, gutter)}px`;
       panel.style.width = `${panelWidth}px`;
-      panel.style.right = 'auto';
-      panel.style.bottom = 'auto';
+      panel.style.right = "auto";
+      panel.style.bottom = "auto";
     }
 
     function mountPanelPortal() {
@@ -100,13 +140,15 @@
       if (panel.parentNode !== document.body) {
         document.body.appendChild(panel);
       }
-      panel.classList.add('dropdown-panel--portal');
-      panel.style.position = 'fixed';
+      panel.classList.add("dropdown-panel--portal");
+      panel.style.position = "fixed";
       positionPanelAtToggle();
     }
 
     function restorePanelPortal(panelEl) {
-      if (!panelEl || !panelEl.classList.contains('dropdown-panel--portal')) {return;}
+      if (!panelEl || !panelEl.classList.contains("dropdown-panel--portal")) {
+        return;
+      }
 
       const placeholder = panelEl.__portalPlaceholder;
       if (placeholder && placeholder.parentNode) {
@@ -115,13 +157,13 @@
       }
 
       panelEl.__portalPlaceholder = null;
-      panelEl.classList.remove('dropdown-panel--portal');
-      panelEl.style.position = '';
-      panelEl.style.top = '';
-      panelEl.style.left = '';
-      panelEl.style.width = '';
-      panelEl.style.right = '';
-      panelEl.style.bottom = '';
+      panelEl.classList.remove("dropdown-panel--portal");
+      panelEl.style.position = "";
+      panelEl.style.top = "";
+      panelEl.style.left = "";
+      panelEl.style.width = "";
+      panelEl.style.right = "";
+      panelEl.style.bottom = "";
     }
 
     function syncLanguagePanelPortal() {
@@ -129,7 +171,7 @@
         mountPanelPortal();
         return;
       }
-      if (document.documentElement.hasAttribute('data-grid-overlay')) {
+      if (document.documentElement.hasAttribute("data-grid-overlay")) {
         return;
       }
       restorePanelPortal(panel);
@@ -137,13 +179,15 @@
 
     function togglePanel(e) {
       e.stopPropagation();
-      const isHidden = panel.hasAttribute('hidden');
+      const isHidden = panel.hasAttribute("hidden");
 
       if (isHidden) {
         closeThemePanel();
-        panel.removeAttribute('hidden');
-        if (overlay) {overlay.removeAttribute('hidden');}
-        toggle.setAttribute('aria-expanded', 'true');
+        panel.removeAttribute("hidden");
+        if (overlay) {
+          overlay.removeAttribute("hidden");
+        }
+        toggle.setAttribute("aria-expanded", "true");
         syncLanguagePanelPortal();
       } else {
         closePanel();
@@ -151,61 +195,67 @@
     }
 
     function closePanel() {
-      if (panel && !panel.hasAttribute('hidden')) {
-        panel.setAttribute('hidden', '');
-        if (overlay) {overlay.setAttribute('hidden', '');}
-        toggle.setAttribute('aria-expanded', 'false');
+      if (panel && !panel.hasAttribute("hidden")) {
+        panel.setAttribute("hidden", "");
+        if (overlay) {
+          overlay.setAttribute("hidden", "");
+        }
+        toggle.setAttribute("aria-expanded", "false");
         syncLanguagePanelPortal();
       }
     }
 
     function closeThemePanel() {
-      const themePanel = document.querySelector('.theme-panel');
-      const themeToggle = document.querySelector('.theme-toggle');
-      const themeOverlay = document.querySelector('.theme-overlay');
+      const themePanel = document.querySelector(".theme-panel");
+      const themeToggle = document.querySelector(".theme-toggle");
+      const themeOverlay = document.querySelector(".theme-overlay");
 
-      if (themePanel && !themePanel.hasAttribute('hidden')) {
-        themePanel.setAttribute('hidden', '');
-        if (themeOverlay) {themeOverlay.setAttribute('hidden', '');}
-        if (themeToggle) {themeToggle.setAttribute('aria-expanded', 'false');}
+      if (themePanel && !themePanel.hasAttribute("hidden")) {
+        themePanel.setAttribute("hidden", "");
+        if (themeOverlay) {
+          themeOverlay.setAttribute("hidden", "");
+        }
+        if (themeToggle) {
+          themeToggle.setAttribute("aria-expanded", "false");
+        }
         restorePanelPortal(themePanel);
       }
     }
 
     // Toggle on click
-    toggle.addEventListener('click', togglePanel);
+    toggle.addEventListener("click", togglePanel);
     syncLanguagePanelPortal();
 
     if (overlay) {
-      overlay.addEventListener('click', closePanel);
+      overlay.addEventListener("click", closePanel);
     }
 
     // Close on click outside
-    document.addEventListener('click', function(e) {
+    document.addEventListener("click", function (e) {
       if (!toggle.contains(e.target) && !panel.contains(e.target)) {
         closePanel();
       }
     });
 
-    const syncOnViewportChange = function() {
-      if (!panel.hasAttribute('hidden')) {
+    const syncOnViewportChange = function () {
+      if (!panel.hasAttribute("hidden")) {
         syncLanguagePanelPortal();
       }
     };
-    window.addEventListener('resize', syncOnViewportChange);
-    window.addEventListener('scroll', syncOnViewportChange, { passive: true });
+    window.addEventListener("resize", syncOnViewportChange);
+    window.addEventListener("scroll", syncOnViewportChange, { passive: true });
 
-    const gridObserver = new MutationObserver(function() {
+    const gridObserver = new MutationObserver(function () {
       syncOnViewportChange();
     });
     gridObserver.observe(document.documentElement, {
       attributes: true,
-      attributeFilter: ['data-grid-overlay']
+      attributeFilter: ["data-grid-overlay"],
     });
 
     // Close on Escape key
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape') {
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
         closePanel();
       }
     });
@@ -215,13 +265,13 @@
     let touchCurrentY = 0;
 
     if (panel && overlay) {
-      panel.addEventListener('touchstart', function(e) {
+      panel.addEventListener("touchstart", function (e) {
         touchStartY = e.changedTouches[0].screenY;
-        panel.style.transition = 'none';
-        overlay.style.transition = 'none';
+        panel.style.transition = "none";
+        overlay.style.transition = "none";
       });
 
-      panel.addEventListener('touchmove', function(e) {
+      panel.addEventListener("touchmove", function (e) {
         touchCurrentY = e.changedTouches[0].screenY;
         const deltaY = touchCurrentY - touchStartY;
 
@@ -233,24 +283,24 @@
           // Update overlay opacity based on drag distance
           const panelHeight = panel.getBoundingClientRect().height;
           const maxDeltaY = window.innerHeight - panelHeight - 8; // 8px from bottom
-          const opacity = 1 - (deltaY / maxDeltaY);
+          const opacity = 1 - deltaY / maxDeltaY;
           overlay.style.opacity = Math.max(opacity, 0);
         }
       });
 
-      panel.addEventListener('touchend', function () {
+      panel.addEventListener("touchend", function () {
         const deltaY = touchCurrentY - touchStartY;
 
-        panel.style.transition = 'transform 0.3s ease-in-out';
-        overlay.style.transition = 'opacity 0.3s ease-in-out';
+        panel.style.transition = "transform 0.3s ease-in-out";
+        overlay.style.transition = "opacity 0.3s ease-in-out";
 
         // Close if dragged down more than 50px
         if (deltaY > 50) {
           closePanel();
         } else {
           // Return to original position
-          panel.style.transform = 'translateY(0)';
-          overlay.style.opacity = '1';
+          panel.style.transform = "translateY(0)";
+          overlay.style.opacity = "1";
         }
 
         touchStartY = 0;

--- a/assets/js/terminal-fs.js
+++ b/assets/js/terminal-fs.js
@@ -1,0 +1,141 @@
+/**
+ * terminal-fs.js — the terminal's filesystem model (window.TerminalFS).
+ *
+ * One authoritative source for "what the site contains": the full-tree manifest
+ * Hugo emits into <script data-js="terminal-manifest"> (see
+ * layouts/partials/terminal-manifest.html). Every reachable node — sections,
+ * every post, standalone pages, a section's tags/ dir — is keyed by its LOGICAL
+ * path (`works`, `works/a-cut-up-world`, `legal/license`), independent of the
+ * real URL slug (works posts live at /englishwork/…, but the terminal dir is
+ * `works/`). The manifest carries the real `url` for fetching; the logical key
+ * is what `ls`/`cd`/`tree`/completion walk.
+ *
+ * This module reads that blob lazily (cached on first use, like the old
+ * terminalManifest()) and exposes a small, pure API the engine reroutes onto.
+ * It replaces the terminal's former scattered model — the top-level-only
+ * manifest, the nav-link-harvested dir tree, the per-cwd ls cache, the
+ * index.json prefetch/seed, and the live-DOM card scrape — all of which were
+ * incrementally rebuilding this same thing at runtime.
+ *
+ * Same data-module pattern as terminal-data.js: an IIFE that publishes a single
+ * window global. Load BEFORE terminal.js, which aliases it at init.
+ */
+(function () {
+  "use strict";
+
+  var manifestCache = null;
+  var treeCache = null;
+
+  // Decode a single path segment the way terminal.js reads hrefs: percent-escapes
+  // resolved (a localized slug g%c3%b6teborgsaffisch → göteborgsaffisch) and
+  // lowercased, so a manifest key matches a typed/derived path exactly.
+  function decodeSeg(seg) {
+    try {
+      return decodeURIComponent(String(seg)).toLowerCase();
+    } catch (e) {
+      return String(seg).toLowerCase(); // malformed escape — keep the raw segment
+    }
+  }
+
+  function normalizeKey(key) {
+    return String(key).split("/").filter(Boolean).map(decodeSeg).join("/");
+  }
+
+  // The raw manifest map, keyed by normalized logical path → {kind, url, title,
+  // tags}. Cached; a malformed/absent blob yields {} (the engine then defaults
+  // unknown nodes to `dir`, exactly as before).
+  function manifest() {
+    if (manifestCache) {
+      return manifestCache;
+    }
+    manifestCache = {};
+    var el = document.querySelector('[data-js="terminal-manifest"]');
+    if (el && el.textContent) {
+      try {
+        var raw = JSON.parse(el.textContent) || {};
+        Object.keys(raw).forEach(function (key) {
+          var norm = normalizeKey(key);
+          if (norm) {
+            manifestCache[norm] = raw[key];
+          }
+        });
+      } catch (e) {
+        /* malformed manifest — fall back to the empty default */
+      }
+    }
+    return manifestCache;
+  }
+
+  function makeNode(name) {
+    return {
+      name: name,
+      kind: "dir",
+      url: null,
+      href: null,
+      title: null,
+      tags: null,
+      children: {},
+    };
+  }
+
+  // The nested tree, built once from the flat manifest by splitting each key on
+  // "/". Intermediate segments that are themselves keys (e.g. `works` under
+  // `works/tags`) get their data when their own key is processed; order doesn't
+  // matter because nodes are create-then-assign.
+  function tree() {
+    if (treeCache) {
+      return treeCache;
+    }
+    var root = makeNode("~");
+    var m = manifest();
+    Object.keys(m).forEach(function (key) {
+      var entry = m[key] || {};
+      var segs = key.split("/").filter(Boolean);
+      if (!segs.length) {
+        return;
+      }
+      var node = root;
+      segs.forEach(function (seg) {
+        if (!node.children[seg]) {
+          node.children[seg] = makeNode(seg);
+        }
+        node = node.children[seg];
+      });
+      node.kind = entry.kind || node.kind || "dir";
+      node.url = entry.url || node.url || null;
+      node.href = node.url; // alias: terminal.js reads node.href for "(cd to list)"
+      node.title = entry.title || node.title || null;
+      node.tags = entry.tags || node.tags || null;
+    });
+    treeCache = root;
+    return root;
+  }
+
+  // Walk the tree to the node at the given (already-normalized) segments, or null.
+  function node(segments) {
+    var n = tree();
+    var segs = segments || [];
+    for (var i = 0; i < segs.length; i++) {
+      n = n.children[segs[i]];
+      if (!n) {
+        return null;
+      }
+    }
+    return n;
+  }
+
+  // Drop the caches so a re-read picks up a fresh manifest — used after an
+  // in-place page swap replaces the manifest blob (Step 2+ of the plan; a no-op
+  // seam today).
+  function refresh() {
+    manifestCache = null;
+    treeCache = null;
+  }
+
+  window.TerminalFS = {
+    manifest: manifest,
+    tree: tree,
+    node: node,
+    refresh: refresh,
+  };
+})();

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -137,8 +137,13 @@
     ) {
       window.CotyScaleActions.init();
     }
-    // Stamp the swapped-in cards' slugs so they render as .md filenames.
-    if (
+    // Re-derive the terminal's view of the page: the i18n catalog, the
+    // fs/tree/nav model and the swapped-in cards' slug stamps. rehydrate()
+    // subsumes the slug-stamping; fall back to the narrower TerminalSlugs seam
+    // if an older engine is loaded.
+    if (window.Terminal && typeof window.Terminal.rehydrate === "function") {
+      window.Terminal.rehydrate();
+    } else if (
       window.TerminalSlugs &&
       typeof window.TerminalSlugs.refresh === "function"
     ) {

--- a/assets/js/terminal-nav.js
+++ b/assets/js/terminal-nav.js
@@ -123,8 +123,10 @@
 
   // Re-run only the content-dependent init a #main swap invalidates. Kept tiny
   // by design (see the file header): lightbox figure focusability, plus the
-  // cheap idempotent Coty init when that engine is loaded.
-  function refreshContentInit() {
+  // cheap idempotent Coty init when that engine is loaded. `doc` is the fetched
+  // document, handed to rehydrate so a language swap can transplant the chrome
+  // that lives outside #main (i18n/manifest/nav/<html lang>).
+  function refreshContentInit(doc) {
     if (
       window.TerminalLightbox &&
       typeof window.TerminalLightbox.refresh === "function"
@@ -138,11 +140,12 @@
       window.CotyScaleActions.init();
     }
     // Re-derive the terminal's view of the page: the i18n catalog, the
-    // fs/tree/nav model and the swapped-in cards' slug stamps. rehydrate()
-    // subsumes the slug-stamping; fall back to the narrower TerminalSlugs seam
-    // if an older engine is loaded.
+    // fs/tree/nav model and the swapped-in cards' slug stamps. rehydrate(doc)
+    // subsumes the slug-stamping (and transplants the language chrome when the
+    // fetched doc differs); fall back to the narrower TerminalSlugs seam if an
+    // older engine is loaded.
     if (window.Terminal && typeof window.Terminal.rehydrate === "function") {
-      window.Terminal.rehydrate();
+      window.Terminal.rehydrate(doc);
     } else if (
       window.TerminalSlugs &&
       typeof window.TerminalSlugs.refresh === "function"
@@ -238,7 +241,7 @@
     } else {
       document.documentElement.removeAttribute("data-terminal-home");
     }
-    refreshContentInit();
+    refreshContentInit(doc);
     settleScroll();
     return true;
   }

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -4803,6 +4803,28 @@
       ) {
         return;
       }
+      // The statusbar language toggle switches language in place (fetch + swap +
+      // rehydrate) rather than full-reloading — the same path a typed `lang`
+      // takes, with a reload fallback when the swap declines. Handled before the
+      // nav-link match, which excludes `.terminal-quick` (a toggle is a language
+      // switch, not a directory change, so it prints no `cd` echo).
+      var langLink =
+        e.target && e.target.closest
+          ? e.target.closest(".terminal-quick--lang[href]")
+          : null;
+      if (langLink) {
+        var langHref = langLink.getAttribute("href");
+        if (langHref && langHref.charAt(0) !== "#") {
+          e.preventDefault();
+          navigateTerminal({
+            type: "navigate",
+            url: langHref,
+            cd: false,
+            lang: true,
+          });
+        }
+        return;
+      }
       var link =
         e.target && e.target.closest
           ? e.target.closest(
@@ -5057,6 +5079,17 @@
       // chrome (i18n/manifest/nav/<html lang>) for a language swap.
       rehydrate: function (sourceDoc) {
         hydrateTerminalSession(sourceDoc);
+      },
+      // Switch language in place from OUTSIDE the command engine — the statusbar
+      // toggle and the settings-panel radio — by running the exact path a typed
+      // `lang` takes (swap + transplant + confirm, or a full-reload fallback when
+      // the gate/fetch declines). Keeps every language switch out of a reload in
+      // terminal layout without duplicating the swap logic.
+      switchLanguage: function (url) {
+        if (!url) {
+          return;
+        }
+        navigateTerminal({ type: "navigate", url: url, cd: false, lang: true });
       },
       captureInput: captureTerminalInput,
       releaseInput: releaseTerminalInput,

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -4790,6 +4790,67 @@
       container.insertBefore(line, anchor);
     }
 
+    // The terminal command a clicked real-page link stands for, or null when the
+    // link doesn't resolve to something the terminal knows (then the caller falls
+    // back to the browser). Content cards are already stamped by
+    // terminalStampSlugs — data-slug → a post (cat), data-dir → a section (cd) —
+    // and that stamp is the terminal name, so it survives the URL-slug rename (a
+    // work lives at /englishwork/…) and the Swedish translation. Nav links are
+    // classified from their logical path by kind, but only when the node is known
+    // (the Swedish nav slug the manifest keys elsewhere returns null → reload).
+    function terminalCommandForClick(target) {
+      if (!target || !target.closest) {
+        return null;
+      }
+      var card = target.closest(".summary-card, .article-card");
+      if (card) {
+        var stamped = card.querySelector("[data-slug], [data-dir]");
+        if (stamped) {
+          var slug = stamped.getAttribute("data-slug");
+          if (slug) {
+            return "cat " + slug + ".md";
+          }
+          var dir = stamped.getAttribute("data-dir");
+          if (dir) {
+            return "cd " + dir;
+          }
+        }
+        return null; // an unstamped card link — leave it to the browser
+      }
+      var navLink = target.closest(
+        ".top-menu__nav a[href]:not(.terminal-quick), .terminal-prompt__host[href]"
+      );
+      if (!navLink) {
+        return null;
+      }
+      var href = navLink.getAttribute("href");
+      if (!href || href.charAt(0) === "#") {
+        return null;
+      }
+      var segs = terminalHrefSegments(href);
+      if (!segs) {
+        return null; // external / non-root-relative
+      }
+      if (!segs.length) {
+        return "cd ~"; // the prompt host / home
+      }
+      var node = terminalNodeAt(segs);
+      if (!node) {
+        return null; // unknown to the terminal → fall back to the reload
+      }
+      var name = segs.join("/");
+      switch (node.kind || terminalNodeKind(name)) {
+        case "file":
+          return "cat " + segs[segs.length - 1] + ".md";
+        case "action":
+          return name;
+        case "exempt":
+          return "open " + name;
+        default:
+          return "cd " + name;
+      }
+    }
+
     // Nav clicks that change page read as `cd <page>` on the next screen.
     document.addEventListener("click", function (e) {
       if (
@@ -4822,6 +4883,25 @@
             cd: false,
             lang: true,
           });
+        }
+        return;
+      }
+      // Clicking a real-page link runs the matching terminal command in place
+      // instead of reloading — a section cds (+ ls), a post/project card cats
+      // itself inline — so the scrollback and prompt survive. Only when the link
+      // resolves to something the terminal knows; otherwise fall through to the
+      // stash + full reload below, exactly as before.
+      var clickCmd = terminalCommandForClick(e.target);
+      if (clickCmd) {
+        e.preventDefault();
+        runTerminalInput(clickCmd);
+        // A directory "opens" — append its listing, matching the rendered
+        // ls-entry behavior (transcript mode, where the session IS the page).
+        if (
+          document.documentElement.hasAttribute("data-terminal-transcript") &&
+          /^cd\s+\S/.test(clickCmd)
+        ) {
+          runTerminalInput("ls");
         }
         return;
       }

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1952,7 +1952,9 @@
           }
           // Switch language by loading the translated page. cd:false so the
           // navigation doesn't print a spurious `cd` echo (same directory,
-          // different language).
+          // different language); lang:true lets navigateTerminal swap it in
+          // place (fetch + transplant the chrome + rehydrate) instead of a full
+          // reload, so the session survives the language change.
           return {
             echo: input,
             lines: [],
@@ -1960,6 +1962,7 @@
               type: "navigate",
               url: languages[langTarget].href,
               cd: false,
+              lang: true,
             },
           };
         }
@@ -2975,14 +2978,23 @@
     // echo already printed to the scrollback, so an in-place swap needs no extra
     // output; on fallback the reload wipes it and the stash reprints it on top.
     function navigateTerminal(action) {
-      var cwd = hrefToCwd(action.url);
+      // A language switch is the same directory in another language, so keep the
+      // current cwd — the target URL carries the NEW language's prefix, which
+      // hrefToCwd (which strips the CURRENT page's prefix) wouldn't recognise, so
+      // deriving from it would misread e.g. /sv/writing/ as ~/sv.
+      var cwd =
+        action.lang === true ? currentTerminalCwd() : hrefToCwd(action.url);
       // In transcript mode the page content (#main) is hidden — it's just the
       // boot transcript's data source — so an in-place #main swap would paint
       // nothing. A `navigate` (open/lang) instead does a full load; the
       // destination re-runs its own boot transcript, keeping the session model.
+      // A language switch is cd:false (same directory) but should still swap in
+      // place — the whole point of the persistent session. Everything else in
+      // the gate stands: transcript mode paints nothing on a #main swap, home is
+      // a CSS-bundled page terminal-nav declines, cross-origin/no-nav can't swap.
       var canSwap =
         !document.documentElement.hasAttribute("data-terminal-transcript") &&
-        action.cd !== false &&
+        (action.cd !== false || action.lang === true) &&
         isTerminalLayout() &&
         cwd !== "~" &&
         isSameOriginUrl(action.url) &&
@@ -2995,8 +3007,29 @@
       window.TerminalNav.go(action.url, { cwd: cwd }).then(function (swapped) {
         if (!swapped) {
           fullReloadNavigate(action);
+          return;
+        }
+        // The swap re-hydrated the engine mid-flight, so TI18N and the language
+        // selector are already the new language — confirm it in that language.
+        if (action.lang === true) {
+          confirmLanguageSwitch();
         }
       });
+    }
+
+    // Print the post-swap language confirmation and raise the same toast the
+    // other terminal settings use. Reads the now-current language off the
+    // freshly transplanted selector so the label is in the new language.
+    function confirmLanguageSwitch() {
+      var here = currentLang();
+      var name = (terminalLanguages()[here] || {}).name || here;
+      printTerminalLine(
+        tiText("langSwitched", "language → %s", name),
+        "terminal-session__out"
+      );
+      if (window.Toast && typeof window.Toast.show === "function") {
+        window.Toast.show("language", name);
+      }
     }
 
     // Render a fetched directory listing by what the cwd IS:
@@ -4824,9 +4857,97 @@
     // the cards' slug stamps. Boot calls it once; an in-place swap (terminal-nav)
     // calls it after replacing #main, so the engine can't keep answering from the
     // previous page's chrome (the "Swedish page, English replies" desync class).
-    // A cross-document chrome transplant (i18n/manifest/nav for the language
-    // swap) is step 3; today the source is always the live DOM.
-    function hydrateTerminalSession() {
+
+    // Transplant the language-differing chrome that lives OUTSIDE #main from a
+    // fetched document into the live DOM — used by a language swap, where the
+    // i18n catalog, manifest, nav and <html lang> all flip. Done by content /
+    // attribute writes IN PLACE, never node replacement: the settings panel, nav
+    // and language radios carry direct-bound listeners (theme.js, settings-
+    // dropdown.js, language-dropdown.js) that a node swap would orphan. The data
+    // scripts have no listeners, so their text is replaced freely. For a
+    // same-language content swap the source equals the live chrome, so this is a
+    // no-op. Decorative non-terminal chrome (panel labels, footer strings) isn't
+    // relocalized here — it lags until the next full load (step 4).
+    function transplantTerminalChrome(sourceDoc) {
+      if (!sourceDoc || !sourceDoc.documentElement) {
+        return;
+      }
+      // 1. Data scripts (no listeners): i18n catalog, fs manifest, welcome text.
+      ["terminal-i18n", "terminal-manifest", "terminal-welcome"].forEach(
+        function (key) {
+          var sel = '[data-js="' + key + '"]';
+          var src = sourceDoc.querySelector(sel);
+          var live = document.querySelector(sel);
+          if (src && live) {
+            live.textContent = src.textContent;
+          }
+        }
+      );
+      // 2. <html> lang + home url. Leave the runtime, localStorage-driven attrs
+      // (data-mode/palette/typography/layout/effect-*/terminal-*) untouched —
+      // they're not in the fetched static markup and are already correct.
+      var srcHtml = sourceDoc.documentElement;
+      var lang = srcHtml.getAttribute("lang");
+      if (lang) {
+        document.documentElement.setAttribute("lang", lang);
+      }
+      var homeUrl = srcHtml.getAttribute("data-home-url");
+      if (homeUrl) {
+        document.documentElement.setAttribute("data-home-url", homeUrl);
+      }
+      // 3. Nav links (incl. the prompt host + the statusbar lang toggle): update
+      // href + label in place so `ls nav`, cd targets and the toggle all track
+      // the new language. The two translations render one template, so the anchor
+      // order matches; a length mismatch means an unexpected shape — skip it.
+      var liveNav = document.querySelectorAll(".top-menu__nav a[href]");
+      var srcNav = sourceDoc.querySelectorAll(".top-menu__nav a[href]");
+      if (liveNav.length && liveNav.length === srcNav.length) {
+        for (var i = 0; i < liveNav.length; i++) {
+          liveNav[i].setAttribute("href", srcNav[i].getAttribute("href") || "");
+          liveNav[i].textContent = srcNav[i].textContent;
+        }
+      }
+      // 4. Language radios: match by code, copy the translated href (the current
+      // language carries none) + checked state, so a later lang/panel switch and
+      // terminalLanguages() target the right pages.
+      var srcLangByCode = {};
+      sourceDoc
+        .querySelectorAll(".language-option input[data-language-code]")
+        .forEach(function (input) {
+          var c = (
+            input.getAttribute("data-language-code") || ""
+          ).toLowerCase();
+          if (c) {
+            srcLangByCode[c] = input;
+          }
+        });
+      document
+        .querySelectorAll(".language-option input[data-language-code]")
+        .forEach(function (input) {
+          var c = (
+            input.getAttribute("data-language-code") || ""
+          ).toLowerCase();
+          var src = srcLangByCode[c];
+          if (!src) {
+            return;
+          }
+          var href = src.getAttribute("data-language-href");
+          if (href) {
+            input.setAttribute("data-language-href", href);
+          } else {
+            input.removeAttribute("data-language-href");
+          }
+          input.checked = src.hasAttribute("checked");
+        });
+    }
+
+    // Given a fetched document (a language swap), transplant the chrome first;
+    // then re-derive. Without a sourceDoc this is the boot / same-language path,
+    // exactly as before.
+    function hydrateTerminalSession(sourceDoc) {
+      if (sourceDoc) {
+        transplantTerminalChrome(sourceDoc);
+      }
       readTerminalCatalog();
       terminalDirTreeCache = null;
       terminalNavTargetsCache = null;
@@ -4932,8 +5053,10 @@
       // in-place navigation has swapped #main. terminal-nav.js calls this so the
       // i18n catalog, the fs/tree/nav model and the card slug stamps track the
       // new page instead of the one that booted. Subsumes TerminalSlugs.refresh.
-      rehydrate: function () {
-        hydrateTerminalSession();
+      // Pass the fetched document to also transplant the language-differing
+      // chrome (i18n/manifest/nav/<html lang>) for a language swap.
+      rehydrate: function (sourceDoc) {
+        hydrateTerminalSession(sourceDoc);
       },
       captureInput: captureTerminalInput,
       releaseInput: releaseTerminalInput,

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -2978,23 +2978,58 @@
     // echo already printed to the scrollback, so an in-place swap needs no extra
     // output; on fallback the reload wipes it and the stash reprints it on top.
     function navigateTerminal(action) {
-      // A language switch is the same directory in another language, so keep the
-      // current cwd — the target URL carries the NEW language's prefix, which
-      // hrefToCwd (which strips the CURRENT page's prefix) wouldn't recognise, so
-      // deriving from it would misread e.g. /sv/writing/ as ~/sv.
-      var cwd =
-        action.lang === true ? currentTerminalCwd() : hrefToCwd(action.url);
-      // In transcript mode the page content (#main) is hidden — it's just the
-      // boot transcript's data source — so an in-place #main swap would paint
-      // nothing. A `navigate` (open/lang) instead does a full load; the
-      // destination re-runs its own boot transcript, keeping the session model.
-      // A language switch is cd:false (same directory) but should still swap in
-      // place — the whole point of the persistent session. Everything else in
-      // the gate stands: transcript mode paints nothing on a #main swap, home is
-      // a CSS-bundled page terminal-nav declines, cross-origin/no-nav can't swap.
+      // A language switch keeps the terminal session and only needs the CHROME
+      // swapped (i18n catalog, manifest, nav, <html lang>), not the visible
+      // #main — so it takes its own in-place path: fetch the translated page,
+      // hydrate the engine from it, push history and confirm, keeping the current
+      // cwd (same directory, new language). That works everywhere a #main swap
+      // can't: transcript mode (where #main is hidden and a swap would paint
+      // nothing) and CSS-bundled pages like home (which the #main-swap route
+      // declines). A full reload is only the fallback when fetch can't run or
+      // fails.
+      if (action.lang === true) {
+        if (
+          isTerminalLayout() &&
+          isSameOriginUrl(action.url) &&
+          typeof window.fetch === "function"
+        ) {
+          window
+            .fetch(action.url, { credentials: "same-origin" })
+            .then(function (res) {
+              return res.ok ? res.text() : Promise.reject();
+            })
+            .then(function (html) {
+              var doc = new DOMParser().parseFromString(html, "text/html");
+              hydrateTerminalSession(doc);
+              try {
+                window.history.pushState(
+                  { terminalLang: true },
+                  "",
+                  action.url
+                );
+              } catch (e) {
+                /* same-origin already checked; ignore a hostile pushState throw */
+              }
+              // Hydrate flipped TI18N + the selector, so this reads in the new
+              // language.
+              confirmLanguageSwitch();
+            })
+            .catch(function () {
+              fullReloadNavigate(action);
+            });
+          return;
+        }
+        fullReloadNavigate(action);
+        return;
+      }
+      // Typed cd/open/home: swap the visible #main in place when we can. In
+      // transcript mode #main is hidden (a swap paints nothing), home is a
+      // CSS-bundled page terminal-nav declines, cross-origin/no-nav can't swap —
+      // those fall back to a full reload, which re-runs the destination's boot.
+      var cwd = hrefToCwd(action.url);
       var canSwap =
         !document.documentElement.hasAttribute("data-terminal-transcript") &&
-        (action.cd !== false || action.lang === true) &&
+        action.cd !== false &&
         isTerminalLayout() &&
         cwd !== "~" &&
         isSameOriginUrl(action.url) &&
@@ -3007,12 +3042,6 @@
       window.TerminalNav.go(action.url, { cwd: cwd }).then(function (swapped) {
         if (!swapped) {
           fullReloadNavigate(action);
-          return;
-        }
-        // The swap re-hydrated the engine mid-flight, so TI18N and the language
-        // selector are already the new language — confirm it in that language.
-        if (action.lang === true) {
-          confirmLanguageSwitch();
         }
       });
     }

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -367,21 +367,16 @@
     // post can scroll the reader to the top of that output (see revealTerminalCat).
     var lastTerminalCmdLine = null;
 
-    // Localized terminal strings, rendered per language by footer.html into
-    // data-js="terminal-i18n". Present on every terminal page; the English
-    // literals in terminal-data.js are the fallback (no-JS build, a missing
-    // catalog, or a parse error), so the terminal never renders blank.
-    var TI18N = (function () {
-      var el = document.querySelector('[data-js="terminal-i18n"]');
-      if (!el || !el.textContent) {
-        return {};
-      }
-      try {
-        return JSON.parse(el.textContent) || {};
-      } catch (e) {
-        return {};
-      }
-    })();
+    // Localized terminal strings + the tables derived from them (help, pseudo-
+    // files, easter eggs), read per language from data-js="terminal-i18n". Held
+    // in reassignable vars, not consts: hydrateTerminalSession() re-reads them
+    // after an in-place page/language swap so the engine can't reply from the
+    // previous language's catalog. The English literals in terminal-data.js are
+    // the fallback (no-JS build, a missing catalog, or a parse error).
+    var TI18N = {};
+    var TERMINAL_HELP = [];
+    var TERMINAL_FILES = {};
+    var TERMINAL_EASTER_EGGS = [];
 
     // A newline-joined i18n block → an array of lines (edge blank lines from the
     // TOML triple-quote trimmed), or the English fallback when the catalog lacks
@@ -406,7 +401,40 @@
     }
 
     var TERMINAL_LAYOUTS = TD.TERMINAL_LAYOUTS || [];
-    const TERMINAL_HELP = tiLines(TI18N.help, TD.TERMINAL_HELP || []);
+
+    // Read data-js="terminal-i18n" and (re)derive the catalog-backed tables.
+    // The single place the catalog is parsed — called at boot and again by
+    // hydrateTerminalSession() after an in-place swap.
+    function readTerminalCatalog() {
+      var el = document.querySelector('[data-js="terminal-i18n"]');
+      TI18N = {};
+      if (el && el.textContent) {
+        try {
+          TI18N = JSON.parse(el.textContent) || {};
+        } catch (e) {
+          TI18N = {}; // malformed catalog — fall back to the English literals
+        }
+      }
+      TERMINAL_HELP = tiLines(TI18N.help, TD.TERMINAL_HELP || []);
+      // Pseudo-files: English literals, then overlay any localized blocks from
+      // the catalog (readme/about/secret/config). welcome and colophon aren't
+      // here — they're reproduced live from the page's own localized DOM.
+      var files = {};
+      var base = TD.TERMINAL_FILES || { welcome: [], colophon: [] };
+      Object.keys(base).forEach(function (k) {
+        files[k] = base[k];
+      });
+      var cat = TI18N.files || {};
+      Object.keys(cat).forEach(function (k) {
+        files[k] = tiLines(cat[k], files[k] || []);
+      });
+      TERMINAL_FILES = files;
+      TERMINAL_EASTER_EGGS = tiLines(
+        TI18N.easterEggs,
+        TD.TERMINAL_EASTER_EGGS || []
+      );
+    }
+    readTerminalCatalog();
 
     const TERMINAL_COMMAND_NAMES = TD.TERMINAL_COMMAND_NAMES || [];
 
@@ -429,27 +457,7 @@
       },
     };
 
-    // Pseudo-files: start from the English literals, then overlay any localized
-    // blocks from the catalog (readme/about/secret/config). welcome and colophon
-    // aren't here — they're reproduced live from the page's own (already
-    // localized) DOM by terminalWelcomeLines / terminalColophonLines.
-    const TERMINAL_FILES = (function () {
-      var base = TD.TERMINAL_FILES || { welcome: [], colophon: [] };
-      var files = {};
-      Object.keys(base).forEach(function (k) {
-        files[k] = base[k];
-      });
-      var cat = TI18N.files || {};
-      Object.keys(cat).forEach(function (k) {
-        files[k] = tiLines(cat[k], files[k] || []);
-      });
-      return files;
-    })();
     const TERMINAL_FORTUNES = TD.TERMINAL_FORTUNES || [];
-    const TERMINAL_EASTER_EGGS = tiLines(
-      TI18N.easterEggs,
-      TD.TERMINAL_EASTER_EGGS || []
-    );
 
     function terminalHost() {
       return (window.location && window.location.hostname) || "tor-bjorn.com";
@@ -4810,7 +4818,27 @@
           }
         });
     }
-    terminalStampSlugs();
+
+    // One entry point for (re)deriving everything the terminal reads from the
+    // page chrome — the i18n catalog and its tables, the fs/tree/nav caches, and
+    // the cards' slug stamps. Boot calls it once; an in-place swap (terminal-nav)
+    // calls it after replacing #main, so the engine can't keep answering from the
+    // previous page's chrome (the "Swedish page, English replies" desync class).
+    // A cross-document chrome transplant (i18n/manifest/nav for the language
+    // swap) is step 3; today the source is always the live DOM.
+    function hydrateTerminalSession() {
+      readTerminalCatalog();
+      terminalDirTreeCache = null;
+      terminalNavTargetsCache = null;
+      if (
+        window.TerminalFS &&
+        typeof window.TerminalFS.refresh === "function"
+      ) {
+        window.TerminalFS.refresh();
+      }
+      terminalStampSlugs();
+    }
+    hydrateTerminalSession();
     window.TerminalSlugs = { refresh: terminalStampSlugs };
 
     // Replay the page's boot transcript into the scrollback (after slugs are
@@ -4899,6 +4927,13 @@
         if (terminalBootRunner) {
           window.setTimeout(terminalBootRunner, 0);
         }
+      },
+      // Re-derive everything the engine reads from the page chrome after an
+      // in-place navigation has swapped #main. terminal-nav.js calls this so the
+      // i18n catalog, the fs/tree/nav model and the card slug stamps track the
+      // new page instead of the one that booted. Subsumes TerminalSlugs.refresh.
+      rehydrate: function () {
+        hydrateTerminalSession();
       },
       captureInput: captureTerminalInput,
       releaseInput: releaseTerminalInput,

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -340,73 +340,12 @@
     var terminalHistory = [];
     var TERMINAL_HISTORY_MAX = 100;
 
-    // Entry labels a remote `ls` fetched, keyed by cwd segments ("works/tags").
-    // An append-only `cd` moves the prompt without loading the directory, so Tab
-    // completion (synchronous, reads only the loaded page + the static tree) has
-    // nothing to offer there. Once you `ls` such a directory we cache what it
-    // held, so completing within it works — matching how you'd naturally `ls`
-    // first, then Tab.
-    var terminalLsDirCache = {};
-
-    // Prefetch the site's JSON feed (index.json — every published page in the
-    // main sections, with its URL) once, and fold each page into the ls cache
-    // under its parent directory. A real shell can complete a path you've never
-    // `cd`'d into because the filesystem is local; this gives the terminal the
-    // same reach, so `cat ~/works/thi⇥` completes from any page, not just from
-    // inside ~/works. Best-effort and purely additive: a real `ls` still
-    // overwrites the cache (fresh wins), and a missing/failed feed just leaves
-    // completion as lazy as it was before.
-    var terminalContentIndexSeeded = false;
-    function terminalSeedContentIndex() {
-      if (terminalContentIndexSeeded || typeof window.fetch !== "function") {
-        return;
-      }
-      terminalContentIndexSeeded = true;
-      var url = terminalHomeUrl().replace(/\/+$/, "") + "/index.json";
-      var pending;
-      try {
-        pending = window.fetch(url, { credentials: "same-origin" });
-      } catch (e) {
-        return; // fetch threw synchronously — leave completion lazy
-      }
-      if (!pending || typeof pending.then !== "function") {
-        return; // not a real fetch (e.g. a bare stub) — nothing to await
-      }
-      pending
-        .then(function (res) {
-          return res.ok ? res.json() : Promise.reject();
-        })
-        .then(function (feed) {
-          ((feed && feed.items) || []).forEach(function (item) {
-            var href = String(item && item.url ? item.url : "").replace(
-              /^[a-z]+:\/\/[^/]+/i,
-              ""
-            );
-            var segs = terminalHrefSegments(href);
-            // A top-level page (segs.length < 2) is already in the tree/manifest
-            // — only the nested posts need seeding.
-            if (!segs || segs.length < 2) {
-              return;
-            }
-            var dirKey = segs.slice(0, -1).join("/");
-            var file = segs[segs.length - 1] + ".md";
-            var list =
-              terminalLsDirCache[dirKey] || (terminalLsDirCache[dirKey] = []);
-            var exists = list.some(function (label) {
-              return label.replace(/[/@*]+$/, "").toLowerCase() === file;
-            });
-            if (!exists) {
-              list.push(file);
-            }
-          });
-          // A ghost the user is already looking at should pick up the newly
-          // known posts without waiting for the next keystroke.
-          terminalUpdateGhost();
-        })
-        .catch(function () {
-          /* no feed / offline — completion stays lazy, exactly as before */
-        });
-    }
+    // The site model — what `ls`/`cd`/`tree`/completion treat as the filesystem
+    // — lives in terminal-fs.js (window.TerminalFS): one full-tree manifest,
+    // read synchronously. It replaced the old scattered model (a top-level-only
+    // manifest, a per-cwd ls cache, and an index.json prefetch that folded posts
+    // into it). Completion now knows every post the instant the page loads, with
+    // no fetch to await, so the former warm-the-cache seed is gone.
 
     // Literal tables — help text, Tab-completion vocabulary, cat-able
     // pseudo-files, fortunes, the easter-egg index, the konami sequence and
@@ -623,28 +562,28 @@
       });
     }
 
-    // A small nested directory tree built from every nav + footer link path,
-    // so `ls`, `tree`, `cd` and Tab completion share one data-driven model of
-    // the "filesystem". Cached like terminalNavTargets — the links are static.
+    // The nested directory tree `ls`, `tree`, `cd` and Tab completion walk.
+    // The authoritative structure — sections, every post, standalone pages —
+    // comes from the full-tree manifest via window.TerminalFS (one synchronous
+    // source, no per-page scraping). Then the nav/footer links are harvested for
+    // the one thing the flat manifest doesn't enumerate: a section's `tags/`
+    // taxonomy dir (works has real tag term pages; the term contents are listed
+    // on demand by remote-ls). Cached — both the manifest and the links are
+    // static for the page's lifetime.
     var terminalDirTreeCache = null;
     function terminalDirTree() {
       if (terminalDirTreeCache) {
         return terminalDirTreeCache;
       }
-      var root = { name: "~", href: terminalHomeUrl(), children: {} };
-      // Seed the top level from the manifest — the authoritative list of what's
-      // in ~ (including footer-only sections like legal that carry no nav link,
-      // and without the noise of harvesting every footer href e.g. index.xml).
-      var manifest = terminalManifest();
-      Object.keys(manifest).forEach(function (seg) {
-        root.children[seg] = {
-          name: seg,
-          href: manifest[seg].url || null,
-          children: {},
-        };
-      });
-      // Then harvest the (relative) nav links for deeper structure — a section's
-      // tags/ and the like.
+      var root = (window.TerminalFS && window.TerminalFS.tree()) || {
+        name: "~",
+        href: terminalHomeUrl(),
+        kind: "dir",
+        children: {},
+      };
+      // Graft the (relative) nav/footer links for a section's tags/ hierarchy —
+      // idempotent: sections and posts are already in the manifest tree, so this
+      // only adds the taxonomy dirs the manifest leaves out.
       var links = document.querySelectorAll(
         ".top-menu__nav a[href]:not(.terminal-quick), .top-menu__link[href]"
       );
@@ -656,7 +595,12 @@
         var node = root;
         segs.forEach(function (seg) {
           if (!node.children[seg]) {
-            node.children[seg] = { name: seg, href: null, children: {} };
+            node.children[seg] = {
+              name: seg,
+              href: null,
+              kind: "dir",
+              children: {},
+            };
           }
           node = node.children[seg];
         });
@@ -736,67 +680,25 @@
       return node;
     }
 
-    // Slugs of the current page's own content links (article / summary cards)
-    // that live under the given section — so `ls` inside e.g. ~/writing lists
-    // the actual posts, which the nav tree can't know about.
-    function terminalPageContentSlugs(sectionSegments) {
-      if (!sectionSegments.length) {
-        return [];
-      }
-      var section = sectionSegments[0];
-      var out = [];
-      var seen = {};
-      document
-        .querySelectorAll(".article-card a[href], .summary-card a[href]")
-        .forEach(function (link) {
-          var segs = terminalHrefSegments(link.getAttribute("href"));
-          if (!segs || segs.length < 2 || segs[0] !== section) {
-            return;
-          }
-          var slug = segs[segs.length - 1];
-          if (seen[slug]) {
-            return;
-          }
-          seen[slug] = true;
-          out.push(slug);
-        });
-      return out;
-    }
-
-    // List a single directory. Structural children come from the nav/footer
-    // tree; for the current directory, the page's own content links are merged
-    // in. Unknown path → an ls-style error; a real page whose contents can't
-    // be listed from here (a different section) → a `cd` hint rather than a
-    // bare empty result.
     // The terminal presents the site as a filesystem, and Hugo tells it what
-    // each top-level thing IS via the manifest emitted in head.html: a section
-    // is a `dir`, a standalone page a `file`, the contact form an `action`, a
-    // visual tool `exempt`. Parsed once; the client no longer guesses.
-    var terminalManifestCache = null;
+    // each thing IS via the full-tree manifest emitted in head.html: a section
+    // is a `dir`, a post/standalone page a `file`, the contact form an `action`,
+    // a visual tool `exempt`. window.TerminalFS parses it once (keys normalized
+    // to decoded, lowercased logical paths); this is the flat map, for the
+    // callers that look a node up by name (cd/cat classification, slug stamping).
     function terminalManifest() {
-      if (terminalManifestCache) {
-        return terminalManifestCache;
-      }
-      terminalManifestCache = {};
-      var el = document.querySelector('[data-js="terminal-manifest"]');
-      if (el && el.textContent) {
-        try {
-          terminalManifestCache = JSON.parse(el.textContent) || {};
-        } catch (e) {
-          /* malformed manifest — fall back to the dir default below */
-        }
-      }
-      return terminalManifestCache;
+      return (window.TerminalFS && window.TerminalFS.manifest()) || {};
     }
 
-    // A top-level segment's kind. Deeper structural nodes (e.g. a section's
-    // `tags/`) aren't in the manifest and default to `dir` — they list children.
+    // A node's kind by its logical path (`works` or `works/a-cut-up-world`).
+    // A path not in the manifest (e.g. a nav-grafted `tags/` dir) defaults to
+    // `dir` — it lists children.
     function terminalNodeKind(name) {
       var e = terminalManifest()[String(name || "").toLowerCase()];
       return (e && e.kind) || "dir";
     }
 
-    // A top-level segment's URL from the manifest — lets the terminal reach a
+    // A logical path's URL from the manifest — lets the terminal reach a
     // footer-only section (legal) that has no nav link to resolve against.
     function terminalManifestUrl(name) {
       var e = terminalManifest()[String(name || "").toLowerCase()];
@@ -805,8 +707,19 @@
 
     // How an entry renders in a listing: dir → `name/`, file → `name.md`,
     // action → `name` (a command), exempt → `name*` (a tool you `open`).
-    function terminalEntryLabel(name) {
-      switch (terminalNodeKind(name)) {
+    // Takes a tree node (kind carried per node, so nested posts label as files)
+    // or a bare top-level name (kind looked up in the manifest).
+    function terminalEntryLabel(nameOrNode) {
+      var name;
+      var kind;
+      if (nameOrNode && typeof nameOrNode === "object") {
+        name = nameOrNode.name;
+        kind = nameOrNode.kind || "dir";
+      } else {
+        name = nameOrNode;
+        kind = terminalNodeKind(name);
+      }
+      switch (kind) {
         case "file":
           return name + ".md";
         case "action":
@@ -1191,27 +1104,16 @@
 
     // A directory's entry labels, kind-formatted (dir → `name/`, file →
     // `name.md`, action → `name`, exempt → `name*`). Shared by the text `ls`
-    // and the clickable `ls` so the two can never list different things.
-    function terminalLsEntryLabels(node, targetSegs, isCwd, showHidden) {
+    // and the clickable `ls` so the two can never list different things. The
+    // children — sections, and each section's posts as files — come straight
+    // from the manifest tree, so a section lists its posts whether or not the
+    // page they live on is the one loaded.
+    function terminalLsEntryLabels(node, showHidden) {
       var entries = Object.keys(node.children)
         .sort()
         .map(function (k) {
-          return terminalEntryLabel(node.children[k].name);
+          return terminalEntryLabel(node.children[k]);
         });
-      if (isCwd) {
-        // The page's own content (posts) are FILES: a post is a .md you `cat`,
-        // not a directory you `cd` into — so it reads like real `ls` and the
-        // prompt stays in the section when you open one.
-        terminalPageContentSlugs(targetSegs).forEach(function (slug) {
-          var entry = slug + ".md";
-          if (
-            entries.indexOf(entry) === -1 &&
-            entries.indexOf(slug + "/") === -1
-          ) {
-            entries.push(entry);
-          }
-        });
-      }
       if (showHidden) {
         entries = [".secret", ".config"].concat(entries);
       }
@@ -1276,7 +1178,7 @@
         ];
       }
       var isCwd = targetSegs.join("/") === terminalCwdSegments().join("/");
-      var entries = terminalLsEntryLabels(node, targetSegs, isCwd, showHidden);
+      var entries = terminalLsEntryLabels(node, showHidden);
       if (!entries.length) {
         // A real page (has an href) that we're not currently on: its contents
         // live on that page, so point there instead of printing nothing.
@@ -1326,14 +1228,19 @@
           out.push(
             keys
               .map(function (k) {
-                return n.children[k].name + "/";
+                return terminalEntryLabel(n.children[k]);
               })
               .join("  ")
           );
         }
         out.push("");
+        // Recurse into directories only (a section, or its tags/ dir — printed
+        // even when empty). A post is a file: it's a leaf, not its own header.
         keys.forEach(function (k) {
-          walk(n.children[k], p + "/" + n.children[k].name);
+          var child = n.children[k];
+          if ((child.kind || "dir") === "dir") {
+            walk(child, p + "/" + child.name);
+          }
         });
       }
       walk(node, path);
@@ -1354,7 +1261,7 @@
           lines.push(
             prefix +
               (last ? "└── " : "├── ") +
-              terminalEntryLabel(node.children[key].name)
+              terminalEntryLabel(node.children[key])
           );
           walk(node.children[key], prefix + (last ? "    " : "│   "));
         });
@@ -2212,16 +2119,19 @@
               action: null,
             };
           }
-          // Append-only: listing the section (or a nested tags dir) you've cd'd
-          // into but haven't loaded (cd only moved the prompt) — fetch it and
-          // print below, without touching anything above.
+          // Append-only fallback: listing a directory the manifest tree can't
+          // resolve — a tag term dir (its posts are symlinks listed on the term
+          // page) or a node absent from the manifest — that you've cd'd into but
+          // haven't loaded. Fetch it and print below, without touching anything
+          // above. A section or any other dir the manifest knows lists
+          // synchronously from the tree in the clickable branch, no fetch.
           if (!lsPaths.length && !lsLong.length) {
             var lsSegs = terminalCwdSegments();
-            // You've cd'd away from the loaded page (live cwd ≠ page cwd), so the
-            // current DOM can't list here → fetch that path and print it below.
+            var lsCwdNode = terminalNodeAt(lsSegs);
             if (
               lsSegs.length &&
-              lsSegs.join("/") !== terminalPageCwdSegments().join("/")
+              lsSegs.join("/") !== terminalPageCwdSegments().join("/") &&
+              (!lsCwdNode || !Object.keys(lsCwdNode.children).length)
             ) {
               var lsUrl = terminalCwdUrl(lsSegs);
               if (lsUrl) {
@@ -2254,12 +2164,7 @@
               var lsTokSegs = terminalResolveSegments(lsPaths[0] || "");
               var lsTokNode = terminalNodeAt(lsTokSegs);
               if (lsTokNode) {
-                var lsTokLabels = terminalLsEntryLabels(
-                  lsTokNode,
-                  lsTokSegs,
-                  lsTokSegs.join("/") === terminalCwdSegments().join("/"),
-                  false
-                );
+                var lsTokLabels = terminalLsEntryLabels(lsTokNode, false);
                 if (lsTokLabels.length) {
                   return {
                     echo: input,
@@ -3345,10 +3250,6 @@
               var doc = new DOMParser().parseFromString(html, "text/html");
               var files = terminalRemoteLsEntries(doc, action.cwd);
               if (files.length) {
-                // Remember what this directory held, so Tab completion works in
-                // it even though the `cd` never loaded its page.
-                terminalLsDirCache[terminalSegmentsOf(action.cwd).join("/")] =
-                  files;
                 // Clickable, like the local `ls` — each post cats itself, each
                 // tag dir cds into it.
                 printTerminalLsList(
@@ -4347,40 +4248,23 @@
             ? terminalCwdSegments()
             : terminalResolveSegments(dirPart);
         var node = terminalNodeAt(dirSegs);
-        var names = node
-          ? Object.keys(node.children).filter(function (name) {
-              return name.indexOf(filePart) === 0;
-            })
-          : [];
-        // cat/open reach the page's posts too — complete them as .md files.
-        if (verb === "cat" || verb === "open") {
-          terminalPageContentSlugs(dirSegs).forEach(function (slug) {
-            var file = slug + ".md";
-            if (file.indexOf(filePart) === 0 && names.indexOf(file) === -1) {
-              names.push(file);
+        // The manifest tree knows the whole directory synchronously — sections,
+        // and each section's posts as files — so completion reaches any post the
+        // instant the page loads, with no cache to warm. cat/open complete a post
+        // as `name.md` (you cat a file); cd/ls complete it bare.
+        var names = [];
+        if (node) {
+          Object.keys(node.children).forEach(function (name) {
+            var child = node.children[name];
+            var display =
+              (verb === "cat" || verb === "open") && child.kind === "file"
+                ? name + ".md"
+                : name;
+            if (display.toLowerCase().indexOf(filePart) === 0) {
+              names.push(display);
             }
           });
         }
-        // A directory you `cd`'d into but never loaded isn't in the tree or the
-        // live DOM — but if you `ls`'d it, its entries are cached. Offer dir
-        // names to cd, and (for cat/open) its files as .md, stripping the
-        // classify markers (`/`, `@`) so they complete like real names.
-        (terminalLsDirCache[dirSegs.join("/")] || []).forEach(function (label) {
-          if (/\/$/.test(label)) {
-            var dir = label.slice(0, -1).toLowerCase();
-            if (dir.indexOf(filePart) === 0 && names.indexOf(dir) === -1) {
-              names.push(dir);
-            }
-          } else if (
-            (verb === "cat" || verb === "open") &&
-            /\.md@?$/i.test(label)
-          ) {
-            var file = label.replace(/@$/, "").toLowerCase();
-            if (file.indexOf(filePart) === 0 && names.indexOf(file) === -1) {
-              names.push(file);
-            }
-          }
-        });
         candidates = names.map(function (name) {
           return dirPart + name;
         });
@@ -4394,9 +4278,6 @@
       if (!terminalInput) {
         return;
       }
-      // An explicit completion request is a hard signal to warm the page-index
-      // cache, in case the prompt was never focused first (e.g. a key-bar Tab).
-      terminalSeedContentIndex();
       var candidates = terminalCompletionFor(terminalInput.value).candidates;
       if (candidates.length === 1) {
         var parts = terminalInput.value.split(/\s+/);
@@ -4491,11 +4372,7 @@
       });
       // The inline suggestion is only meaningful while typing: refresh it on
       // focus, clear it on blur so it doesn't linger under the idle caret.
-      // Focusing the prompt is also the first sign the user is about to type,
-      // so warm the page-index cache now — the completion for an unvisited
-      // directory needs it, and it's a one-shot fetch.
       terminalInput.addEventListener("focus", function () {
-        terminalSeedContentIndex();
         terminalUpdateGhost();
       });
       terminalInput.addEventListener("blur", function () {

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -4997,8 +4997,9 @@
     // dropdown.js, language-dropdown.js) that a node swap would orphan. The data
     // scripts have no listeners, so their text is replaced freely. For a
     // same-language content swap the source equals the live chrome, so this is a
-    // no-op. Decorative non-terminal chrome (panel labels, footer strings) isn't
-    // relocalized here — it lags until the next full load (step 4).
+    // no-op. The terminal's own prompt line (the exit hint + input label) IS
+    // relocalized; decorative non-terminal chrome (settings-panel labels, the
+    // footer strings) isn't — it lags until the next full load.
     function transplantTerminalChrome(sourceDoc) {
       if (!sourceDoc || !sourceDoc.documentElement) {
         return;
@@ -5070,6 +5071,25 @@
           }
           input.checked = src.hasAttribute("checked");
         });
+      // 5. The live prompt line's localized text. It lives in .terminal-tail,
+      // which also holds the real <input> (direct-bound listeners) — so copy
+      // the strings IN PLACE, never replace the node: the exit hint (a CSS
+      // ::after content: attr(data-exit-hint), so writing the attribute
+      // re-renders it) and the sr-only input label. Without this the prompt
+      // keeps whispering the boot language after an in-place language swap.
+      var srcTail = sourceDoc.querySelector(".terminal-tail");
+      var liveTail = document.querySelector(".terminal-tail");
+      if (srcTail && liveTail) {
+        var exitHint = srcTail.getAttribute("data-exit-hint");
+        if (exitHint !== null) {
+          liveTail.setAttribute("data-exit-hint", exitHint);
+        }
+        var srcLabel = srcTail.querySelector('label[for="terminal-input"]');
+        var liveLabel = liveTail.querySelector('label[for="terminal-input"]');
+        if (srcLabel && liveLabel) {
+          liveLabel.textContent = srcLabel.textContent;
+        }
+      }
     }
 
     // Given a fetched document (a language swap), transplant the chrome first;

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -580,6 +580,9 @@ other = "cat: cannot reach %s"
 [terminal_pager_more]
 other = "--More--  +%s more · tap"
 
+[terminal_lang_switched]
+other = "language → %s"
+
 [terminal_err_cat_isdir]
 other = "cat: %s: Is a directory — try: ls %s/"
 

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -574,6 +574,9 @@ other = "cat: når inte %s"
 [terminal_pager_more]
 other = "--More--  +%s rader · tryck"
 
+[terminal_lang_switched]
+other = "språk → %s"
+
 [terminal_err_cat_isdir]
 other = "cat: %s: Är en katalog — testa: ls %s/"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -190,7 +190,8 @@
           "catUnreachable" (i18n "terminal_err_cat_unreachable")
           "catIsDir" (i18n "terminal_err_cat_isdir")
           "notFound" (i18n "terminal_err_not_found")
-          "pagerMore" (i18n "terminal_pager_more"))
+          "pagerMore" (i18n "terminal_pager_more")
+          "langSwitched" (i18n "terminal_lang_switched"))
         "flows" (dict
           "contactIntro" (i18n "terminal_flow_contact_intro")
           "subscribeIntro" (i18n "terminal_flow_subscribe_intro")

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -792,6 +792,7 @@
   {{ $js21 := resources.Get "js/ui-library-pantone-scales.js" }}
   {{ $js_lightbox := resources.Get "js/lightbox.js" }}
   {{ $js_terminal_data := resources.Get "js/terminal-data.js" }}
+  {{ $js_terminal_fs := resources.Get "js/terminal-fs.js" }}
   {{ $js_terminal := resources.Get "js/terminal.js" }}
   {{ $js_terminal_flows := resources.Get "js/terminal-flows.js" }}
   {{ $js_terminal_nav := resources.Get "js/terminal-nav.js" }}
@@ -820,6 +821,7 @@
     <script src="{{ $js4.RelPermalink }}" defer></script>
     <script src="{{ $js_theme_pantone.RelPermalink }}" defer></script>
     <script src="{{ $js_terminal_data.RelPermalink }}" defer></script>
+    <script src="{{ $js_terminal_fs.RelPermalink }}" defer></script>
     <script src="{{ $js_terminal.RelPermalink }}" defer></script>
     <script src="{{ $js_terminal_flows.RelPermalink }}" defer></script>
     <script src="{{ $js5.RelPermalink }}" defer></script>
@@ -857,7 +859,7 @@
     <script src="{{ $js_terminal_ai.RelPermalink }}" defer></script>
   {{ else }}
     <!-- JavaScript production -->
-    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js_custom_palette $js4 $js_theme_pantone $js_terminal_data $js_terminal $js_terminal_flows $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav $js_terminal_ai_data $js_terminal_ai }}
+    {{ $js := slice $js1 $js2 $js3 $js_toast $js_theme_derive $js_custom_palette $js4 $js_theme_pantone $js_terminal_data $js_terminal_fs $js_terminal $js_terminal_flows $js5 $js6 $js8 $js11 $js_theme_share $js12 $js13 $js14 $js15 $js16 $js17 $js20 $js_lightbox $js_terminal_nav $js_terminal_ai_data $js_terminal_ai }}
     {{ $js = $js | resources.Concat "js.js" | minify | fingerprint }}
     <script src="{{ $js.RelPermalink }}" defer></script>
     {{ $pageJs := slice }}

--- a/layouts/partials/terminal-manifest.html
+++ b/layouts/partials/terminal-manifest.html
@@ -1,22 +1,33 @@
-{{/* Terminal filesystem manifest: maps each top-level segment to its kind and
-  URL so the terminal classifies ls/cd/tree and can fetch a dir without a
-  hardcoded guess. Sections are directories, standalone top-level pages are
-  files; a page overrides its kind via a `terminal_kind` param (contact =
-  action). The visual tools (terminal_kind = exempt) can't render as a
-  terminal, so they're left OUT of the filesystem entirely — not listed by
-  `ls`, not reachable by cd/open. The URL lets the terminal reach
-  footer-only sections (legal) that aren't in the nav.
+{{/* Terminal filesystem manifest: the full site tree the terminal treats as its
+  filesystem, keyed by LOGICAL path so `ls`/`cd`/`tree`/completion know every
+  node synchronously (no runtime scraping — see assets/js/terminal-fs.js).
+
+  Each entry maps a logical path → {kind, url, title, tags?}:
+  - Sections are `dir`s (works, writing, newsletter, legal).
+  - Every post / standalone page is a `file`; a page overrides its kind via a
+  `terminal_kind` param (contact = action). `hidden`/`exempt` pages are left
+  OUT entirely — not listed by ls, not reachable by cd/open.
+  - The `url` is the real RelPermalink (used to fetch a post's body); the key
+  is the LOGICAL path, which can differ (works posts live at /englishwork/…
+  but the terminal dir is `works/`). We rebuild the logical path from
+  `.Section` + the tail of the URL, so the renamed section slug never leaks
+  into the tree.
+
+  Section `tags/` taxonomy dirs aren't enumerated here — the terminal grafts
+  those from nav/footer links, and term contents load on demand via remote-ls.
 
   A returning partial so head.html emits it as the terminal-manifest JSON and
   the template-render tests can assert the mapping without rendering all of
   head.html.
 */}}
 {{- $kinds := dict -}}
+{{- $sectionNames := slice -}}
 {{- range site.Sections -}}
   {{- $k := "dir" -}}
   {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
   {{- if ne $k "exempt" -}}
-    {{- $kinds = merge $kinds (dict .Section (dict "kind" $k "url" .RelPermalink)) -}}
+    {{- $sectionNames = append .Section $sectionNames -}}
+    {{- $kinds = merge $kinds (dict .Section (dict "kind" $k "url" .RelPermalink "title" .Title)) -}}
   {{- end -}}
 {{- end -}}
 {{- range where site.RegularPages "Kind" "page" -}}
@@ -24,11 +35,39 @@
   {{- $rel = strings.TrimPrefix (printf "%s/" .Language.Lang) $rel -}}
   {{- $rel = strings.Trim $rel "/" -}}
   {{- $segs := split $rel "/" -}}
+  {{- $section := .Section -}}
   {{- $tk := .Params.terminal_kind | default "" -}}
-  {{- if and (eq (len $segs) 1) (ne $tk "hidden") (ne $tk "exempt") -}}
+  {{/* Include a page only when it belongs to a real (non-exempt) content
+    section, or is a standalone top-level page. This keeps taxonomy/term
+    bundles (clients, employers) out of the filesystem, as before.
+  */}}
+  {{- $include := false -}}
+  {{- if $section -}}
+    {{- if in $sectionNames $section -}}{{ $include = true }}{{- end -}}
+  {{- else if eq (len $segs) 1 -}}
+    {{- $include = true -}}
+  {{- end -}}
+  {{- if and $include (ne $tk "hidden") (ne $tk "exempt") -}}
     {{- $k := "file" -}}
     {{- with .Params.terminal_kind }}{{ $k = . }}{{ end -}}
-    {{- $kinds = merge $kinds (dict (index $segs 0) (dict "kind" $k "url" .RelPermalink)) -}}
+    {{/* Logical path: the section name (not its URL slug) + the URL tail, built
+      as a string so the renamed section slug never leaks into the key. A
+      standalone top-level page keeps its single segment.
+    */}}
+    {{- $key := delimit $segs "/" -}}
+    {{- if $section -}}
+      {{- $tail := after 1 $segs -}}
+      {{- if gt (len $tail) 0 -}}
+        {{- $key = printf "%s/%s" $section (delimit $tail "/") -}}
+      {{- else -}}
+        {{- $key = $section -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $entry := dict "kind" $k "url" .RelPermalink "title" .Title -}}
+    {{- with .Params.tags }}
+      {{ $entry = merge $entry (dict "tags" .) }}
+    {{ end -}}
+    {{- $kinds = merge $kinds (dict $key $entry) -}}
   {{- end -}}
 {{- end -}}
 {{- return $kinds -}}

--- a/test/hugo-render.test.js
+++ b/test/hugo-render.test.js
@@ -181,6 +181,19 @@ describeOrSkip("Hugo template rendering", () => {
       expect(manifest()["docs"]).toMatchObject({ kind: "action" });
     });
 
+    test("widened to the full tree: a section's nested post is a file, keyed by its logical path", () => {
+      const m = manifest();
+      // sample-work lives at employer-fixture/sample-work/ — a depth-2 page the
+      // old top-level-only manifest never emitted. It's now a file under its
+      // section, keyed by the logical path (section name + tail), not flattened
+      // to a bare slug.
+      expect(m["employer-fixture/sample-work"]).toMatchObject({
+        kind: "file",
+        url: "/employer-fixture/sample-work/",
+      });
+      expect(m).not.toHaveProperty("sample-work");
+    });
+
     test("exempt sections and hidden pages are left out entirely", () => {
       const m = manifest();
       expect(m).not.toHaveProperty("tools"); // terminal_kind: exempt


### PR DESCRIPTION
The cumulative PR for the whole Väg 3 arc — the terminal persistent-session
architecture from `docs/terminal-architecture-plan.md` (#260). The branches are
stacked, so this branch (`claude/vag-3-steg-4b-links-t7c2wn`) contains **all five
steps plus two follow-up fixes**, and its Netlify deploy preview is the full
total to review.

**Preview:** https://deploy-preview-262--tor-bjorn.netlify.app

### The five steps
1. **Consolidate the site-model** into one full-tree manifest + `terminal-fs.js`; retire the per-cwd ls cache, the `index.json` prefetch/seed, and the live-DOM card scrape (also open standalone as #261).
2. **Extract `session.hydrate()`** — one re-entrant function that re-reads the i18n catalog and resets the fs/tree/nav caches; boot and swap both call it.
3. **Language swap in place** — a typed `lang`/`set language` fetches the translated page, transplants the language-differing chrome (i18n/manifest/nav/`<html lang>`) and re-hydrates, then confirms in the new language — no reload.
4. **Toggle + panel radio** routed through the same language swap, so *every* language switch in the terminal layout avoids a reload.
5. **Internal link clicks as commands** — clicking a nav link / content card in the terminal layout runs the matching command (`cd` + `ls`, or `cat` inline) instead of full-loading; the scrollback and prompt survive.

### Follow-up fixes (from live testing on the preview)
6. **Transcript-mode reload** — the real terminal always boots in transcript mode (`data-terminal-transcript`), where the `#main`-swap gate forced a full reload; give the language switch its own chrome-only path (fetch → hydrate → pushState → confirm) so it swaps in place in transcript mode and on home too.
7. **Relocalize the prompt line** — the exit hint (a CSS `::after` reading `data-exit-hint`) and the sr-only input label are server-rendered and weren't transplanted, so the prompt kept the boot language after a swap; copy them in place (never replacing the live `<input>`).

Because the branches are stacked, this contains #261&#39;s step-1 commit too — it is the **superset** of the arc. Verified locally: `npm test` green (704 passing), eslint + prettier clean; CI `quality` job + Netlify deploy green on the head commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)