### PR TITLE
Hide blend overlays on themed lightbox media

### DIFF
--- a/layouts/partials/work-theme-tritone.html
+++ b/layouts/partials/work-theme-tritone.html
@@ -64,6 +64,16 @@
      opened image or hero embed keeps the themed tritone. Emitted only when the
      page hasn't opted out via plain_media (there's no .works-post ancestor on
      the body-level lightbox to carry that exclusion). */
+  :root[data-effect-blend="on"][data-palette="standard"] .lightbox__picture::before,
+  :root[data-effect-blend="on"][data-palette="standard"] .lightbox__picture::after,
+  :root[data-effect-blend="on"][data-palette="standard"] .lightbox__embed-wrap::before,
+  :root[data-effect-blend="on"][data-palette="standard"] .lightbox__embed-wrap::after {
+    /* The global blend overlays (style.css) also land on the lightbox's own
+       <picture> / .video-wrapper; hide them here as the .works-post-scoped
+       rule above can't reach the body-level lightbox, else the standard
+       duotone would stack over the tritone filter below. */
+    display: none;
+  }
   :root[data-effect-blend="on"][data-palette="standard"]:not([data-mode="dark"]) :is(.lightbox__img, .lightbox__embed) {
     filter: url(#wt-{{ $id }}-light);
   }


### PR DESCRIPTION
Follow-up to #271 addressing a post-merge Codex review comment.

### Problem
The per-work-theme tritone filter is now applied to lightbox media
(`.lightbox__img` / `.lightbox__embed`), but the standard-palette blend
overlays were left stacked on top of it. Those `::before`/`::after` duotone
overlays (`assets/css/style.css:624-652`) are **global** — they match any
`picture` / `.video-wrapper` — while the overlay-hiding rules are scoped to
`.works-post`. Since the lightbox is appended to `document.body`, its own
`<picture class="lightbox__picture">` and `.lightbox__embed-wrap.video-wrapper`
kept the standard duotone, so enlarged media rendered as **tritone + standard
duotone** rather than the project tritone alone.

### Fix
Hide the `::before`/`::after` pseudo-elements on the lightbox's own
`.lightbox__picture` / `.lightbox__embed-wrap` under `data-effect-blend="on"`
+ standard palette — the same global opt-out Pantone's tritone already applies.
Emitted only when the page hasn't opted out via `plain_media`, matching the
rest of the treatment.

### Verification
- Production build clean; the overlay-hide rules are emitted on themed pages.
- CSS-only change, no token or contrast impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A3J2u3Ayr8KuwRtaD4sLo

---
_Generated by [Claude Code](https://claude.ai/code/session_011A3J2u3Ayr8KuwRtaD4sLo)_