### PR TITLE
Add mobile navigation to the settings sheet; menu-glyph trigger

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -156,7 +156,8 @@ html[data-grid-overlay] .top-menu {
 }
 
 .top-menu__item--nav .top-menu__link.active {
-  background: var(--surface-default);
+  color: var(--state-selected);
+  font-weight: var(--sans-weight-medium);
 }
 
 #layout.clientpage .top-menu__item--nav[data-menu-id="works"],

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -317,6 +317,30 @@
       transparent
     );
   }
+
+  /* Fallback (no Popover API): the legacy [hidden] path gets no detents, but the
+     panel still must fit the viewport. It's anchored to the bottom, so without a
+     cap a panel taller than the screen pushes its top — now the nav — off the top
+     edge with no way to reach it. Cap the height and let the body scroll, the
+     same overflow model the popover sheet uses (minus the drag detents). vh
+     first for old engines that predate both Popover and dvh; dvh overrides where
+     supported. */
+  .settings-panel:not([hidden]):not([popover]) {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    max-height: calc(100vh - var(--spacing-24));
+    max-height: calc(100dvh - var(--spacing-24));
+    overflow: hidden;
+  }
+
+  .settings-panel:not([hidden]):not([popover]) .settings-panel__body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-bottom: max(var(--spacing-16), env(safe-area-inset-bottom));
+  }
 }
 
 /* Lock background scroll while the mobile bottom sheet is open. Desktop keeps

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -374,35 +374,6 @@
   }
 }
 
-/* The scrim + top fade use var(--surface-page). Safari doesn't reliably update
-   a mode-scoped custom property inside a top-layer ::backdrop, so on a
-   light/dark toggle the top band kept the old colour and fell out of sync with
-   the page (a regression from moving the fade off .settings-overlay::before
-   into ::backdrop). Selector matching DOES reach the ::backdrop, so pin the
-   colour per mode with concrete values (mirroring the computed --surface-page).
-   Scoped to the bottom-sheet range — the desktop dropdown has no scrim. Custom
-   palettes fall back to the base rule's var(); the standard light/dark toggle
-   (the visible case) is now correct. */
-@media (max-width: 29.9375em) {
-  :root[data-mode="light"] .settings-panel[popover]:popover-open::backdrop {
-    background: linear-gradient(
-        to bottom,
-        hsl(240, 100%, 99.6%) 90px,
-        transparent 130px
-      ),
-      color-mix(in srgb, hsl(240, 100%, 99.6%) 55%, transparent);
-  }
-
-  :root[data-mode="dark"] .settings-panel[popover]:popover-open::backdrop {
-    background: linear-gradient(
-        to bottom,
-        hsl(240, 22.4%, 9.6%) 90px,
-        transparent 130px
-      ),
-      color-mix(in srgb, hsl(240, 22.4%, 9.6%) 55%, transparent);
-  }
-}
-
 .settings-panel::before {
   content: "";
   position: absolute;

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -59,6 +59,95 @@
   display: block;
 }
 
+/* Gear on desktop (settings-only panel), menu glyph on phones where the panel
+   also holds the nav. Swapped at the same breakpoint as .settings-nav. */
+.settings-icon--menu {
+  display: none;
+}
+
+@media (max-width: 47.9375em) {
+  .settings-icon--gear {
+    display: none;
+  }
+
+  .settings-icon--menu {
+    display: block;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Navigation in the panel
+   The header drops its primary nav links on phones, so they live at the top of
+   this panel there (inside .settings-panel__body, so they ride the sheet's
+   internal scroll / detents). Hidden by default: the desktop dropdown sits
+   under a header that still shows the nav, so it would be redundant. Revealed
+   at the same breakpoint the header nav disappears (<=47.9375em) — spanning
+   both the tablet dropdown (>=30em) and the phone bottom sheet (<30em).
+   --------------------------------------------------------------------------- */
+.settings-nav,
+.settings-nav__divider {
+  display: none;
+}
+
+@media (max-width: 47.9375em) {
+  .settings-nav {
+    display: block;
+  }
+
+  .settings-nav__divider {
+    display: block;
+  }
+
+  /* One horizontal row, never wrapping — keeps nav to a single line so it adds
+     minimal height to the sheet's resting detent. Overflows sideways if the
+     links ever exceed the width; a horizontal swipe here doesn't collide with
+     the sheet's vertical drag / scroll. */
+  .settings-nav__list {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--spacing-4);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .settings-nav__list::-webkit-scrollbar {
+    display: none;
+  }
+
+  .settings-nav__item {
+    flex: 0 0 auto;
+  }
+
+  .settings-nav__link {
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--size-40);
+    padding: var(--spacing-8) var(--spacing-12);
+    border-radius: var(--radius-8);
+    color: var(--text-default);
+    font-size: var(--text-base);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background var(--motion-duration-base)
+        var(--motion-ease-standard),
+      color var(--motion-duration-base) var(--motion-ease-standard);
+  }
+
+  .settings-nav__link:hover,
+  .settings-nav__link:focus-visible {
+    background: var(--state-surface-hover);
+  }
+
+  .settings-nav__link.active {
+    background: var(--surface-default);
+    font-weight: var(--sans-weight-medium);
+  }
+}
+
 .settings-panel {
   --theme-control-size: var(--size-40);
   /* Drag-to-dismiss progress (0 = at rest, 1 = pulled its full height). Set by

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -374,6 +374,35 @@
   }
 }
 
+/* The scrim + top fade use var(--surface-page). Safari doesn't reliably update
+   a mode-scoped custom property inside a top-layer ::backdrop, so on a
+   light/dark toggle the top band kept the old colour and fell out of sync with
+   the page (a regression from moving the fade off .settings-overlay::before
+   into ::backdrop). Selector matching DOES reach the ::backdrop, so pin the
+   colour per mode with concrete values (mirroring the computed --surface-page).
+   Scoped to the bottom-sheet range — the desktop dropdown has no scrim. Custom
+   palettes fall back to the base rule's var(); the standard light/dark toggle
+   (the visible case) is now correct. */
+@media (max-width: 29.9375em) {
+  :root[data-mode="light"] .settings-panel[popover]:popover-open::backdrop {
+    background: linear-gradient(
+        to bottom,
+        hsl(240, 100%, 99.6%) 90px,
+        transparent 130px
+      ),
+      color-mix(in srgb, hsl(240, 100%, 99.6%) 55%, transparent);
+  }
+
+  :root[data-mode="dark"] .settings-panel[popover]:popover-open::backdrop {
+    background: linear-gradient(
+        to bottom,
+        hsl(240, 22.4%, 9.6%) 90px,
+        transparent 130px
+      ),
+      color-mix(in srgb, hsl(240, 22.4%, 9.6%) 55%, transparent);
+  }
+}
+
 .settings-panel::before {
   content: "";
   position: absolute;

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -330,21 +330,30 @@
 }
 
 .settings-panel::backdrop {
-  /* Scrim, plus a solid → transparent gradient at the very top that fades to
-     the page bg to hide the sheet/edge under the status bar (this replaces the
-     old .settings-overlay::before). */
-  background: linear-gradient(
-      to bottom,
-      var(--surface-page) 90px,
-      transparent 130px
-    ),
-    color-mix(in srgb, var(--surface-page) 55%, transparent);
+  /* Scrim: a page-coloured wash so the strip above the sheet matches the page
+     (the top bar looks the same whether the sheet is open or not). Split out as
+     background-color, not the `background` shorthand, so it can TRANSITION — on
+     a light/dark toggle it must recolour in step with the page (700ms), not
+     snap ahead of it. The duration comes from :root's --theme-transition-
+     duration (the same path --surface-page takes to reach this ::backdrop),
+     falling back to the sheet duration when no swap is running. The solid →
+     transparent top fade (hides the sheet/edge under the status bar; replaces
+     the old .settings-overlay::before) stays a background-image. */
+  background-color: color-mix(in srgb, var(--surface-page) 55%, transparent);
+  background-image: linear-gradient(
+    to bottom,
+    var(--surface-page) 90px,
+    transparent 130px
+  );
   -webkit-backdrop-filter: blur(0) saturate(100%);
   backdrop-filter: blur(0) saturate(100%);
   opacity: 0;
   transition: opacity var(--motion-duration-sheet) var(--motion-ease-emphasized),
     -webkit-backdrop-filter var(--motion-duration-sheet) var(--motion-ease-emphasized),
     backdrop-filter var(--motion-duration-sheet) var(--motion-ease-emphasized),
+    background-color
+      var(--theme-transition-duration, var(--motion-duration-sheet))
+      var(--motion-ease-theme),
     display var(--motion-duration-sheet) var(--motion-ease-emphasized)
       allow-discrete,
     overlay var(--motion-duration-sheet) var(--motion-ease-emphasized)

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -126,24 +126,30 @@
     display: inline-flex;
     align-items: center;
     min-height: var(--size-40);
-    padding: var(--spacing-8) var(--spacing-12);
+    /* 8px inline padding lines the first link's text up with the section
+       headings (which also inset 8px); vertical padding 0 + line-height 1 keeps
+       the row height at the 40px min so it doesn't tower over the mode tab. */
+    padding: 0 var(--spacing-8);
     border-radius: var(--radius-8);
     color: var(--text-default);
     font-size: var(--text-base);
+    line-height: 1;
     text-decoration: none;
     white-space: nowrap;
-    transition: background var(--motion-duration-base)
-        var(--motion-ease-standard),
-      color var(--motion-duration-base) var(--motion-ease-standard);
+    transition: color var(--motion-duration-base) var(--motion-ease-standard);
   }
 
   .settings-nav__link:hover,
   .settings-nav__link:focus-visible {
-    background: var(--state-surface-hover);
+    color: var(--state-selected);
   }
 
+  /* Active = iris text + medium weight (matches the mode options' selected
+     colour). A background fill was invisible on light — --surface-default
+     (iris-2) is near-white there against the elevated panel — and boxed the
+     link taller than its neighbours. Colour reads in both modes. */
   .settings-nav__link.active {
-    background: var(--surface-default);
+    color: var(--state-selected);
     font-weight: var(--sans-weight-medium);
   }
 }

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -98,24 +98,19 @@
     display: block;
   }
 
-  /* One horizontal row, never wrapping — keeps nav to a single line so it adds
-     minimal height to the sheet's resting detent. Overflows sideways if the
-     links ever exceed the width; a horizontal swipe here doesn't collide with
-     the sheet's vertical drag / scroll. */
+  /* A plain flex row — same as the other sections' option rows, and crucially
+     NOT a scroll container. An earlier overflow-x:auto turned this into a
+     horizontal scroller, which on iOS swallowed a vertical drag (the sheet's
+     detent/dismiss gesture) instead of letting it through. The links (Works /
+     Writing / About me) fit, and wrap rather than clip in the rare case they
+     don't. */
   .settings-nav__list {
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     gap: var(--spacing-4);
     margin: 0;
     padding: 0;
     list-style: none;
-    overflow-x: auto;
-    scrollbar-width: none;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .settings-nav__list::-webkit-scrollbar {
-    display: none;
   }
 
   .settings-nav__item {

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -132,7 +132,7 @@
     padding: 0 var(--spacing-8);
     border-radius: var(--radius-8);
     color: var(--text-default);
-    font-size: var(--text-base);
+    font-size: var(--text-sm);
     line-height: 1;
     text-decoration: none;
     white-space: nowrap;

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -329,58 +329,15 @@
   }
 }
 
+/* The scrim is a real DOM element (.settings-overlay, wired up in
+   settings-dropdown.js) — not this pseudo-element. On iOS Safari a top-layer
+   ::backdrop recolours late on a light/dark swap: it isn't fed prompt
+   --surface-page updates, and its page-coloured top band was a background-IMAGE
+   gradient that can't transition at all — so the top bar fell out of step with
+   the page. A real element inherits normally and its colour transitions in
+   sync, so the popover's own ::backdrop stays fully transparent. */
 .settings-panel::backdrop {
-  /* Scrim: a page-coloured wash so the strip above the sheet matches the page
-     (the top bar looks the same whether the sheet is open or not). Split out as
-     background-color, not the `background` shorthand, so it can TRANSITION — on
-     a light/dark toggle it must recolour in step with the page (700ms), not
-     snap ahead of it. The duration comes from :root's --theme-transition-
-     duration (the same path --surface-page takes to reach this ::backdrop),
-     falling back to the sheet duration when no swap is running. The solid →
-     transparent top fade (hides the sheet/edge under the status bar; replaces
-     the old .settings-overlay::before) stays a background-image. */
-  background-color: color-mix(in srgb, var(--surface-page) 55%, transparent);
-  background-image: linear-gradient(
-    to bottom,
-    var(--surface-page) 90px,
-    transparent 130px
-  );
-  -webkit-backdrop-filter: blur(0) saturate(100%);
-  backdrop-filter: blur(0) saturate(100%);
-  opacity: 0;
-  transition: opacity var(--motion-duration-sheet) var(--motion-ease-emphasized),
-    -webkit-backdrop-filter var(--motion-duration-sheet) var(--motion-ease-emphasized),
-    backdrop-filter var(--motion-duration-sheet) var(--motion-ease-emphasized),
-    background-color
-      var(--theme-transition-duration, var(--motion-duration-sheet))
-      var(--motion-ease-theme),
-    display var(--motion-duration-sheet) var(--motion-ease-emphasized)
-      allow-discrete,
-    overlay var(--motion-duration-sheet) var(--motion-ease-emphasized)
-      allow-discrete;
-}
-
-.settings-panel:popover-open::backdrop {
-  /* --sheet-drag (0 → 1) is set by the drag handler and inherited from the
-     panel; it fades the scrim/blur out as the sheet is pulled down. Falls back
-     to 0 (full scrim) when unset or where ::backdrop doesn't inherit vars. */
-  opacity: calc(1 - var(--sheet-drag, 0));
-  -webkit-backdrop-filter: blur(calc((1 - var(--sheet-drag, 0)) * 14px))
-    saturate(120%);
-  backdrop-filter: blur(calc((1 - var(--sheet-drag, 0)) * 14px)) saturate(120%);
-}
-
-/* While the finger is down, the scrim must track the drag with no lag. */
-.settings-panel.is-dragging::backdrop {
-  transition: none;
-}
-
-@starting-style {
-  .settings-panel:popover-open::backdrop {
-    opacity: 0;
-    -webkit-backdrop-filter: blur(0) saturate(100%);
-    backdrop-filter: blur(0) saturate(100%);
-  }
+  background: transparent;
 }
 
 .settings-panel::before {
@@ -395,14 +352,20 @@
   border-radius: calc(var(--spacing-2) * 1.5);
 }
 
+/* ---------------------------------------------------------------------------
+   Bottom-sheet scrim — a REAL DOM element (restored), not the popover
+   ::backdrop. See settings-dropdown.js: the popover path moves this to <body>
+   and toggles it with the sheet. The element carries only the frost
+   (backdrop-filter); the page-coloured wash lives on ::before as a solid,
+   transitionable background-color revealed through a colour-less mask — so it
+   recolours in lockstep with the page on a light/dark swap, which the
+   ::backdrop pseudo could not do on iOS Safari.
+   --------------------------------------------------------------------------- */
 .settings-overlay {
   display: block;
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: color-mix(in srgb, var(--surface-page) 55%, transparent);
+  inset: 0;
+  background: transparent;
   /* Closed = no blur; it ramps to blur(14px) on open (below) so the frost
      visibly builds instead of appearing at full strength the moment opacity
      lifts. */
@@ -417,30 +380,54 @@
     backdrop-filter var(--motion-duration-sheet) var(--motion-ease-emphasized);
 }
 
+/* The page-coloured wash + opaque top band, in ONE solid background-color so it
+   can transition (a gradient / ::backdrop couldn't). The mask carries the shape
+   — opaque 0–90px (the "top bar", identical to the page), 55% wash from 130px
+   down — and carries no colour, so it's correct in every mode. The transition
+   mirrors the page's own theme-swap timing (--theme-transition-duration, set on
+   :root during a swap; --motion-duration-xslow fallback) and easing, so the top
+   bar recolours in exact sync with the rest of the page. */
 .settings-overlay::before {
   content: "";
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 130px;
-  background: linear-gradient(to bottom, var(--surface-page) 90px, transparent);
+  inset: 0;
+  background-color: var(--surface-page);
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    #000 0,
+    #000 90px,
+    rgba(0, 0, 0, 0.55) 130px,
+    rgba(0, 0, 0, 0.55) 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    #000 0,
+    #000 90px,
+    rgba(0, 0, 0, 0.55) 130px,
+    rgba(0, 0, 0, 0.55) 100%
+  );
   pointer-events: none;
+  transition: background-color
+    var(--theme-transition-duration, var(--motion-duration-xslow))
+    var(--motion-ease-theme);
 }
 
 @supports (backdrop-filter: url(#x)) and
   (not (-webkit-appearance: -apple-pay-button)) {
   .settings-overlay {
     backdrop-filter: url(#liquid-glass) blur(0) saturate(100%);
-    background: color-mix(in srgb, var(--surface-page) 40%, transparent);
   }
 }
 
+/* Open: fade in, and fade back out as the sheet is dragged down — --sheet-drag
+   (0 → 1) is set on this element by the drag handler in step with the panel.
+   Parent opacity fades the ::before wash along with it; the blur melts too. */
 .settings-overlay:not([hidden]) {
-  opacity: 1;
   visibility: visible;
-  -webkit-backdrop-filter: blur(14px) saturate(120%);
-  backdrop-filter: blur(14px) saturate(120%);
+  opacity: calc(1 - var(--sheet-drag, 0));
+  -webkit-backdrop-filter: blur(calc((1 - var(--sheet-drag, 0)) * 14px))
+    saturate(120%);
+  backdrop-filter: blur(calc((1 - var(--sheet-drag, 0)) * 14px)) saturate(120%);
 }
 
 /* Open state for the liquid-glass variant — declared after the base open rule
@@ -448,8 +435,14 @@
 @supports (backdrop-filter: url(#x)) and
   (not (-webkit-appearance: -apple-pay-button)) {
   .settings-overlay:not([hidden]) {
-    backdrop-filter: url(#liquid-glass) blur(14px) saturate(120%);
+    backdrop-filter: url(#liquid-glass)
+      blur(calc((1 - var(--sheet-drag, 0)) * 14px)) saturate(120%);
   }
+}
+
+/* While the finger is down, the scrim tracks the drag with no lag. */
+.settings-overlay.is-dragging {
+  transition: none;
 }
 
 /* ≥ 30em: render as an anchored dropdown popover (not a bottom sheet).
@@ -509,15 +502,6 @@
       opacity: 0;
       transform: translateY(calc(var(--spacing-8) * -1));
     }
-  }
-
-  /* Target the open state so it beats .settings-panel:popover-open::backdrop
-     (equal specificity, later in source) — no scrim/blur on the desktop
-     dropdown. */
-  .settings-panel:popover-open::backdrop {
-    background: transparent;
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
   }
 
   /* No mobile-sheet drag handle or full-screen scrim on desktop. */

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -290,28 +290,26 @@
     touch-action: pan-y pinch-zoom;
   }
 
-  /* Overflow cue: a soft gradient over the sheet's bottom edge (the sheet has no
-     bottom padding, so it sits over real content) that dissolves the last of the
-     content — reads as "there's more — drag up to expand". Its opacity is
-     transitioned so it fades in/out rather than popping when .is-clipped toggles.
-     JS toggles .is-clipped only at rest while the body overflows, and lifts it
-     once scrolled to the end or expanded. pointer-events:none so it never blocks
-     the control underneath. */
-  .settings-panel[popover]::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: calc(var(--spacing-40) + var(--spacing-16));
-    background: linear-gradient(to top, var(--surface-elevated), transparent);
-    opacity: 0;
-    transition: opacity var(--motion-duration-base) var(--motion-ease-standard);
-    pointer-events: none;
-  }
-
-  .settings-panel[popover].is-clipped::after {
-    opacity: 1;
+  /* Overflow cue: fade the body's bottom edge when it overflows the resting
+     detent — reads as "there's more — drag up to expand". A mask (dissolving the
+     content to transparent, revealing the panel colour behind) rather than a
+     colour overlay: the old fade painted var(--surface-elevated), but this is a
+     top-layer popover and Safari doesn't reliably pass the mode-scoped custom
+     property into it, so in dark mode the overlay fell back to the light base
+     value and the cue looked light on dark. A mask carries no colour, so it's
+     correct in every mode. JS toggles .is-clipped only at rest while the body
+     overflows, and clears it once scrolled to the end or expanded. */
+  .settings-panel[popover].is-clipped .settings-panel__body {
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      #000 calc(100% - var(--spacing-40) - var(--spacing-16)),
+      transparent
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      #000 calc(100% - var(--spacing-40) - var(--spacing-16)),
+      transparent
+    );
   }
 }
 

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -147,6 +147,17 @@
     color: var(--state-selected);
     font-weight: var(--sans-weight-medium);
   }
+
+  /* Focus mode (a client/employer page) drops Works + About from the primary
+     nav — mirror the header's .top-menu__item--nav scoping (navigation.css) so
+     the sheet nav doesn't diverge from desktop and re-expose them. The panel
+     stays inside #layout in the popover path, so this ancestor selector holds. */
+  #layout.clientpage .settings-nav__item[data-menu-id="works"],
+  #layout.clientpage .settings-nav__item[data-menu-id="about"],
+  #layout.employerpage .settings-nav__item[data-menu-id="works"],
+  #layout.employerpage .settings-nav__item[data-menu-id="about"] {
+    display: none;
+  }
 }
 
 .settings-panel {

--- a/assets/css/components/settings-dropdown.css
+++ b/assets/css/components/settings-dropdown.css
@@ -150,12 +150,14 @@
 
   /* Focus mode (a client/employer page) drops Works + About from the primary
      nav — mirror the header's .top-menu__item--nav scoping (navigation.css) so
-     the sheet nav doesn't diverge from desktop and re-expose them. The panel
-     stays inside #layout in the popover path, so this ancestor selector holds. */
-  #layout.clientpage .settings-nav__item[data-menu-id="works"],
-  #layout.clientpage .settings-nav__item[data-menu-id="about"],
-  #layout.employerpage .settings-nav__item[data-menu-id="works"],
-  #layout.employerpage .settings-nav__item[data-menu-id="about"] {
+     the sheet nav doesn't diverge from desktop and re-expose them. Keyed off
+     :root (data-focus-view, mirrored there by focus-mode.js), NOT #layout: the
+     legacy fallback portals the panel out to <body>, so an #layout ancestor
+     selector wouldn't reach it — :root always does, in both paths. */
+  :root[data-focus-view="client"] .settings-nav__item[data-menu-id="works"],
+  :root[data-focus-view="client"] .settings-nav__item[data-menu-id="about"],
+  :root[data-focus-view="employer"] .settings-nav__item[data-menu-id="works"],
+  :root[data-focus-view="employer"] .settings-nav__item[data-menu-id="about"] {
     display: none;
   }
 }
@@ -463,6 +465,17 @@
   -webkit-backdrop-filter: blur(calc((1 - var(--sheet-drag, 0)) * 14px))
     saturate(120%);
   backdrop-filter: blur(calc((1 - var(--sheet-drag, 0)) * 14px)) saturate(120%);
+}
+
+/* Enter from transparent/no-blur so the scrim fades IN when un-hidden (a real
+   element going display:none -> block otherwise snaps to the open state). The
+   exit is handled in JS (closeOverlay fades opacity/blur out before [hidden]). */
+@starting-style {
+  .settings-overlay:not([hidden]) {
+    opacity: 0;
+    -webkit-backdrop-filter: blur(0) saturate(100%);
+    backdrop-filter: blur(0) saturate(100%);
+  }
 }
 
 /* Open state for the liquid-glass variant — declared after the base open rule

--- a/assets/css/components/toast.css
+++ b/assets/css/components/toast.css
@@ -43,12 +43,19 @@
 }
 
 /* Promoted to the top layer (JS sets popover="manual") so it shows above the
-   settings sheet. Neutralise the UA popover box — its inset:0 + margin:auto
-   would fight the toast's own top/centre positioning — while keeping the
-   toast's own border, background and top offset. */
+   settings sheet. Fully re-assert the toast's own fixed, top-centred,
+   content-sized box: the UA popover defaults (inset:0 + margin:auto + fit
+   sizing) otherwise stretch it to nearly fill the screen on iOS. */
 .toast[popover] {
+  inset: auto;
+  top: var(--spacing-24);
+  left: 0;
+  right: 0;
   bottom: auto;
-  margin-block: 0;
+  width: fit-content;
+  max-width: calc(100% - var(--spacing-32));
+  height: auto;
+  margin: 0 auto;
   overflow: visible;
 }
 

--- a/assets/css/components/toast.css
+++ b/assets/css/components/toast.css
@@ -27,8 +27,11 @@
   white-space: nowrap;
 
   color: var(--text-default);
-  background:
-    radial-gradient(ellipse at 30% 20%, rgba(255, 255, 255, 0.18) 0%, transparent 55%),
+  background: radial-gradient(
+      ellipse at 30% 20%,
+      rgba(255, 255, 255, 0.18) 0%,
+      transparent 55%
+    ),
     var(--component-toast-bg);
   border: 1px solid var(--component-toast-border);
   box-shadow: var(--shadow-02);
@@ -37,6 +40,16 @@
 
   opacity: 0;
   pointer-events: none;
+}
+
+/* Promoted to the top layer (JS sets popover="manual") so it shows above the
+   settings sheet. Neutralise the UA popover box — its inset:0 + margin:auto
+   would fight the toast's own top/centre positioning — while keeping the
+   toast's own border, background and top offset. */
+.toast[popover] {
+  bottom: auto;
+  margin-block: 0;
+  overflow: visible;
 }
 
 .toast--no-icon {
@@ -141,7 +154,7 @@
 /* Directional rim light — bright at top, invisible at sides, subtle at bottom.
    Gradient border via mask technique: only the 1px padding area is visible. */
 .toast::after {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   border-radius: inherit;
@@ -149,13 +162,11 @@
   background: linear-gradient(
     175deg,
     rgba(255, 255, 255, 0.55) 0%,
-    rgba(255, 255, 255, 0.0) 35%,
-    rgba(255, 255, 255, 0.0) 65%,
+    rgba(255, 255, 255, 0) 35%,
+    rgba(255, 255, 255, 0) 65%,
     rgba(255, 255, 255, 0.12) 100%
   );
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   pointer-events: none;
@@ -168,12 +179,16 @@
    scrollbar-gutter:stable was our previous signal but Safari 17.2 added support,
    causing Safari to match and receive the SVG filter which breaks the entire chain.
    -webkit-backdrop-filter intentionally omitted so Safari keeps the blur() base rule. */
-@supports (backdrop-filter: url(#x)) and (not (-webkit-appearance: -apple-pay-button)) {
+@supports (backdrop-filter: url(#x)) and
+  (not (-webkit-appearance: -apple-pay-button)) {
   .toast {
     backdrop-filter: url(#liquid-glass) blur(12px) saturate(140%);
     /* Reduce opacity for Chromium — liquid glass refraction compensates visually. */
-    background:
-      radial-gradient(ellipse at 30% 20%, rgba(255, 255, 255, 0.18) 0%, transparent 55%),
+    background: radial-gradient(
+        ellipse at 30% 20%,
+        rgba(255, 255, 255, 0.18) 0%,
+        transparent 55%
+      ),
       color-mix(in srgb, var(--surface-page) 12%, transparent);
   }
 }

--- a/assets/js/coty-scale.js
+++ b/assets/js/coty-scale.js
@@ -477,8 +477,14 @@
     ) {
       return 0;
     }
+    // The inline --theme-transition-duration lives on <html> (documentElement),
+    // not <body>: theme.js sets it there so the top-layer settings sheet can
+    // inherit it on Safari. The darkmodeTransition class stays on <body> (guard
+    // above), but the property value must be read from the root.
     var val =
-      document.body.style.getPropertyValue("--theme-transition-duration") || "";
+      document.documentElement.style.getPropertyValue(
+        "--theme-transition-duration"
+      ) || "";
     var ms = parseFloat(val);
     return isNaN(ms) || ms <= 0 ? 0 : ms;
   }

--- a/assets/js/focus-mode.js
+++ b/assets/js/focus-mode.js
@@ -115,9 +115,15 @@
 
     if (context.type === CONFIG.VIEW_CLIENT) {
       layout.classList.add(CONFIG.CLASS_CLIENTPAGE);
+      // Mirror the state on :root too. The class on #layout drives most focus
+      // styling, but the settings sheet can be portaled out of #layout (the
+      // legacy no-Popover fallback moves it under <body>), so its nav scoping
+      // keys off this root attribute, which stays an ancestor in both paths.
+      document.documentElement.setAttribute('data-focus-view', 'client');
       console.log('Focus mode: Client mode activated', context.ref || '');
     } else if (context.type === CONFIG.VIEW_EMPLOYER) {
       layout.classList.add(CONFIG.CLASS_EMPLOYERPAGE);
+      document.documentElement.setAttribute('data-focus-view', 'employer');
       console.log('Focus mode: Employer mode activated');
     }
   }

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -37,6 +37,27 @@
       return;
     }
 
+    // Keep the trigger's accessible name in step with what it opens: the primary
+    // menu at the nav breakpoint (where the panel also carries the nav), plain
+    // settings above it. CSS swaps the glyph at the same width but can't touch
+    // aria-label, so mirror it here — on load and on width changes — for both
+    // the popover and legacy paths.
+    var navMedia = window.matchMedia("(max-width: 47.9375em)");
+    function syncToggleLabel() {
+      var label = navMedia.matches
+        ? toggle.getAttribute("data-label-menu")
+        : toggle.getAttribute("data-label-settings");
+      if (label) {
+        toggle.setAttribute("aria-label", label);
+      }
+    }
+    syncToggleLabel();
+    if (navMedia.addEventListener) {
+      navMedia.addEventListener("change", syncToggleLabel);
+    } else if (navMedia.addListener) {
+      navMedia.addListener(syncToggleLabel);
+    }
+
     // --- Popover prototype (progressive enhancement) ---------------------
     // Where the Popover API is supported, upgrade the panel to a native
     // top-layer popover: native open/close/light-dismiss/focus, ::backdrop as

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -217,7 +217,6 @@
       var dragStartMax = 0; // sheet outer height at engage (px)
       var dragRestPx = 0; // resting detent height (px)
       var dragFullPx = 0; // expanded detent height (px)
-      var dragStartedExpanded = false; // did this drag begin from fullscreen?
 
       function isMobileSheet() {
         return (
@@ -403,7 +402,6 @@
           // (measured when already at rest, computed from content otherwise).
           dragStartMax = Math.round(panel.getBoundingClientRect().height);
           dragFullPx = sheetBounds().full;
-          dragStartedExpanded = sheetExpanded;
           // Whether expanding would actually reveal anything: measured now, while
           // the body is still at its resting layout (before the resize below).
           // Already expanded → the body scrolls, so treat as expandable.
@@ -484,11 +482,11 @@
         if (action === "expand" && !dragCanExpand) {
           action = "rest";
         }
-        // Dismissal is reserved for drags that begin at rest; a long pull that
-        // starts from fullscreen collapses to rest rather than closing.
-        if (action === "dismiss" && dragStartedExpanded) {
-          action = "rest";
-        }
+        // A downward pull past the dismiss threshold closes the sheet from
+        // either detent: from rest directly, and from fullscreen once it has
+        // been dragged all the way down through rest (decideSheetTarget already
+        // requires clearing rest − dismissThreshold, so a small collapse still
+        // just settles at rest).
         // Re-enable the CSS transitions (both the panel's and, via removing the
         // class, the ::backdrop's) so the tail motion animates.
         panel.classList.remove("is-dragging");

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -956,77 +956,11 @@
       attributeFilter: ["data-grid-overlay"],
     });
 
-    // Touch support for swipe-to-close on mobile bottom sheet
-    let touchStartY = 0;
-    let touchCurrentY = 0;
-    // Whether this gesture has engaged the dismiss drag (vs. scrolling the body).
-    let swipeDragging = false;
-    // Whether this gesture is even eligible to become a dismiss — latched once,
-    // at touchstart, from the body's scroll position.
-    let swipeCanDismiss = false;
-
-    if (panel && overlay) {
-      const legacyBody = panel.querySelector('[data-js="settings-panel-body"]');
-
-      panel.addEventListener("touchstart", function (e) {
-        touchStartY = e.changedTouches[0].screenY;
-        touchCurrentY = touchStartY;
-        swipeDragging = false;
-        // Decide dismiss eligibility ONCE, here — only a gesture that begins
-        // with the body already at the top may become a dismiss. A gesture that
-        // starts scrolled stays a scroll for its whole duration, so reaching the
-        // top mid-swipe can't hijack it (and jump the sheet by the whole delta
-        // measured from touchstart) into a close.
-        swipeCanDismiss = !legacyBody || legacyBody.scrollTop <= 0;
-        panel.style.transition = "none";
-        overlay.style.transition = "none";
-      });
-
-      panel.addEventListener("touchmove", function (e) {
-        touchCurrentY = e.changedTouches[0].screenY;
-        const deltaY = touchCurrentY - touchStartY;
-
-        // Engage the dismiss drag only on a downward pull, and only when this
-        // gesture was eligible from the start (body at the top). Otherwise it's
-        // the user scrolling the body — leave it to the browser.
-        if (!swipeDragging) {
-          if (swipeCanDismiss && deltaY > 0) {
-            swipeDragging = true;
-          } else {
-            return;
-          }
-        }
-
-        e.preventDefault();
-        panel.style.transform = `translateY(${deltaY}px)`;
-
-        // Update overlay opacity based on drag distance
-        const panelHeight = panel.getBoundingClientRect().height;
-        const maxDeltaY = window.innerHeight - panelHeight - 8; // 8px from bottom
-        const opacity = 1 - deltaY / maxDeltaY;
-        overlay.style.opacity = Math.max(opacity, 0);
-      });
-
-      panel.addEventListener("touchend", function (_e) {
-        const deltaY = touchCurrentY - touchStartY;
-
-        panel.style.transition = "transform 0.3s ease-in-out";
-        overlay.style.transition = "opacity 0.3s ease-in-out";
-
-        // Close only if this gesture actually engaged the dismiss drag and
-        // travelled past the threshold — a scroll-up release must never close.
-        if (swipeDragging && deltaY > 50) {
-          closePanel();
-        } else {
-          // Return to original position
-          panel.style.transform = "translateY(0)";
-          overlay.style.opacity = "1";
-        }
-
-        swipeDragging = false;
-        touchStartY = 0;
-        touchCurrentY = 0;
-      });
-    }
+    // No touch swipe-to-close on the legacy (no-Popover) fallback: it fought the
+    // sheet's own body scroll — a downward swipe to scroll back up toward the
+    // nav read as a dismiss — and the fallback already closes via the overlay,
+    // Escape, and an outside click. The modern popover path keeps its full
+    // drag-to-dismiss / expand detents (initPopoverPanel); this swipe only ever
+    // ran where the Popover API is absent, which is effectively nowhere now.
   });
 })();

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -57,9 +57,15 @@
     }
 
     function initPopoverPanel() {
-      // The custom overlay is replaced by ::backdrop.
-      if (overlay && overlay.parentNode) {
-        overlay.parentNode.removeChild(overlay);
+      // The scrim is this real .settings-overlay element, NOT the popover
+      // ::backdrop: on iOS Safari a top-layer pseudo-element recolours late on a
+      // light/dark swap, so its page-coloured top bar fell out of step with the
+      // page. A real element inherits normally and transitions in sync. Move it
+      // to <body> so its fixed positioning is viewport-relative (no header
+      // ancestor transform can trap it) and it stacks predictably beneath the
+      // top-layer panel (which always paints above normal DOM).
+      if (overlay && overlay.parentNode !== document.body) {
+        document.body.appendChild(overlay);
       }
 
       function enablePopover() {
@@ -114,6 +120,30 @@
       // The mobile sheet's internal scroll container; the detent drag grows/
       // shrinks the sheet around it. Absent on the desktop dropdown path.
       var panelBody = panel.querySelector('[data-js="settings-panel-body"]');
+
+      // The scrim lives on a sibling element now (see above), so its drag state
+      // has to be driven in lockstep with the panel's: --sheet-drag fades the
+      // scrim/blur as the sheet is pulled down, and .is-dragging freezes its
+      // transition while the finger is down. Mirror every set onto the overlay.
+      function setSheetDrag(value) {
+        panel.style.setProperty("--sheet-drag", value);
+        if (overlay) {
+          overlay.style.setProperty("--sheet-drag", value);
+        }
+      }
+      function clearSheetDrag() {
+        panel.style.removeProperty("--sheet-drag");
+        if (overlay) {
+          overlay.style.removeProperty("--sheet-drag");
+        }
+      }
+      function setSheetDragging(on) {
+        panel.classList.toggle("is-dragging", on);
+        if (overlay) {
+          overlay.classList.toggle("is-dragging", on);
+        }
+      }
+
       var sheetExpanded = false;
       // The resting outer height (px), measured while the sheet is actually at
       // rest (on open, and at the start of a rest drag). Reused when a drag
@@ -130,6 +160,16 @@
         openGeneration++;
         toggle.setAttribute("aria-expanded", open ? "true" : "false");
         setSettingsPanelOpenState(open);
+        // Show/hide the real scrim with the panel. On desktop the CSS keeps it
+        // display:none, so un-hiding it there is a no-op — no scrim on the
+        // anchored dropdown, only on the mobile bottom sheet.
+        if (overlay) {
+          if (open) {
+            overlay.removeAttribute("hidden");
+          } else {
+            overlay.setAttribute("hidden", "");
+          }
+        }
         if (open) {
           positionPanel();
           // Capture the true resting height now, while the sheet hugs its
@@ -160,12 +200,15 @@
           }
           dragEngaged = false;
           dragDelta = 0;
-          panel.classList.remove("is-dragging");
+          setSheetDragging(false);
           panel.style.height = "";
           panel.style.maxHeight = "";
           panel.style.transform = "";
           panel.style.transition = "";
-          panel.style.removeProperty("--sheet-drag");
+          clearSheetDrag();
+          if (overlay) {
+            overlay.style.transition = "";
+          }
           if (panelBody) {
             panelBody.scrollTop = 0;
           }
@@ -396,7 +439,7 @@
           // Keep the overflow fade through the drag (it re-evaluates on settle)
           // so it doesn't blink out the moment you touch the sheet.
           setDragTransition(false);
-          panel.classList.add("is-dragging"); // freezes the ::backdrop transition
+          setSheetDragging(true); // freezes the scrim's transition too
           // Snapshot the geometry the live resize + release decision work in:
           // the outer height at grab, the full detent, and the resting height
           // (measured when already at rest, computed from content otherwise).
@@ -432,15 +475,12 @@
         if (proposed >= dragRestPx) {
           panel.style.transform = "";
           panel.style.height = Math.min(proposed, dragFullPx) + "px";
-          panel.style.setProperty("--sheet-drag", "0");
+          setSheetDrag("0");
         } else {
           panel.style.height = dragRestPx + "px";
           var off = dragRestPx - proposed;
           panel.style.transform = "translateY(" + off + "px)";
-          panel.style.setProperty(
-            "--sheet-drag",
-            String(Math.min(1, off / (dragRestPx || 1)))
-          );
+          setSheetDrag(String(Math.min(1, off / (dragRestPx || 1))));
         }
         // Re-evaluate the overflow fade against the sheet's new live height, so
         // it fades in as a collapse crosses into overflow (not only on release).
@@ -489,7 +529,7 @@
         // just settles at rest).
         // Re-enable the CSS transitions (both the panel's and, via removing the
         // class, the ::backdrop's) so the tail motion animates.
-        panel.classList.remove("is-dragging");
+        setSheetDragging(false);
         setDragTransition(true);
         void panel.offsetHeight; // flush so the dragged position is the start
         if (action === "dismiss") {
@@ -520,7 +560,7 @@
             panel.style.transition = "";
             panel.style.height = "";
             panel.style.maxHeight = "";
-            panel.style.removeProperty("--sheet-drag");
+            clearSheetDrag();
           };
           var onEnd = function (ev) {
             if (ev.target === panel && ev.propertyName === "transform") {
@@ -530,11 +570,11 @@
           panel.addEventListener("transitionend", onEnd);
           window.setTimeout(finish, 500); // fallback if transitionend is missed
           panel.style.transform = "translateY(100%)";
-          panel.style.setProperty("--sheet-drag", "1");
+          setSheetDrag("1");
           return;
         }
         panel.style.transform = "";
-        panel.style.setProperty("--sheet-drag", "0");
+        setSheetDrag("0");
         // Leave max-height unconstrained (it's "none" from the drag) through the
         // height transition — a none→length max-height isn't interpolated, so
         // reapplying the cap now would clamp a high dragged height to rest before

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -959,10 +959,16 @@
     // Touch support for swipe-to-close on mobile bottom sheet
     let touchStartY = 0;
     let touchCurrentY = 0;
+    // Whether this gesture has engaged the dismiss drag (vs. scrolling the body).
+    let swipeDragging = false;
 
     if (panel && overlay) {
+      const legacyBody = panel.querySelector('[data-js="settings-panel-body"]');
+
       panel.addEventListener("touchstart", function (e) {
         touchStartY = e.changedTouches[0].screenY;
+        touchCurrentY = touchStartY;
+        swipeDragging = false;
         panel.style.transition = "none";
         overlay.style.transition = "none";
       });
@@ -971,17 +977,26 @@
         touchCurrentY = e.changedTouches[0].screenY;
         const deltaY = touchCurrentY - touchStartY;
 
-        // Only allow dragging downwards
-        if (deltaY > 0) {
-          e.preventDefault();
-          panel.style.transform = `translateY(${deltaY}px)`;
-
-          // Update overlay opacity based on drag distance
-          const panelHeight = panel.getBoundingClientRect().height;
-          const maxDeltaY = window.innerHeight - panelHeight - 8; // 8px from bottom
-          const opacity = 1 - deltaY / maxDeltaY;
-          overlay.style.opacity = Math.max(opacity, 0);
+        // Engage the dismiss drag only on a downward pull while the scroll
+        // container is at the top. When the body is scrolled down, a downward
+        // pull is the user scrolling back up toward the nav / earlier settings —
+        // leave it to the browser instead of hijacking it to close the sheet.
+        if (!swipeDragging) {
+          if (deltaY > 0 && (!legacyBody || legacyBody.scrollTop <= 0)) {
+            swipeDragging = true;
+          } else {
+            return;
+          }
         }
+
+        e.preventDefault();
+        panel.style.transform = `translateY(${deltaY}px)`;
+
+        // Update overlay opacity based on drag distance
+        const panelHeight = panel.getBoundingClientRect().height;
+        const maxDeltaY = window.innerHeight - panelHeight - 8; // 8px from bottom
+        const opacity = 1 - deltaY / maxDeltaY;
+        overlay.style.opacity = Math.max(opacity, 0);
       });
 
       panel.addEventListener("touchend", function (_e) {
@@ -990,8 +1005,9 @@
         panel.style.transition = "transform 0.3s ease-in-out";
         overlay.style.transition = "opacity 0.3s ease-in-out";
 
-        // Close if dragged down more than 50px
-        if (deltaY > 50) {
+        // Close only if this gesture actually engaged the dismiss drag and
+        // travelled past the threshold — a scroll-up release must never close.
+        if (swipeDragging && deltaY > 50) {
           closePanel();
         } else {
           // Return to original position
@@ -999,6 +1015,7 @@
           overlay.style.opacity = "1";
         }
 
+        swipeDragging = false;
         touchStartY = 0;
         touchCurrentY = 0;
       });

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -961,6 +961,9 @@
     let touchCurrentY = 0;
     // Whether this gesture has engaged the dismiss drag (vs. scrolling the body).
     let swipeDragging = false;
+    // Whether this gesture is even eligible to become a dismiss — latched once,
+    // at touchstart, from the body's scroll position.
+    let swipeCanDismiss = false;
 
     if (panel && overlay) {
       const legacyBody = panel.querySelector('[data-js="settings-panel-body"]');
@@ -969,6 +972,12 @@
         touchStartY = e.changedTouches[0].screenY;
         touchCurrentY = touchStartY;
         swipeDragging = false;
+        // Decide dismiss eligibility ONCE, here — only a gesture that begins
+        // with the body already at the top may become a dismiss. A gesture that
+        // starts scrolled stays a scroll for its whole duration, so reaching the
+        // top mid-swipe can't hijack it (and jump the sheet by the whole delta
+        // measured from touchstart) into a close.
+        swipeCanDismiss = !legacyBody || legacyBody.scrollTop <= 0;
         panel.style.transition = "none";
         overlay.style.transition = "none";
       });
@@ -977,12 +986,11 @@
         touchCurrentY = e.changedTouches[0].screenY;
         const deltaY = touchCurrentY - touchStartY;
 
-        // Engage the dismiss drag only on a downward pull while the scroll
-        // container is at the top. When the body is scrolled down, a downward
-        // pull is the user scrolling back up toward the nav / earlier settings —
-        // leave it to the browser instead of hijacking it to close the sheet.
+        // Engage the dismiss drag only on a downward pull, and only when this
+        // gesture was eligible from the start (body at the top). Otherwise it's
+        // the user scrolling the body — leave it to the browser.
         if (!swipeDragging) {
-          if (deltaY > 0 && (!legacyBody || legacyBody.scrollTop <= 0)) {
+          if (swipeCanDismiss && deltaY > 0) {
             swipeDragging = true;
           } else {
             return;

--- a/assets/js/settings-dropdown.js
+++ b/assets/js/settings-dropdown.js
@@ -153,16 +153,72 @@
         }
       }
       function clearSheetDrag() {
+        // Panel only — the overlay's --sheet-drag is owned by openOverlay /
+        // closeOverlay (and the live drag). Clearing it here would undo the
+        // fade-out closeOverlay sets, snapping the scrim back to full opacity.
         panel.style.removeProperty("--sheet-drag");
-        if (overlay) {
-          overlay.style.removeProperty("--sheet-drag");
-        }
       }
       function setSheetDragging(on) {
         panel.classList.toggle("is-dragging", on);
         if (overlay) {
           overlay.classList.toggle("is-dragging", on);
         }
+      }
+
+      // Open the scrim: un-hide and clear any closing/drag state so it fades in
+      // fresh (base opacity:0 -> open, via @starting-style in the CSS).
+      function openOverlay() {
+        if (!overlay) {
+          return;
+        }
+        overlay.classList.remove("is-dragging");
+        overlay.style.transition = "";
+        overlay.style.removeProperty("--sheet-drag");
+        overlay.removeAttribute("hidden");
+      }
+
+      // Close the scrim in step with the sheet's popover exit: fade it out first
+      // (opacity/blur -> 0 via --sheet-drag), then set [hidden] once the
+      // transition ends. Setting [hidden] immediately would display:none the
+      // element before its transition could run, snapping the wash away while the
+      // sheet is still sliding out. Guarded by openGeneration so a quick reopen
+      // doesn't hide the freshly reopened scrim.
+      function closeOverlay() {
+        if (!overlay || overlay.hasAttribute("hidden")) {
+          return;
+        }
+        overlay.classList.remove("is-dragging");
+        overlay.style.transition = "";
+        overlay.style.setProperty("--sheet-drag", "1");
+        var gen = openGeneration;
+        var done = false;
+        var timer = null;
+        var onEnd = null;
+        var finish = function () {
+          if (done) {
+            return;
+          }
+          done = true;
+          overlay.removeEventListener("transitionend", onEnd);
+          if (timer) {
+            window.clearTimeout(timer);
+          }
+          // Reopened since this close armed? leave the now-open scrim alone.
+          if (openGeneration !== gen) {
+            return;
+          }
+          overlay.setAttribute("hidden", "");
+          overlay.style.removeProperty("--sheet-drag");
+        };
+        onEnd = function (ev) {
+          if (ev.target === overlay && ev.propertyName === "opacity") {
+            finish();
+          }
+        };
+        overlay.addEventListener("transitionend", onEnd);
+        // Fallback if transitionend never arrives (desktop keeps the overlay
+        // display:none, reduced-motion, an interrupted close, etc.).
+        timer = window.setTimeout(finish, 500);
       }
 
       var sheetExpanded = false;
@@ -182,16 +238,11 @@
         toggle.setAttribute("aria-expanded", open ? "true" : "false");
         setSettingsPanelOpenState(open);
         // Show/hide the real scrim with the panel. On desktop the CSS keeps it
-        // display:none, so un-hiding it there is a no-op — no scrim on the
-        // anchored dropdown, only on the mobile bottom sheet.
-        if (overlay) {
-          if (open) {
-            overlay.removeAttribute("hidden");
-          } else {
-            overlay.setAttribute("hidden", "");
-          }
-        }
+        // display:none, so this is a no-op there — no scrim on the anchored
+        // dropdown, only on the mobile bottom sheet. Close fades out first (see
+        // closeOverlay) instead of snapping [hidden] on mid-slide.
         if (open) {
+          openOverlay();
           positionPanel();
           // Capture the true resting height now, while the sheet hugs its
           // content (before any expand stretches the body).
@@ -227,9 +278,7 @@
           panel.style.transform = "";
           panel.style.transition = "";
           clearSheetDrag();
-          if (overlay) {
-            overlay.style.transition = "";
-          }
+          closeOverlay();
           if (panelBody) {
             panelBody.scrollTop = 0;
           }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -49,7 +49,13 @@
     var duration = Number(durationMs) || THEME_SWAP_TRANSITION_DEFAULT_MS;
     stopThemeTransitionTimer();
     document.body.classList.remove("darkmodeTransition");
-    document.body.style.setProperty(
+    // Set the duration on :root, not <body>. Safari inherits top-layer elements
+    // (the open settings sheet is a popover) from :root rather than their DOM
+    // parent, so a var on <body> never reached the sheet — it fell back to
+    // --motion-duration-xslow (1000ms) while the page used this 700ms, and the
+    // sheet's colour swap lagged behind the rest of the page. On :root the sheet
+    // inherits it too (same path --surface-page already takes), so they sync.
+    document.documentElement.style.setProperty(
       "--theme-transition-duration",
       duration + "ms"
     );
@@ -57,7 +63,9 @@
     document.body.classList.add("darkmodeTransition");
     themeTransitionTimer = window.setTimeout(function () {
       document.body.classList.remove("darkmodeTransition");
-      document.body.style.removeProperty("--theme-transition-duration");
+      document.documentElement.style.removeProperty(
+        "--theme-transition-duration"
+      );
       themeTransitionTimer = null;
     }, duration);
   }

--- a/assets/js/toast.js
+++ b/assets/js/toast.js
@@ -124,6 +124,14 @@
     textWrap.appendChild(valueEl);
     el.appendChild(iconWrap);
     el.appendChild(textWrap);
+    // The settings sheet is a top-layer popover; a plain z-indexed toast would
+    // sit behind it (and its backdrop). Promote the toast to the top layer too
+    // (manual = no light-dismiss, we auto-hide) where supported, so it always
+    // shows above the sheet. Browsers without popover keep the z-index path —
+    // there the sheet isn't a popover either, so nothing renders above it.
+    if (typeof el.showPopover === 'function') {
+      el.setAttribute('popover', 'manual');
+    }
     document.body.appendChild(el);
     el.addEventListener('touchstart', onTouchStart, { passive: true });
     el.addEventListener('touchmove', onTouchMove, { passive: false });
@@ -165,6 +173,10 @@
     valueEl.textContent = value || '';
     setIcon(iconId);
 
+    // Reveal in the top layer before animating in (popover starts display:none).
+    if (toast.hasAttribute('popover') && !toast.matches(':popover-open')) {
+      try { toast.showPopover(); } catch (e) { /* already open / unsupported */ }
+    }
     // Force reflow so the browser sees the class change
     void toast.offsetWidth;
     toast.classList.add('toast--visible');
@@ -183,6 +195,10 @@
 
     var afterHide = function () {
       el.classList.remove('toast--hiding');
+      // Drop it back out of the top layer once faded out.
+      if (el.hasAttribute('popover') && el.matches(':popover-open')) {
+        try { el.hidePopover(); } catch (e) { /* already closed */ }
+      }
     };
 
     el.addEventListener('animationend', afterHide, { once: true });

--- a/assets/js/toast.js
+++ b/assets/js/toast.js
@@ -24,6 +24,12 @@
   var titleEl = null;
   var valueEl = null;
   var hideTimer = null;
+  // Pending teardown from the last hide() — tracked so a superseding show() can
+  // cancel it before it fires. Otherwise the stale animationend listener / 400ms
+  // fallback would hidePopover() the reused element out from under a new toast,
+  // leaving it flagged visible but removed from the top layer (so, invisible).
+  var hideListener = null;
+  var hideFallbackTimer = null;
   var spriteBase = '';
   var swipeStartX = 0;
   var swipeStartY = 0;
@@ -165,18 +171,30 @@
     var iconId = (options && options.icon) || '';
     var toast = getOrCreate();
 
-    // Reset any in-progress animation
+    // Reset any in-progress animation, and cancel a pending hide() teardown so
+    // its stale animationend/fallback can't hidePopover() this element after we
+    // reopen it below.
     clearTimeout(hideTimer);
+    cancelPendingHide();
     toast.classList.remove('toast--hiding', 'toast--visible');
+
+    // Reveal in the top layer BEFORE writing the text. A closed popover is
+    // display:none, so a polite live-region update made while it's hidden is
+    // skipped by screen readers; opening first puts the region in the a11y tree
+    // so the confirmation is announced. Re-show even when already open: a
+    // settings sheet closed and reopened after this toast would sit above it in
+    // the top layer, so drop and re-add to re-promote it to the top.
+    if (toast.hasAttribute('popover')) {
+      try {
+        if (toast.matches(':popover-open')) { toast.hidePopover(); }
+        toast.showPopover();
+      } catch (e) { /* unsupported / race */ }
+    }
 
     titleEl.textContent = title || '';
     valueEl.textContent = value || '';
     setIcon(iconId);
 
-    // Reveal in the top layer before animating in (popover starts display:none).
-    if (toast.hasAttribute('popover') && !toast.matches(':popover-open')) {
-      try { toast.showPopover(); } catch (e) { /* already open / unsupported */ }
-    }
     // Force reflow so the browser sees the class change
     void toast.offsetWidth;
     toast.classList.add('toast--visible');
@@ -186,14 +204,29 @@
     }, duration);
   }
 
+  // Cancel a pending hide() teardown (its animationend listener + fallback
+  // timer) so it can't run after a superseding show() has reopened the toast.
+  function cancelPendingHide() {
+    if (hideFallbackTimer) {
+      clearTimeout(hideFallbackTimer);
+      hideFallbackTimer = null;
+    }
+    if (el && hideListener) {
+      el.removeEventListener('animationend', hideListener);
+    }
+    hideListener = null;
+  }
+
   function hide() {
     if (!el) {return;}
     clearTimeout(hideTimer);
+    cancelPendingHide();
 
     el.classList.remove('toast--visible');
     el.classList.add('toast--hiding');
 
     var afterHide = function () {
+      cancelPendingHide();
       el.classList.remove('toast--hiding');
       // Drop it back out of the top layer once faded out.
       if (el.hasAttribute('popover') && el.matches(':popover-open')) {
@@ -201,9 +234,10 @@
       }
     };
 
+    hideListener = afterHide;
     el.addEventListener('animationend', afterHide, { once: true });
     // Safety fallback
-    setTimeout(afterHide, 400);
+    hideFallbackTimer = setTimeout(afterHide, 400);
   }
 
   /**

--- a/layouts/partials/settings-dropdown.html
+++ b/layouts/partials/settings-dropdown.html
@@ -25,9 +25,19 @@
     aria-haspopup="true"
     data-js="settings-toggle"
   >
-    <span class="settings-icon" aria-hidden="true">
+    {{/* The panel is settings-only on desktop (gear), but on phones it also
+      carries the primary nav (see the .settings-nav block below), so the
+      trigger becomes a menu glyph there. CSS swaps the two at the nav
+      breakpoint — settings-dropdown.css.
+    */}}
+    <span class="settings-icon settings-icon--gear" aria-hidden="true">
       <svg class="icon" aria-hidden="true">
         <use href="#icon-settings"></use>
+      </svg>
+    </span>
+    <span class="settings-icon settings-icon--menu" aria-hidden="true">
+      <svg class="icon" aria-hidden="true">
+        <use href="#icon-menu"></use>
       </svg>
     </span>
   </button>
@@ -45,6 +55,51 @@
       the body scrolls when content overflows a detent.
     */}}
     <div class="settings-panel__body" data-js="settings-panel-body">
+      {{/* Mobile navigation. On phones the header drops the primary nav links
+        (no room beside the brand + controls), so they live here at the top of
+        the sheet. Shown only where the header nav is hidden (<=47.9375em) — see
+        settings-dropdown.css; hidden in the desktop dropdown, which sits under a
+        header that already carries the nav. Plain links: a tap navigates and the
+        sheet closes with the page. Active-link + client/employer scoping mirror
+        the header's top nav. Inside .settings-panel__body so it rides the sheet's
+        internal scroll / detents.
+      */}}
+      <nav class="settings-nav" aria-label="{{ i18n "menu_title" }}">
+        <div class="theme-section-heading">
+          <h3 class="theme-section-title">{{ i18n "navigation" }}</h3>
+        </div>
+        <ul class="settings-nav__list">
+          {{- $urltop := .RelPermalink -}}
+          <li class="settings-nav__item" data-menu-id="home">
+            <a
+              class="settings-nav__link {{ if .IsHome }}active{{ end }}"
+              href="{{ "/" | relLangURL }}"
+              {{ if .IsHome }}aria-current="page"{{ end }}
+              >{{ i18n "home" }}</a
+            >
+          </li>
+          {{- range .Site.Menus.top -}}
+            {{- $nameLower := lower .Name -}}
+            {{- $isContact := or (eq .Identifier "contact") (eq $nameLower "contact") (eq $nameLower "kontakt") -}}
+            {{- if not $isContact -}}
+              {{- $linkURL := .URL | relLangURL -}}
+              <li class="settings-nav__item" data-menu-id="{{ .Identifier }}">
+                <a
+                  class="settings-nav__link {{ if eq $urltop $linkURL }}
+                    active
+                  {{ end }}"
+                  href="{{ $linkURL }}"
+                  {{ if eq $urltop $linkURL }}aria-current="page"{{ end }}
+                  >{{ .Name }}</a
+                >
+              </li>
+            {{- end -}}
+          {{- end -}}
+        </ul>
+      </nav>
+
+      <div class="theme-divider settings-nav__divider"></div>
+
       <div class="theme-section theme-section--mode">
         <div class="theme-section-heading">
           <h3 class="theme-section-title">{{ i18n "mode" }}</h3>

--- a/layouts/partials/settings-dropdown.html
+++ b/layouts/partials/settings-dropdown.html
@@ -68,16 +68,12 @@
         <div class="theme-section-heading">
           <h3 class="theme-section-title">{{ i18n "navigation" }}</h3>
         </div>
+        {{/* No Home entry: like the desktop header nav, home is the brand
+          wordmark (top-left, links to /), which is present on mobile too — an
+          explicit Home here would duplicate it and diverge from desktop.
+        */}}
         <ul class="settings-nav__list">
           {{- $urltop := .RelPermalink -}}
-          <li class="settings-nav__item" data-menu-id="home">
-            <a
-              class="settings-nav__link {{ if .IsHome }}active{{ end }}"
-              href="{{ "/" | relLangURL }}"
-              {{ if .IsHome }}aria-current="page"{{ end }}
-              >{{ i18n "home" }}</a
-            >
-          </li>
           {{- range .Site.Menus.top -}}
             {{- $nameLower := lower .Name -}}
             {{- $isContact := or (eq .Identifier "contact") (eq $nameLower "contact") (eq $nameLower "kontakt") -}}

--- a/layouts/partials/settings-dropdown.html
+++ b/layouts/partials/settings-dropdown.html
@@ -18,9 +18,18 @@
 
 
 <div class="settings-dropdown">
+  {{/* The trigger opens a settings-only panel on desktop (gear) but the primary
+    menu on phones, where it also carries the nav (see .settings-nav). Its
+    accessible name follows suit: "Settings" on desktop, the main-menu label at
+    the nav breakpoint — settings-dropdown.js swaps aria-label to data-label-menu
+    there so screen-reader users find the navigation, not just settings. The
+    static aria-label is the desktop default (correct before JS runs).
+  */}}
   <button
     class="settings-toggle"
     aria-label="{{ i18n "Settings" }}"
+    data-label-settings="{{ i18n "Settings" }}"
+    data-label-menu="{{ i18n "menu_title" }}"
     aria-expanded="false"
     aria-haspopup="true"
     data-js="settings-toggle"

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -31,12 +31,19 @@
   </symbol>
   <symbol id="icon-menu" viewBox="0 0 24 24">
     <path
-      d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5"
-      fill="none"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="1.5"
+      d="M8.75 3.25a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0"
+      fill="currentColor"
+      stroke="none"
+    ></path>
+    <path
+      d="M8.75 12a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0"
+      fill="currentColor"
+      stroke="none"
+    ></path>
+    <path
+      d="M8.75 20.75a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0"
+      fill="currentColor"
+      stroke="none"
     ></path>
   </symbol>
   <symbol id="icon-contact" viewBox="0 0 24 24">

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -29,6 +29,16 @@
       stroke-width="1"
     ></path>
   </symbol>
+  <symbol id="icon-menu" viewBox="0 0 24 24">
+    <path
+      d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5"
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.5"
+    ></path>
+  </symbol>
   <symbol id="icon-contact" viewBox="0 0 24 24">
     <g transform="translate(2.5, 3)">
       <path

--- a/layouts/partials/topmenu.html
+++ b/layouts/partials/topmenu.html
@@ -31,19 +31,28 @@
   </symbol>
   <symbol id="icon-menu" viewBox="0 0 24 24">
     <path
-      d="M8.75 3.25a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0"
-      fill="currentColor"
-      stroke="none"
+      d="M9.362 3.378a2.625 2.625 0 1 0 5.25 0 2.625 2.625 0 1 0 -5.25 0Z"
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.5"
     ></path>
     <path
-      d="M8.75 12a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0"
-      fill="currentColor"
-      stroke="none"
+      d="M9.362 12.003a2.625 2.625 0 1 0 5.25 0 2.625 2.625 0 1 0 -5.25 0Z"
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.5"
     ></path>
     <path
-      d="M8.75 20.75a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0"
-      fill="currentColor"
-      stroke="none"
+      d="M9.362 20.628a2.625 2.625 0 1 0 5.25 0 2.625 2.625 0 1 0 -5.25 0Z"
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.5"
     ></path>
   </symbol>
   <symbol id="icon-contact" viewBox="0 0 24 24">

--- a/layouts/partials/ui-library/tab-components.html
+++ b/layouts/partials/ui-library/tab-components.html
@@ -1619,6 +1619,17 @@
                   <div class="icon-card">
                     <svg class="icon" width="24" height="24">
                       <use
+                        href="{{ "img/svg/sprite.svg?v=20260211b" | relURL }}#icon-menu"
+                      ></use>
+                    </svg>
+                    <p class="type-information text-muted">
+                      <code>icon-menu</code>
+                    </p>
+                  </div>
+
+                  <div class="icon-card">
+                    <svg class="icon" width="24" height="24">
+                      <use
                         href="{{ "img/svg/sprite.svg?v=20260211b" | relURL }}#icon-system"
                       ></use>
                     </svg>

--- a/static/img/svg/sprite.svg
+++ b/static/img/svg/sprite.svg
@@ -82,11 +82,11 @@
     <path d="M19.922 7.213a1.874 1.874 0 0 0 1.065 2.571l1.265 0.45a1.875 1.875 0 0 1 0 3.534l-1.265 0.45a1.874 1.874 0 0 0 -1.065 2.571L20.5 18a1.875 1.875 0 0 1 -2.5 2.5l-1.213 -0.576a1.874 1.874 0 0 0 -2.571 1.065l-0.45 1.265a1.875 1.875 0 0 1 -3.533 0l-0.45 -1.265a1.875 1.875 0 0 0 -2.572 -1.065L6 20.5A1.874 1.874 0 0 1 3.5 18l0.576 -1.213a1.874 1.874 0 0 0 -1.065 -2.571l-1.265 -0.45a1.875 1.875 0 0 1 0 -3.534l1.265 -0.45a1.874 1.874 0 0 0 1.065 -2.569L3.5 6A1.874 1.874 0 0 1 6 3.5l1.213 0.576a1.875 1.875 0 0 0 2.57 -1.063l0.45 -1.265a1.875 1.875 0 0 1 3.533 0l0.45 1.265a1.874 1.874 0 0 0 2.571 1.065L18 3.5A1.875 1.875 0 0 1 20.5 6Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
     <path d="M7.499 12.001a4.5 4.5 0 1 0 9 0 4.5 4.5 0 1 0 -9 0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
   </symbol>
-  <!-- Menu Icon (vertical, three dots) -->
+  <!-- Menu Icon (vertical, three outline dots) -->
   <symbol id="icon-menu" viewBox="0 0 24 24">
-    <path d="M8.75 3.25a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0" fill="currentColor" stroke="none"></path>
-    <path d="M8.75 12a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0" fill="currentColor" stroke="none"></path>
-    <path d="M8.75 20.75a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0" fill="currentColor" stroke="none"></path>
+    <path d="M9.362 3.378a2.625 2.625 0 1 0 5.25 0 2.625 2.625 0 1 0 -5.25 0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+    <path d="M9.362 12.003a2.625 2.625 0 1 0 5.25 0 2.625 2.625 0 1 0 -5.25 0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
+    <path d="M9.362 20.628a2.625 2.625 0 1 0 5.25 0 2.625 2.625 0 1 0 -5.25 0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path>
   </symbol>
 
   <!-- Accordion Plus Icon -->

--- a/static/img/svg/sprite.svg
+++ b/static/img/svg/sprite.svg
@@ -82,6 +82,12 @@
     <path d="M19.922 7.213a1.874 1.874 0 0 0 1.065 2.571l1.265 0.45a1.875 1.875 0 0 1 0 3.534l-1.265 0.45a1.874 1.874 0 0 0 -1.065 2.571L20.5 18a1.875 1.875 0 0 1 -2.5 2.5l-1.213 -0.576a1.874 1.874 0 0 0 -2.571 1.065l-0.45 1.265a1.875 1.875 0 0 1 -3.533 0l-0.45 -1.265a1.875 1.875 0 0 0 -2.572 -1.065L6 20.5A1.874 1.874 0 0 1 3.5 18l0.576 -1.213a1.874 1.874 0 0 0 -1.065 -2.571l-1.265 -0.45a1.875 1.875 0 0 1 0 -3.534l1.265 -0.45a1.874 1.874 0 0 0 1.065 -2.569L3.5 6A1.874 1.874 0 0 1 6 3.5l1.213 0.576a1.875 1.875 0 0 0 2.57 -1.063l0.45 -1.265a1.875 1.875 0 0 1 3.533 0l0.45 1.265a1.874 1.874 0 0 0 2.571 1.065L18 3.5A1.875 1.875 0 0 1 20.5 6Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
     <path d="M7.499 12.001a4.5 4.5 0 1 0 9 0 4.5 4.5 0 1 0 -9 0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
   </symbol>
+  <!-- Menu Icon (vertical, three dots) -->
+  <symbol id="icon-menu" viewBox="0 0 24 24">
+    <path d="M8.75 3.25a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0" fill="currentColor" stroke="none"></path>
+    <path d="M8.75 12a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0" fill="currentColor" stroke="none"></path>
+    <path d="M8.75 20.75a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0" fill="currentColor" stroke="none"></path>
+  </symbol>
 
   <!-- Accordion Plus Icon -->
   <symbol id="icon-plus" viewBox="0 0 24 24">


### PR DESCRIPTION
On phones the primary nav links (Home/Works/Writing/About) don't fit the top bar beside the brand + controls, so they were reachable only by scrolling to the footer. Fold them into the settings panel instead, and turn the header trigger into a menu glyph so it reads as "menu", not just "settings".

Rebased onto master after #268 merged, so this builds on the settings-sheet detents/scroll rather than adding its own.

## Changes

- **topmenu.html:** add an `#icon-menu` (hamburger) symbol.
- **settings-dropdown.html:** a Navigation section at the top of `.settings-panel__body` (so it rides the sheet's internal scroll / detents from #268); mirrors the header's active-link + client/employer scoping. The toggle now carries both a gear and a menu glyph.
- **settings-dropdown.css:** reveal the nav section and swap gear→menu at the same breakpoint the header nav disappears (`<=47.9375em`) — spanning both the tablet dropdown and the phone sheet. Nav is a single non-wrapping row so it adds minimal height to the resting detent.

## Verification

- Hugo build green (EN + SV); prettier + eslint clean; JS suite green.
- Rendered at 390 / 375 (iPhone SE): nav sits at the top of the sheet, active-link follows the page, and on short viewports the sheet rests at 82dvh with the nav in the scrollable body (no clipping). Desktop dropdown unchanged (gear, no nav).

## Open question (design)

This is effectively a menu behind an icon — nav is one tap away rather than always visible. Two small polish items intentionally left for a decision:
- The toggle's `aria-label` is still "Settings"; on phones it now also opens nav, so "Menu" would be more accurate for screen readers (it's a shared control with desktop).
- The nav section heading is "Navigation" — "Meny"/"Sidor" would work too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)