### PR TITLE
Add pantone play/pause/random terminal commands

### DIFF
--- a/assets/js/__tests__/terminal-commands.test.js
+++ b/assets/js/__tests__/terminal-commands.test.js
@@ -1165,6 +1165,60 @@ describe("terminal command line", () => {
     );
   });
 
+  test("pantone play activates and starts the auto-cycle", () => {
+    loadModule();
+    typeCommand("pantone play");
+    expect(sessionText()).toContain("cycling colour-of-the-year");
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+    expect(document.documentElement.getAttribute("data-pantone-state")).toBe(
+      "playing"
+    );
+  });
+
+  test("pantone play is refused when reduce motion is on", () => {
+    loadModule();
+    document.documentElement.setAttribute("data-effect-reduced-motion", "on");
+    typeCommand("pantone play");
+    expect(sessionText()).toContain("play disabled");
+    // A refusal must not activate Pantone.
+    expect(document.documentElement.getAttribute("data-palette")).not.toBe(
+      "pantone"
+    );
+  });
+
+  test("pantone pause holds the colour and stops cycling", () => {
+    loadModule();
+    typeCommand("pantone play");
+    expect(document.documentElement.getAttribute("data-pantone-state")).toBe(
+      "playing"
+    );
+    typeCommand("pantone pause");
+    expect(document.documentElement.getAttribute("data-pantone-state")).toBe(
+      "paused"
+    );
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+  });
+
+  test("pantone random activates and jumps to a different available year", () => {
+    loadModule();
+    // Two known years, currently on 2026 → random must pick the other (2025).
+    window.CotyScaleActions.getEntries = jest.fn(() => [
+      { year: 2025, name: "Prev" },
+      { year: 2026, name: "Latest" },
+    ]);
+    window.CotyScaleActions.getCurrentYear = jest.fn(() => 2026);
+    typeCommand("pantone random");
+    expect(sessionText()).toContain("(random)");
+    expect(sessionText()).toContain("year → 2025");
+    expect(document.documentElement.getAttribute("data-palette")).toBe(
+      "pantone"
+    );
+  });
+
   test("grain on / off / toggle drives the grain effect", () => {
     loadModule();
     typeCommand("grain on");

--- a/assets/js/terminal-data.js
+++ b/assets/js/terminal-data.js
@@ -46,7 +46,7 @@
     "  echo      print text",
     "  neofetch  session info",
     "  dark|light|system  mode",
-    "  pantone   [on|off|YYYY]",
+    "  pantone   [on|off|play|pause|random|YYYY]",
     "  grain|blend|motion on/off",
     "  grid      layout grid",
     "  set [k v] view/set settings",

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1698,6 +1698,72 @@
               action: { type: "pantone", state: "step", step: step },
             };
           }
+          if (sub === "play") {
+            // Auto-cycling colour is motion — respect the reduce-motion setting
+            // (site toggle or OS preference) and refuse rather than cycle.
+            var reduceMotion =
+              document.documentElement.getAttribute(
+                "data-effect-reduced-motion"
+              ) === "on" ||
+              (typeof window.matchMedia === "function" &&
+                window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+            if (reduceMotion) {
+              return {
+                echo: input,
+                lines: ["pantone: play disabled — reduce motion is on"],
+                action: null,
+              };
+            }
+            return {
+              echo: input,
+              lines: [
+                "[1] pantone: cycling colour-of-the-year — pantone pause to hold, off to stop",
+              ],
+              action: { type: "pantone", state: "play" },
+            };
+          }
+          if (sub === "pause") {
+            return {
+              echo: input,
+              lines: ["pantone: cycling paused (" + getCurrentCotyYear() + ")"],
+              action: { type: "pantone", state: "pause" },
+            };
+          }
+          if (sub === "random") {
+            var randomActions = getCotyActions();
+            var randomEntries =
+              randomActions && typeof randomActions.getEntries === "function"
+                ? randomActions.getEntries()
+                : null;
+            if (randomEntries && randomEntries.length) {
+              var current = Number(getCurrentCotyYear());
+              var pool = randomEntries.filter(function (entry) {
+                return Number(entry.year) !== current;
+              });
+              if (!pool.length) {
+                pool = randomEntries;
+              }
+              var randomYear = Number(
+                pool[Math.floor(Math.random() * pool.length)].year
+              );
+              return {
+                echo: input,
+                lines: ["pantone: year → " + randomYear + " (random)"],
+                action: { type: "pantone", state: "year", year: randomYear },
+              };
+            }
+            // Engine not loaded yet — turn Pantone on (which loads it); the
+            // next `pantone random` can then shuffle among the known years.
+            return {
+              echo: input,
+              lines: [
+                "pantone: on (" +
+                  getCurrentCotyYear() +
+                  ") — run pantone random again to shuffle",
+              ],
+              action: { type: "pantone", state: "on" },
+            };
+          }
           if (/^\d{4}$/.test(sub)) {
             var wanted = parseInt(sub, 10);
             var actions = getCotyActions();
@@ -1735,7 +1801,7 @@
               lines: [
                 "pantone: unknown option '" +
                   sub +
-                  "' — try on, off, next, prev, or a year",
+                  "' — try on, off, play, pause, random, next, prev, or a year",
               ],
               action: null,
             };
@@ -3228,6 +3294,20 @@
             advanceCotyYear(action.step, {
               fromUser: true,
               transitionDuration: PANTONE_MANUAL_TRANSITION_MS,
+            });
+          } else if (action.state === "play") {
+            // Activate + start the auto-cycle loop (setPantoneState "playing"
+            // arms the timer). Reset to the latest year only when starting cold.
+            activatePantone({
+              playing: true,
+              resetYear: !isPantoneModeActive(),
+            });
+          } else if (action.state === "pause") {
+            // Hold the current colour, stop cycling. From off, this turns
+            // Pantone on (paused) at the latest year.
+            activatePantone({
+              playing: false,
+              resetYear: !isPantoneModeActive(),
             });
           } else {
             togglePantoneMode();

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -484,7 +484,7 @@ commands:
   echo      print text
   neofetch  session info
   dark|light|system  mode
-  pantone   [on|off|YYYY]
+  pantone   [on|off|play|pause|random|YYYY]
   grain|blend|motion on/off
   grid      layout grid
   set [k v] view/set settings

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -478,7 +478,7 @@ kommandon:
   echo      skriv text
   neofetch  sessionsinfo
   dark|light|system  läge
-  pantone   [on|off|YYYY]
+  pantone   [on|off|play|pause|random|YYYY]
   grain|blend|motion on/off
   grid      rutnät
   set [k v] visa/ändra inställn.


### PR DESCRIPTION
Adds three new `pantone` sub-commands to the terminal layout, reusing the existing colour-of-the-year (Pantone) infrastructure.

## What's new

- **`pantone play`** — starts the colour-of-the-year auto-cycle. Reduce-motion gated: with the site toggle or the OS `prefers-reduced-motion` on, it refuses (`play disabled — reduce motion is on`) rather than animating.
- **`pantone pause`** — holds the current colour and stops cycling (`paused`). From the off state, this turns Pantone on in the paused state at the latest year.
- **`pantone random`** — jumps to a random known year, excluding the one currently shown. If the CotyScale engine hasn't loaded yet, it turns Pantone on first and prompts to run again to shuffle.

The unknown-option hint now reads `try on, off, play, pause, random, next, prev, or a year`.

## Implementation notes

- All three commands route through the existing `activatePantone` loop — `play`/`pause` set `data-pantone-state` to `playing`/`paused`; `random` reuses the existing `{ state: "year" }` action. No `theme.js` changes required.
- `random` reads the live `CotyScaleActions.getEntries()` list, filters out the current year, and falls back to the full set if the current year is the only entry.

## Tests

Four new tests in `terminal-commands.test.js`:
- `pantone play` activates and starts the auto-cycle
- `pantone play` is refused when reduce motion is on (no activation)
- `pantone pause` holds the colour and stops cycling
- `pantone random` activates and jumps to a different available year

Full suite green (715 passed); lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012urSgHTxruJ5WpeGfrvWbK)_