### PR TITLE
Set coverage ratchet floors (were all 0)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,12 +17,16 @@ module.exports = {
   ],
 
   // Coverage thresholds (starting conservative, will increase over time)
+  // Ratchet floors, set a few points below the current numbers (statements ~45,
+  // branches ~37, functions ~51, lines ~45) so they don't fail today's suite but
+  // do catch a real regression — a PR that deletes tests or lands a chunk of
+  // untested code. Raise them as coverage climbs; don't lower them.
   coverageThreshold: {
     global: {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0,
+      branches: 30,
+      functions: 45,
+      lines: 40,
+      statements: 40,
     },
   },
 


### PR DESCRIPTION
From the review's testing-gaps finding. `jest.config.js` had `coverageThreshold` all at `0`, so `npm run test:coverage` (run in CI) could never fail on a coverage regression.

Set floors a few points below the current numbers (statements ~46%, branches ~38%, functions ~52%, lines ~46%): **branches 30, functions 45, lines 40, statements 40**. They pass today's suite (verified locally, exit 0) and catch a real drop — deleted tests or a chunk of untested code landing. Raise as coverage climbs.

Fully self-contained; no site output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYpjRwAVKiK2JfW1PVLJDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYpjRwAVKiK2JfW1PVLJDr)_