### PR TITLE
Remove unused Typekit and the dead Mailchimp endpoint

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -63,7 +63,7 @@
       </address>
     </div>
 
-    {{- $newsletterAction := .Site.Params.newsletter_action | default "https://tor-bjorn.us14.list-manage.com/subscribe/post-json?u=294f66f378d5370fcbc5aa02f&id=74c003d094&f_id=0075bce5f0&c=?" -}}
+    {{- $newsletterAction := .Site.Params.newsletter_action | default "/.netlify/functions/newsletter-subscribe" -}}
     {{- $newsletterEmailField := .Site.Params.newsletter_email_field | default "EMAIL" -}}
     <section class="footer-newsletter use-subgrid">
       <div class="footer-newsletter__inner">

--- a/layouts/portfolio-print/single.html
+++ b/layouts/portfolio-print/single.html
@@ -4,14 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-      Portfolio – {{ .Params.company_name | title }} | {{ .Site.Title }}
+      Portfolio – {{ .Params.company_name | title }} |
+      {{ .Site.Title }}
     </title>
     <meta name="robots" content="noindex, nofollow" />
-
-    <!-- Typekit fonts -->
-    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
-    <link rel="preconnect" href="https://p.typekit.net" crossorigin />
-    <link rel="stylesheet" href="https://use.typekit.net/diz3sha.css" />
 
     <!-- CSS -->
     {{ $reset := resources.Get "css/base/reset.css" }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -99,16 +99,15 @@
     #   - script:  self + inline (many pre-hydration <head> scripts + the
     #              preload onload= handler) + the Cloudflare Web Analytics beacon.
     #   - style:   self + inline (@font-face block, critical hero CSS, the
-    #              theme-no-trans style injected by the head script) + Adobe
-    #              Typekit, used by the portfolio-print layout.
-    #   - font:    self (self-hosted woff2) + Typekit (print layout).
+    #              theme-no-trans style injected by the head script).
+    #   - font:    self (self-hosted woff2 only).
     #   - img:     self + data: (inline SVG sprites / data-URI icons).
     #   - connect: self (Netlify functions, same-origin nav prefetch, contact +
     #              newsletter POST) + the Cloudflare beacon endpoint.
     #   - frame:   self (the hero-embed <iframe> is always same-origin).
     # No eval/new Function anywhere, so 'unsafe-eval' is intentionally omitted.
     # Kept on one line — Netlify header values do not support continuation.
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://use.typekit.net; img-src 'self' data:; font-src 'self' https://use.typekit.net https://p.typekit.net; connect-src 'self' https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://cloudflareinsights.com https://static.cloudflareinsights.com; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'"
 
 [[headers]]
   for = "/fonts/*"


### PR DESCRIPTION
You mentioned you no longer use Typekit or Mailchimp — verified both are unused at runtime and removed the leftovers.

## Typekit
- Loaded only by `portfolio-print/single.html` (three noindex print pages). An audit of every `font-family` declaration across `assets/css/` found **no reference to any Typekit font family** — the print pages render in the self-hosted fonts via the bundled CSS. The `use.typekit.net/diz3sha.css` stylesheet was dead weight (a render-blocking third-party request), so the three `<link>`s are gone.
- **CSP tightened** accordingly (`netlify.toml`): dropped `use.typekit.net` from `style-src` and `use.typekit.net` / `p.typekit.net` from `font-src` — `font-src` is now `'self'` only. The CSP now references no third-party origin except the Cloudflare analytics beacon.

## Mailchimp
- The newsletter form posts to the Netlify function (`Site.Params.newsletter_action`, set in `config.toml` → Brevo). The `list-manage.com` URL survived only as a **never-used default fallback** in `footer.html` that also embedded the Mailchimp account/list ids; replaced it with the function path.
- `newsletter-form.js` does a plain `fetch` expecting the function's JSON contract — no Mailchimp-specific JSONP anywhere, so nothing else changes.
- **Kept `data-mc-form`**: it's now just the selector the newsletter JS (and terminal-flows.js) use to find the form, not a Mailchimp dependency — renaming it would be pure churn across three files.

## Verification
Template/config-only. Built by `pr-checks` + the Netlify Deploy Preview. No lingering `typekit` / `list-manage` / account-id references remain in `layouts/`, `assets/`, `netlify/`, or `config.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYpjRwAVKiK2JfW1PVLJDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYpjRwAVKiK2JfW1PVLJDr)_