### PR TITLE
Page cross-fade + brand wordmark retract on navigation

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -223,7 +223,12 @@ html[data-grid-overlay] .top-menu {
 .brand__mark {
   display: block;
   height: 1.5rem;
-  width: 6rem;
+  /* Rest width = the loop only (progressbar.js sets it to the loop width at
+     scroll 0 on every load). Matching that here avoids a first-paint shrink
+     from 6rem → ~1.5rem, which otherwise reflowed the header and — with view
+     transitions — popped against the captured snapshot. It still grows on
+     scroll via the inline width set by progressbar.js. */
+  width: 1.5rem;
   color: var(--text-default);
   max-width: 100%;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -57,59 +57,6 @@ body {
   }
 }
 
-/* || ========== View transitions (cross-document) --------------- */
-
-/* Native, JS-free transitions between page navigations (same-origin, MPA —
-   which is exactly what this Hugo site is). Progressive enhancement: browsers
-   without support just navigate as before. The default is a brief root
-   cross-fade. Supported in Chromium 126+ and Safari 18.2+. */
-@view-transition {
-  navigation: auto;
-}
-
-/* The feel of the page cross-fade. This is the main knob — adjust duration and
-   easing here, or swap the animation entirely (e.g. a directional slide). */
-::view-transition-old(root),
-::view-transition-new(root) {
-  animation-duration: 280ms;
-  animation-timing-function: ease;
-}
-
-/* The header is present on every page: give it its own transition group so it
-   isn't cross-faded as part of the page root… */
-.top-menu {
-  view-transition-name: top-menu;
-}
-
-/* …and hold that group static instead of fading it. A named group still gets a
-   default cross-fade, and the header's content differs per page (active link,
-   the scroll-progress wordmark), so without this it visibly flickers even
-   though it stays in the same place. */
-::view-transition-group(top-menu),
-::view-transition-old(top-menu),
-::view-transition-new(top-menu) {
-  animation: none;
-}
-
-/* While a navigation transition is running, pause the scroll-reveal entry
-   animation (the `is-view-transition` flag is set/cleared by a head script on
-   pagereveal → viewTransition.finished). This keeps content in place for the
-   cross-fade instead of it sliding in over the transition; once the transition
-   finishes the flag is removed and anything still below the fold reveals on
-   scroll as usual. Browsers without view transitions keep reveal throughout. */
-:root.is-view-transition .reveal {
-  opacity: 1;
-  transform: none;
-  transition: none;
-}
-
-/* Honour the OS "reduce motion" preference: skip the navigation transition. */
-@media (prefers-reduced-motion: reduce) {
-  @view-transition {
-    navigation: none;
-  }
-}
-
 /* || ========== Transitions ------------------------------------- */
 
 /* Theme-swap transition for theme-driven surfaces, text, borders, and icons. */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -57,6 +57,29 @@ body {
   }
 }
 
+/* || ========== View transitions (cross-document) --------------- */
+
+/* Native, JS-free transitions between page navigations (same-origin, MPA —
+   which is exactly what this Hugo site is). Progressive enhancement: browsers
+   without support just navigate as before. The default is a brief root
+   cross-fade. Supported in Chromium 126+ and Safari 18.2+. */
+@view-transition {
+  navigation: auto;
+}
+
+/* The header is present on every page: give it a stable transition name so it
+   holds steady across the navigation instead of cross-fading with the page. */
+.top-menu {
+  view-transition-name: top-menu;
+}
+
+/* Honour the OS "reduce motion" preference: skip the navigation transition. */
+@media (prefers-reduced-motion: reduce) {
+  @view-transition {
+    navigation: none;
+  }
+}
+
 /* || ========== Transitions ------------------------------------- */
 
 /* Theme-swap transition for theme-driven surfaces, text, borders, and icons. */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -103,6 +103,17 @@ body {
   }
 }
 
+/* Honour the site's own "Reduce motion" setting too (data-effect-reduced-motion,
+   set pre-paint in head.html). `@view-transition { navigation }` can't be gated
+   on an attribute, so neutralise the snapshot animations instead: the page still
+   swaps, but instantly — no cross-fade — matching the OS-preference behaviour. */
+:root[data-effect-reduced-motion="on"]::view-transition-group(*),
+:root[data-effect-reduced-motion="on"]::view-transition-image-pair(*),
+:root[data-effect-reduced-motion="on"]::view-transition-old(*),
+:root[data-effect-reduced-motion="on"]::view-transition-new(*) {
+  animation: none !important;
+}
+
 /* || ========== Transitions ------------------------------------- */
 
 /* Theme-swap transition for theme-driven surfaces, text, borders, and icons. */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -57,6 +57,52 @@ body {
   }
 }
 
+/* || ========== View transitions (cross-document) --------------- */
+
+/* Native page-to-page cross-fade for same-origin navigations (this Hugo site
+   is a multi-page app). Progressive enhancement: browsers without support just
+   navigate as before. Chromium 126+ and Safari 18.2+ today. */
+@view-transition {
+  navigation: auto;
+}
+
+/* Keep the fade short so the wordmark "hold, then retract" (progressbar.js)
+   reads as snappy rather than delayed. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 200ms;
+}
+
+/* The header is on every page: give it its own group and hold it static instead
+   of cross-fading it (its content differs per page — active link, the
+   scroll-progress wordmark — so a plain cross-fade flickers). Its icons are
+   inlined in topmenu.html so they render in the snapshot rather than blinking. */
+.top-menu {
+  view-transition-name: top-menu;
+}
+::view-transition-group(top-menu),
+::view-transition-old(top-menu),
+::view-transition-new(top-menu) {
+  animation: none;
+}
+
+/* Pause the scroll-reveal entry animation while the transition runs, so content
+   doesn't slide in over the cross-fade. The flag is set/cleared by a head
+   script (pagereveal → viewTransition.finished); below-fold elements resume
+   revealing on scroll afterwards. */
+:root.is-view-transition .reveal {
+  opacity: 1;
+  transform: none;
+  transition: none;
+}
+
+/* Honour the OS "reduce motion" preference: skip the navigation transition. */
+@media (prefers-reduced-motion: reduce) {
+  @view-transition {
+    navigation: none;
+  }
+}
+
 /* || ========== Transitions ------------------------------------- */
 
 /* Theme-swap transition for theme-driven surfaces, text, borders, and icons. */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -67,10 +67,20 @@ body {
   navigation: auto;
 }
 
-/* The header is present on every page: give it a stable transition name so it
-   holds steady across the navigation instead of cross-fading with the page. */
+/* The header is present on every page: give it its own transition group so it
+   isn't cross-faded as part of the page root… */
 .top-menu {
   view-transition-name: top-menu;
+}
+
+/* …and hold that group static instead of fading it. A named group still gets a
+   default cross-fade, and the header's content differs per page (active link,
+   the scroll-progress wordmark), so without this it visibly flickers even
+   though it stays in the same place. */
+::view-transition-group(top-menu),
+::view-transition-old(top-menu),
+::view-transition-new(top-menu) {
+  animation: none;
 }
 
 /* Honour the OS "reduce motion" preference: skip the navigation transition. */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -83,6 +83,17 @@ body {
   animation: none;
 }
 
+/* Where cross-document view transitions run, they ARE the page-to-page motion,
+   so skip the scroll-reveal entry animation — otherwise content sits hidden in
+   the new page's snapshot and slides in over the cross-fade, which reads as a
+   jump. Browsers without view transitions (e.g. Firefox today) keep reveal.
+   The flag is set by a head script that feature-detects `onpagereveal`. */
+:root.has-view-transitions .reveal {
+  opacity: 1;
+  transform: none;
+  transition: none;
+}
+
 /* Honour the OS "reduce motion" preference: skip the navigation transition. */
 @media (prefers-reduced-motion: reduce) {
   @view-transition {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -70,7 +70,7 @@ body {
    reads as snappy rather than delayed. */
 ::view-transition-old(root),
 ::view-transition-new(root) {
-  animation-duration: 200ms;
+  animation-duration: var(--motion-duration-view-transition);
 }
 
 /* The header is on every page: give it its own group and hold it static instead

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -67,6 +67,14 @@ body {
   navigation: auto;
 }
 
+/* The feel of the page cross-fade. This is the main knob — adjust duration and
+   easing here, or swap the animation entirely (e.g. a directional slide). */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 280ms;
+  animation-timing-function: ease;
+}
+
 /* The header is present on every page: give it its own transition group so it
    isn't cross-faded as part of the page root… */
 .top-menu {
@@ -83,12 +91,13 @@ body {
   animation: none;
 }
 
-/* Where cross-document view transitions run, they ARE the page-to-page motion,
-   so skip the scroll-reveal entry animation — otherwise content sits hidden in
-   the new page's snapshot and slides in over the cross-fade, which reads as a
-   jump. Browsers without view transitions (e.g. Firefox today) keep reveal.
-   The flag is set by a head script that feature-detects `onpagereveal`. */
-:root.has-view-transitions .reveal {
+/* While a navigation transition is running, pause the scroll-reveal entry
+   animation (the `is-view-transition` flag is set/cleared by a head script on
+   pagereveal → viewTransition.finished). This keeps content in place for the
+   cross-fade instead of it sliding in over the transition; once the transition
+   finishes the flag is removed and anything still below the fold reveals on
+   scroll as usual. Browsers without view transitions keep reveal throughout. */
+:root.is-view-transition .reveal {
   opacity: 1;
   transform: none;
   transition: none;

--- a/assets/css/tokens/semantic.css
+++ b/assets/css/tokens/semantic.css
@@ -120,6 +120,11 @@
   --motion-stagger-step: 25ms;
   --motion-delay-reveal-step: 220ms;
 
+  /* Navigation motion. The page cross-fade (view transitions) and the brand
+     wordmark retract on navigation; read in style.css and progressbar.js. */
+  --motion-duration-view-transition: var(--motion-duration-base);
+  --motion-duration-brand-retract: var(--motion-duration-slow);
+
   --motion-ease-standard: ease;
   --motion-ease-decelerate: ease-out;
   --motion-ease-accelerate: ease-in;

--- a/assets/js/progressbar.js
+++ b/assets/js/progressbar.js
@@ -18,7 +18,30 @@ let rightMaxPx = 0;
 // progress; the next page paints that length, then tweens it to zero — after
 // the view transition (if one is running) so the two motions don't fight.
 const BRAND_PROGRESS_KEY = "brandProgress";
-const INTRO_DURATION_MS = 300;
+
+// Retract duration comes from the --motion-duration-brand-retract token so CSS
+// and JS share one source of truth; fall back if it's unavailable.
+function readDurationToken(name, fallbackMs) {
+  try {
+    var v = getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+    if (v.endsWith("ms")) {
+      return parseFloat(v);
+    }
+    if (v.endsWith("s")) {
+      return parseFloat(v) * 1000;
+    }
+  } catch (e) {
+    /* getComputedStyle unavailable — use the fallback */
+  }
+  return fallbackMs;
+}
+
+const INTRO_DURATION_MS = readDurationToken(
+  "--motion-duration-brand-retract",
+  300
+);
 let introRafId = null;
 let introPlaying = false;
 

--- a/assets/js/progressbar.js
+++ b/assets/js/progressbar.js
@@ -248,8 +248,17 @@ updateMetrics();
     cancelIntro();
   };
 
-  // Retract on the next frame (once the starting length has painted).
-  requestAnimationFrame(start);
+  // If a cross-document view transition is running, retract once it finishes so
+  // the tween doesn't play under the frozen header snapshot (the wordmark holds
+  // its length through the short fade, then retracts); otherwise retract now.
+  requestAnimationFrame(function () {
+    var vt = window.__pageViewTransition;
+    if (vt && vt.finished && typeof vt.finished.then === "function") {
+      vt.finished.then(start, start);
+    } else {
+      start();
+    }
+  });
 
   window.addEventListener("scroll", onUserScroll, { once: true, passive: true });
 })();

--- a/assets/js/progressbar.js
+++ b/assets/js/progressbar.js
@@ -13,6 +13,15 @@ const loopHeight = 24;
 let leftMaxPx = 0;
 let rightMaxPx = 0;
 
+// On navigation the scroll-progress dash retracts from its previous length back
+// to the resting loop instead of snapping. The leaving page stashes its
+// progress; the next page paints that length, then tweens it to zero — after
+// the view transition (if one is running) so the two motions don't fight.
+const BRAND_PROGRESS_KEY = "brandProgress";
+const INTRO_DURATION_MS = 460;
+let introRafId = null;
+let introPlaying = false;
+
 function updateMetrics() {
   const brandContainer = brandMark ? brandMark.parentElement : null;
   const headerContainer = brandContainer
@@ -48,40 +57,22 @@ function markBrandReady() {
   rootElement.setAttribute("data-brand-ready", "true");
 }
 
-function scheduleProgressUpdate() {
-  if (rafId !== null) {
-    return;
-  }
-  rafId = requestAnimationFrame(() => {
-    rafId = null;
-    progressBar();
-  });
+function prefersReducedMotion() {
+  return (
+    (rootElement &&
+      rootElement.getAttribute("data-effect-reduced-motion") === "on") ||
+    (typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches)
+  );
 }
 
-function progressBar() {
+// Paint the mark for a given 0..1 progress. Shared by the scroll handler and
+// the retract tween so both draw the dash identically (no distortion).
+function renderProgress(progress) {
   if (!brandMark || !brandLineLeft || !brandLineRight || !brandLoop) {
     return;
   }
-  var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
-  var height =
-    document.documentElement.scrollHeight -
-    document.documentElement.clientHeight;
-  var progress = height > 0 ? winScroll / height : 0;
-
   progress = Math.min(Math.max(progress, 0), 1);
-
-  const isCompact =
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(max-width: 47.9375em)").matches;
-
-  // The terminal layout shows the curl as a static letter-sized glyph: no
-  // scroll progress, so the side lines stay at zero and the mark is loop-only.
-  const isTerminal =
-    rootElement && rootElement.getAttribute("data-layout") === "terminal";
-
-  if (isCompact || isTerminal) {
-    progress = 0;
-  }
 
   const leftLength = leftMaxPx * progress;
   const rightLength = rightMaxPx * progress;
@@ -105,6 +96,83 @@ function progressBar() {
   markBrandReady();
 }
 
+// Progress from the current scroll position (0 on compact/terminal layouts,
+// where the mark is a static loop-only glyph).
+function scrollProgress() {
+  var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
+  var height =
+    document.documentElement.scrollHeight -
+    document.documentElement.clientHeight;
+  var progress = height > 0 ? winScroll / height : 0;
+
+  const isCompact =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(max-width: 47.9375em)").matches;
+  const isTerminal =
+    rootElement && rootElement.getAttribute("data-layout") === "terminal";
+
+  if (isCompact || isTerminal) {
+    progress = 0;
+  }
+
+  return Math.min(Math.max(progress, 0), 1);
+}
+
+function scheduleProgressUpdate() {
+  if (rafId !== null) {
+    return;
+  }
+  rafId = requestAnimationFrame(() => {
+    rafId = null;
+    progressBar();
+  });
+}
+
+function progressBar() {
+  // The retract intro owns the mark while it runs.
+  if (introPlaying) {
+    return;
+  }
+  renderProgress(scrollProgress());
+}
+
+// Tween the dash from `from` back to the resting loop (0).
+function playIntro(from) {
+  updateMetrics();
+  introPlaying = true;
+  renderProgress(from);
+
+  var startTs = null;
+  function step(ts) {
+    if (startTs === null) {
+      startTs = ts;
+    }
+    var t = Math.min((ts - startTs) / INTRO_DURATION_MS, 1);
+    var eased = 1 - Math.pow(1 - t, 3); // easeOutCubic
+    renderProgress(from * (1 - eased));
+    if (t < 1) {
+      introRafId = requestAnimationFrame(step);
+    } else {
+      introRafId = null;
+      introPlaying = false;
+      progressBar();
+    }
+  }
+  introRafId = requestAnimationFrame(step);
+}
+
+// Hand control back to the scroll handler (e.g. the user scrolls mid-intro).
+function cancelIntro() {
+  if (introRafId !== null) {
+    cancelAnimationFrame(introRafId);
+    introRafId = null;
+  }
+  if (introPlaying) {
+    introPlaying = false;
+    progressBar();
+  }
+}
+
 function syncBrand() {
   updateMetrics();
   progressBar();
@@ -124,12 +192,75 @@ if (rootElement) {
   rootElement.setAttribute("data-brand-ready", "false");
 }
 
+// Stash the progress on the way out so the next page can retract from it.
+function stashProgress() {
+  try {
+    var p = scrollProgress();
+    if (p > 0.02) {
+      window.sessionStorage.setItem(BRAND_PROGRESS_KEY, String(p));
+    } else {
+      window.sessionStorage.removeItem(BRAND_PROGRESS_KEY);
+    }
+  } catch (e) {
+    /* sessionStorage unavailable — just skip the retract */
+  }
+}
+window.addEventListener("pagehide", stashProgress);
+
 window.onscroll = function () {
   scheduleProgressUpdate();
 };
 
 updateMetrics();
-requestAnimationFrame(syncBrand);
+
+// Retract intro on a fresh, top-of-page navigation; otherwise sync normally.
+(function initBrand() {
+  var stored = 0;
+  try {
+    stored = parseFloat(window.sessionStorage.getItem(BRAND_PROGRESS_KEY)) || 0;
+    window.sessionStorage.removeItem(BRAND_PROGRESS_KEY);
+  } catch (e) {
+    stored = 0;
+  }
+
+  var atTop = (window.scrollY || window.pageYOffset || 0) < 4;
+  if (!(stored > 0.02) || !atTop || prefersReducedMotion() || !brandMark) {
+    requestAnimationFrame(syncBrand);
+    return;
+  }
+
+  // Paint the previous (scrolled) length now so it matches the outgoing page —
+  // seamless if a view transition captures the header — then retract it.
+  introPlaying = true;
+  renderProgress(stored);
+
+  var started = false;
+  var cancelled = false;
+  var start = function () {
+    if (started || cancelled) {
+      return;
+    }
+    started = true;
+    playIntro(stored);
+  };
+  var onUserScroll = function () {
+    cancelled = true;
+    cancelIntro();
+  };
+
+  // If a cross-document view transition is running, retract once it finishes so
+  // the tween doesn't play under the frozen snapshot; otherwise retract now.
+  requestAnimationFrame(function () {
+    var vt = window.__pageViewTransition;
+    if (vt && vt.finished && typeof vt.finished.then === "function") {
+      vt.finished.then(start, start);
+    } else {
+      start();
+    }
+  });
+
+  window.addEventListener("scroll", onUserScroll, { once: true, passive: true });
+})();
 
 if (document.fonts && document.fonts.ready) {
   document.fonts.ready.then(() => settleBrand(6));

--- a/assets/js/progressbar.js
+++ b/assets/js/progressbar.js
@@ -18,7 +18,7 @@ let rightMaxPx = 0;
 // progress; the next page paints that length, then tweens it to zero — after
 // the view transition (if one is running) so the two motions don't fight.
 const BRAND_PROGRESS_KEY = "brandProgress";
-const INTRO_DURATION_MS = 460;
+const INTRO_DURATION_MS = 300;
 let introRafId = null;
 let introPlaying = false;
 
@@ -248,16 +248,8 @@ updateMetrics();
     cancelIntro();
   };
 
-  // If a cross-document view transition is running, retract once it finishes so
-  // the tween doesn't play under the frozen snapshot; otherwise retract now.
-  requestAnimationFrame(function () {
-    var vt = window.__pageViewTransition;
-    if (vt && vt.finished && typeof vt.finished.then === "function") {
-      vt.finished.then(start, start);
-    } else {
-      start();
-    }
-  });
+  // Retract on the next frame (once the starting length has painted).
+  requestAnimationFrame(start);
 
   window.addEventListener("scroll", onUserScroll, { once: true, passive: true });
 })();

--- a/layouts/partials/brand.html
+++ b/layouts/partials/brand.html
@@ -15,7 +15,7 @@
       class="brand__mark"
       data-js="brand-mark"
       data-brand-part="true"
-      viewBox="0 0 140 24"
+      viewBox="0 0 24 24"
       aria-hidden="true"
     >
       <line

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,16 +19,23 @@
     content="#18181b"
     media="(prefers-color-scheme: dark)"
   />
-  <!-- Cross-document view transitions supply the page-to-page motion. Flag the
-       document when the browser actually runs them (the pagereveal event only
-       exists where cross-document view transitions do — Chromium/Safari, not
-       Firefox today). CSS then skips the scroll-reveal entry animation there so
-       it doesn't double up with the navigation cross-fade. Set here (before the
-       body renders) to avoid a flash of the reveal starting state. -->
+  <!-- While a cross-document view transition is running, flag the document so
+       CSS can pause the scroll-reveal entry animation for that moment only —
+       otherwise content sits hidden in the new snapshot and slides in over the
+       cross-fade. The flag is cleared when the transition finishes, so anything
+       still below the fold resumes revealing on scroll. Registered in <head> so
+       it's in place before the pagereveal event fires; a no-op in browsers
+       without cross-document view transitions. -->
   <script>
-    if ("onpagereveal" in window) {
-      document.documentElement.classList.add("has-view-transitions");
-    }
+    window.addEventListener("pagereveal", function (event) {
+      if (!event.viewTransition) return;
+      var root = document.documentElement;
+      root.classList.add("is-view-transition");
+      var clear = function () {
+        root.classList.remove("is-view-transition");
+      };
+      event.viewTransition.finished.then(clear, clear);
+    });
   </script>
   <script>
     (function () {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,6 +31,9 @@
       if (!event.viewTransition) return;
       var root = document.documentElement;
       root.classList.add("is-view-transition");
+      // Expose the running transition so other scripts (e.g. the brand mark
+      // retract) can wait for it to finish before starting their own motion.
+      window.__pageViewTransition = event.viewTransition;
       var clear = function () {
         root.classList.remove("is-view-transition");
       };

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,6 +19,23 @@
     content="#18181b"
     media="(prefers-color-scheme: dark)"
   />
+  <!-- While a cross-document view transition runs, flag the document (so CSS can
+       pause the scroll-reveal entry animation for that moment) and expose the
+       transition so progressbar.js can retract the wordmark once it finishes.
+       Registered in <head> so it's in place before pagereveal fires; a no-op in
+       browsers without cross-document view transitions. -->
+  <script>
+    window.addEventListener("pagereveal", function (event) {
+      if (!event.viewTransition) return;
+      var root = document.documentElement;
+      root.classList.add("is-view-transition");
+      window.__pageViewTransition = event.viewTransition;
+      var clear = function () {
+        root.classList.remove("is-view-transition");
+      };
+      event.viewTransition.finished.then(clear, clear);
+    });
+  </script>
   <script>
     (function () {
       try {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,6 +31,19 @@
       root.classList.add("is-view-transition");
       window.__pageViewTransition = event.viewTransition;
       var clear = function () {
+        // Before dropping the flag, lock in every .reveal element that's
+        // currently in view as revealed. The transition already showed it, so it
+        // must not blink back to opacity:0 if reveal-on-scroll.js is still
+        // waiting on its images. Below-fold elements are left to reveal on scroll.
+        try {
+          var reveals = document.querySelectorAll(".reveal:not(.is-revealed)");
+          for (var i = 0; i < reveals.length; i++) {
+            var box = reveals[i].getBoundingClientRect();
+            if (box.top < window.innerHeight && box.bottom > 0) {
+              reveals[i].classList.add("is-revealed");
+            }
+          }
+        } catch (e) {}
         root.classList.remove("is-view-transition");
       };
       event.viewTransition.finished.then(clear, clear);

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,27 +19,6 @@
     content="#18181b"
     media="(prefers-color-scheme: dark)"
   />
-  <!-- While a cross-document view transition is running, flag the document so
-       CSS can pause the scroll-reveal entry animation for that moment only —
-       otherwise content sits hidden in the new snapshot and slides in over the
-       cross-fade. The flag is cleared when the transition finishes, so anything
-       still below the fold resumes revealing on scroll. Registered in <head> so
-       it's in place before the pagereveal event fires; a no-op in browsers
-       without cross-document view transitions. -->
-  <script>
-    window.addEventListener("pagereveal", function (event) {
-      if (!event.viewTransition) return;
-      var root = document.documentElement;
-      root.classList.add("is-view-transition");
-      // Expose the running transition so other scripts (e.g. the brand mark
-      // retract) can wait for it to finish before starting their own motion.
-      window.__pageViewTransition = event.viewTransition;
-      var clear = function () {
-        root.classList.remove("is-view-transition");
-      };
-      event.viewTransition.finished.then(clear, clear);
-    });
-  </script>
   <script>
     (function () {
       try {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,6 +19,17 @@
     content="#18181b"
     media="(prefers-color-scheme: dark)"
   />
+  <!-- Cross-document view transitions supply the page-to-page motion. Flag the
+       document when the browser actually runs them (the pagereveal event only
+       exists where cross-document view transitions do — Chromium/Safari, not
+       Firefox today). CSS then skips the scroll-reveal entry animation there so
+       it doesn't double up with the navigation cross-fade. Set here (before the
+       body renders) to avoid a flash of the reveal starting state. -->
+  <script>
+    if ("onpagereveal" in window) {
+      document.documentElement.classList.add("has-view-transitions");
+    }
+  </script>
   <script>
     (function () {
       try {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -748,6 +748,17 @@
         storedGrain === "1" ? "on" : "off"
       );
 
+      // Reduce-motion is set here too (not just by theme.js on DOMContentLoaded)
+      // so it's in place before the pagereveal handler and progressbar.js run —
+      // both of which decide whether to animate the navigation/wordmark from this
+      // attribute. Without it, a returning visitor who enabled the site's Reduce
+      // motion (but whose OS reports no-preference) would still get the animation.
+      var storedMotion = localStorage.getItem("theme-effect-reduced-motion");
+      document.documentElement.setAttribute(
+        "data-effect-reduced-motion",
+        storedMotion === "1" ? "on" : "off"
+      );
+
       // CotyScale (Pantone engine) is lazy-loaded. Expose its URL for
       // theme.js, and when Pantone is already active inject it now — before
       // the deferred bundle — so returning Pantone users get their scale with

--- a/layouts/partials/settings-dropdown.html
+++ b/layouts/partials/settings-dropdown.html
@@ -30,7 +30,7 @@
     <span class="settings-icon" aria-hidden="true">
       <svg class="icon" aria-hidden="true">
         <use
-          href="{{ "img/svg/sprite.svg?v=20260211b" | relURL }}#icon-settings"
+          href="#icon-settings"
         ></use>
       </svg>
     </span>

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -1,3 +1,31 @@
+{{/* Inline the icons the header actually paints, so their <use href="#…">
+     resolves against this document rather than the external sprite file.
+     External sprite references aren't drawn into a view-transition snapshot,
+     which made these nav icons blink on navigation; inline symbols render in
+     the snapshot. Hidden container — the symbols only show via <use>. */}}
+<svg
+  width="0"
+  height="0"
+  aria-hidden="true"
+  focusable="false"
+  style="position: absolute; width: 0; height: 0; overflow: hidden"
+>
+  <symbol id="icon-settings" viewBox="0 0 24 24">
+    <path d="M19.922 7.213a1.874 1.874 0 0 0 1.065 2.571l1.265 0.45a1.875 1.875 0 0 1 0 3.534l-1.265 0.45a1.874 1.874 0 0 0 -1.065 2.571L20.5 18a1.875 1.875 0 0 1 -2.5 2.5l-1.213 -0.576a1.874 1.874 0 0 0 -2.571 1.065l-0.45 1.265a1.875 1.875 0 0 1 -3.533 0l-0.45 -1.265a1.875 1.875 0 0 0 -2.572 -1.065L6 20.5A1.874 1.874 0 0 1 3.5 18l0.576 -1.213a1.874 1.874 0 0 0 -1.065 -2.571l-1.265 -0.45a1.875 1.875 0 0 1 0 -3.534l1.265 -0.45a1.874 1.874 0 0 0 1.065 -2.569L3.5 6A1.874 1.874 0 0 1 6 3.5l1.213 0.576a1.875 1.875 0 0 0 2.57 -1.063l0.45 -1.265a1.875 1.875 0 0 1 3.533 0l0.45 1.265a1.874 1.874 0 0 0 2.571 1.065L18 3.5A1.875 1.875 0 0 1 20.5 6Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+    <path d="M7.499 12.001a4.5 4.5 0 1 0 9 0 4.5 4.5 0 1 0 -9 0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  </symbol>
+  <symbol id="icon-contact" viewBox="0 0 24 24">
+    <g transform="translate(2.5, 3)">
+      <path d="M14.5 0.5h-10a4 4 0 0 0 -4 4v5a4 4 0 0 0 4 4h1v4l4.5 -4h4.5a4 4 0 0 0 4 -4v-5a4 4 0 0 0 -4 -4Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+    </g>
+  </symbol>
+  <symbol id="icon-profile-male" viewBox="0 0 24 24">
+    <path d="M7.131 6.875a2.625 2.625 0 1 0 5.25 0 2.625 2.625 0 1 0 -5.25 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+    <path d="M10.006 14.75h-4.75a4.5 4.5 0 0 1 7.75 -3.112" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+    <path d="M7.49 18.75H3.756a3 3 0 0 1 -3 -3v-12a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+    <path d="m13.718 19.227 3.822 -3.822a1.423 1.423 0 0 1 2.012 2.012l-4.44 4.439a2.845 2.845 0 0 1 -4.023 -4.023l4.871 -4.87A4.267 4.267 0 0 1 21.994 19l-4.253 4.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+  </symbol>
+</svg>
 <header id="topmenu" class="top-menu" data-js="top-menu">
   <div class="grain-overlay grain-overlay--nav" aria-hidden="true"></div>
   {{/* Terminal layout: boot banner — a frameless block-pixel rendering of the brand curl (luminance-thresholded from the mark's SVG into █ blocks, Claude-CLI style). No frame: it was what forced a fixed width and clipped/scrolled on phones. Two sizes instead — a compact ~26-col curl for narrow screens, a detailed ~40-col one at >=48em (CSS swaps them) — so each viewport gets art that fits without scrolling. The block glyphs tile solid at line-height 1 (see terminal.css). The host title and boot line print below. Hidden in every other layout. */}}
@@ -150,7 +178,7 @@
               >
                 <svg class="icon icon--sm" aria-hidden="true">
                   <use
-                    href="{{ "img/svg/sprite.svg?v=20260601a" | relURL }}#icon-contact"
+                    href="#icon-contact"
                   ></use>
                 </svg>
               </span>
@@ -159,7 +187,7 @@
                 data-focus-icon="contact-profile"
               >
                 <use
-                  href="{{ "img/svg/sprite.svg?v=20260211b" | relURL }}#icon-profile-male"
+                  href="#icon-profile-male"
                 ></use>
               </svg>
             </span>


### PR DESCRIPTION
## Sammanfattning

Native **cross-document view transitions** (ren CSS, ingen JS-router) för en mjuk sid-fade vid navigering, plus att wordmarkens scroll-drivna streck **drar in sig** i stället för att snappa.

## Vad som ingår

**Sid-fade (view transitions)**
- `@view-transition { navigation: auto }` — kort cross-fade (200 ms). Progressiv förbättring; browsers utan stöd navigerar som förut. Reduced-motion → av.
- Headern hålls **statisk** (egen grupp, `animation: none`) i stället för att fejda med sidan.
- Scroll-reveal pausas bara *under* övergången (flagga sätts/rensas av ett `<head>`-script på `pagereveal`), återupptas sedan.

**Wordmark-indragning**
- `progressbar.js`: sparar progressen vid `pagehide`; nästa sida målar den längden och tween:ar tillbaka till noll (easeOutCubic, 300 ms). Under den korta faden **håller** strecket kvar sin längd (sömlöst med sidan du kom från) och drar sedan in sig när övergången är klar — läser som snärtigt, inte fördröjt.
- Vilobredd/`viewBox` matchar loop-läget så första paint inte krymper (tar bort ett litet layout-skift).

**Ikon-blink-fix**
- Headerns tre synliga ikoner (settings, contact, profile) inline:ades som samma-dokument-symboler i `topmenu.html`; deras `<use>` pekar nu på `#icon-…`. Externa sprite-referenser ritas inte i view-transition-snapshoten (→ blink); inline-symboler gör det.

## Att verifiera på preview (Chromium/Safari 18.2+)
1. Navigera → mjuk, kort sid-fade; **headern står still**.
2. Scrolla ner → navigera → strecket **håller och drar sedan in sig snabbt**, ingen delay.
3. Nav-ikonerna (kugghjul, kontakt) **blinkar inte**.
4. Scroll-reveal fungerar på nya sidan (pausas bara under faden).
5. Reduced-motion på → ingen sid-fade, strecket sitter kort direkt.
6. Firefox: navigerar utan fade (ingen regression), scroll-reveal + indragning fungerar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012urSgHTxruJ5WpeGfrvWbK