### PR TITLE
Update privacy policy to match actual project setup

### DIFF
--- a/content/english/legal/privacy/index.md
+++ b/content/english/legal/privacy/index.md
@@ -14,6 +14,7 @@ In line with GDPR and to be transparent, this page explains what data I collect 
 
 - Newsletter sign‑ups: email address submitted via the form in the footer.
 - Contact form: name, email address, and message.
+- On‑page assistant: if you use the terminal‑style assistant and report a bad answer, or ask something it cannot answer, the text you typed and the assistant's reply are logged.
 
 For aggregate visitor statistics I use Cloudflare Web Analytics. It is privacy‑first: it sets no cookies, does not fingerprint you, and does not collect any personal data — it only records anonymous, aggregated metrics such as page views and referrers. This site sets no cookies of its own, and the services it relies on for the newsletter and contact form do not set cookies either. Spam on the contact form is handled with a hidden honeypot field rather than a captcha.
 
@@ -23,6 +24,7 @@ I also use Google Search Console to understand how visitors find the site via Go
 
 - Newsletter data is stored in Brevo and used only to send newsletters to people who have explicitly subscribed.
 - Contact form submissions are handled by Netlify Forms and forwarded to my email so I can respond to your message.
+- Assistant logs are filed as issues in this site's GitHub repository, and used only to improve the assistant. Please don't type personal information into the assistant.
 
 I do not sell personal information or share it with third‑party data brokers.
 

--- a/content/english/legal/privacy/index.md
+++ b/content/english/legal/privacy/index.md
@@ -14,7 +14,7 @@ In line with GDPR and to be transparent, this page explains what data I collect 
 
 - Newsletter sign‑ups: email address submitted via the form in the footer.
 - Contact form: name, email address, and message.
-- On‑page assistant: if you use the terminal‑style assistant and report a bad answer, or ask something it cannot answer, the text you typed and the assistant's reply are logged.
+- On‑page assistant: if you use the terminal‑style assistant and report a bad answer, or ask something it cannot answer, the text you typed and the assistant's reply are logged — along with a few of your most recent questions from the same session and basic metadata (the page you were on and the site language).
 
 For aggregate visitor statistics I use Cloudflare Web Analytics. It is privacy‑first: it sets no cookies, does not fingerprint you, and does not collect any personal data — it only records anonymous, aggregated metrics such as page views and referrers. This site sets no cookies of its own, and the services it relies on for the newsletter and contact form do not set cookies either. Spam on the contact form is handled with a hidden honeypot field rather than a captcha.
 

--- a/content/english/legal/privacy/index.md
+++ b/content/english/legal/privacy/index.md
@@ -13,16 +13,16 @@ In line with GDPR and to be transparent, this page explains what data I collect 
 ## What data I collect
 
 - Newsletter sign‑ups: email address submitted via the form in the footer.
-- Contact form: name, email address, subject, and message.
+- Contact form: name, email address, and message.
 
-For aggregate visitor statistics I use Cloudflare Web Analytics. It is privacy‑first: it sets no cookies, does not fingerprint you, and does not collect any personal data — it only records anonymous, aggregated metrics such as page views and referrers. This site uses no tracking cookies of its own. However, some third‑party services may set cookies, such as Google reCAPTCHA (used on the contact form).
+For aggregate visitor statistics I use Cloudflare Web Analytics. It is privacy‑first: it sets no cookies, does not fingerprint you, and does not collect any personal data — it only records anonymous, aggregated metrics such as page views and referrers. This site sets no cookies of its own, and the services it relies on for the newsletter and contact form do not set cookies either. Spam on the contact form is handled with a hidden honeypot field rather than a captcha.
 
 I also use Google Search Console to understand how visitors find the site via Google Search. This does not give me access to personal data about you.
 
 ## What I do with the data
 
-- Newsletter data is stored in Mailchimp and used only to send newsletters to people who have explicitly subscribed.
-- Contact form data is sent via Make.com to my email so I can respond to your message.
+- Newsletter data is stored in Brevo and used only to send newsletters to people who have explicitly subscribed.
+- Contact form submissions are handled by Netlify Forms and forwarded to my email so I can respond to your message.
 
 I do not sell personal information or share it with third‑party data brokers.
 

--- a/content/swedish/legal/privacy/index.md
+++ b/content/swedish/legal/privacy/index.md
@@ -15,7 +15,7 @@ I enlighet med GDPR och för att vara transparent beskriver jag här vilken data
 
 - Nyhetsbrev: e‑postadress som skickas via formuläret i sidfoten.
 - Kontaktformulär: namn, e‑postadress och meddelande.
-- Assistenten på sidan: om du använder den terminalliknande assistenten och rapporterar ett dåligt svar, eller ställer en fråga den inte kan besvara, loggas texten du skrev och assistentens svar.
+- Assistenten på sidan: om du använder den terminalliknande assistenten och rapporterar ett dåligt svar, eller ställer en fråga den inte kan besvara, loggas texten du skrev och assistentens svar — tillsammans med några av dina senaste frågor från samma session och grundläggande metadata (sidan du var på och sajtens språk).
 
 För övergripande besöksstatistik använder jag Cloudflare Web Analytics. Det är integritetsvänligt: det sätter inga cookies, fingeravtryckar dig inte och samlar inte in några personuppgifter — det registrerar endast anonym, aggregerad statistik som sidvisningar och hänvisande källor. Sajten sätter inga egna cookies, och tjänsterna som används för nyhetsbrevet och kontaktformuläret sätter inte heller några cookies. Skräppost i kontaktformuläret hanteras med ett dolt honeypot‑fält i stället för en captcha.
 

--- a/content/swedish/legal/privacy/index.md
+++ b/content/swedish/legal/privacy/index.md
@@ -14,16 +14,16 @@ I enlighet med GDPR och för att vara transparent beskriver jag här vilken data
 ## Vilken data jag samlar in
 
 - Nyhetsbrev: e‑postadress som skickas via formuläret i sidfoten.
-- Kontaktformulär: namn, e‑postadress, ämne och meddelande.
+- Kontaktformulär: namn, e‑postadress och meddelande.
 
-För övergripande besöksstatistik använder jag Cloudflare Web Analytics. Det är integritetsvänligt: det sätter inga cookies, fingeravtryckar dig inte och samlar inte in några personuppgifter — det registrerar endast anonym, aggregerad statistik som sidvisningar och hänvisande källor. Sajten använder inga egna spårningscookies. Däremot kan vissa tredjepartstjänster sätta cookies, till exempel Google reCAPTCHA (används i kontaktformuläret).
+För övergripande besöksstatistik använder jag Cloudflare Web Analytics. Det är integritetsvänligt: det sätter inga cookies, fingeravtryckar dig inte och samlar inte in några personuppgifter — det registrerar endast anonym, aggregerad statistik som sidvisningar och hänvisande källor. Sajten sätter inga egna cookies, och tjänsterna som används för nyhetsbrevet och kontaktformuläret sätter inte heller några cookies. Skräppost i kontaktformuläret hanteras med ett dolt honeypot‑fält i stället för en captcha.
 
 Jag använder även Google Search Console för att förstå hur besökare hittar hit via Google. Det ger mig inte tillgång till personuppgifter om dig.
 
 ## Hur data används
 
-- Nyhetsbrevsdata lagras i Mailchimp och används endast för att skicka nyhetsbrev till personer som aktivt har registrerat sig.
-- Data från kontaktformuläret skickas via Make.com till min e‑post så att jag kan svara på ditt meddelande.
+- Nyhetsbrevsdata lagras i Brevo och används endast för att skicka nyhetsbrev till personer som aktivt har registrerat sig.
+- Kontaktformulärets meddelanden hanteras av Netlify Forms och vidarebefordras till min e‑post så att jag kan svara på ditt meddelande.
 
 Jag säljer aldrig personuppgifter och delar inte information med data‑mäklare.
 

--- a/content/swedish/legal/privacy/index.md
+++ b/content/swedish/legal/privacy/index.md
@@ -15,6 +15,7 @@ I enlighet med GDPR och för att vara transparent beskriver jag här vilken data
 
 - Nyhetsbrev: e‑postadress som skickas via formuläret i sidfoten.
 - Kontaktformulär: namn, e‑postadress och meddelande.
+- Assistenten på sidan: om du använder den terminalliknande assistenten och rapporterar ett dåligt svar, eller ställer en fråga den inte kan besvara, loggas texten du skrev och assistentens svar.
 
 För övergripande besöksstatistik använder jag Cloudflare Web Analytics. Det är integritetsvänligt: det sätter inga cookies, fingeravtryckar dig inte och samlar inte in några personuppgifter — det registrerar endast anonym, aggregerad statistik som sidvisningar och hänvisande källor. Sajten sätter inga egna cookies, och tjänsterna som används för nyhetsbrevet och kontaktformuläret sätter inte heller några cookies. Skräppost i kontaktformuläret hanteras med ett dolt honeypot‑fält i stället för en captcha.
 
@@ -24,6 +25,7 @@ Jag använder även Google Search Console för att förstå hur besökare hittar
 
 - Nyhetsbrevsdata lagras i Brevo och används endast för att skicka nyhetsbrev till personer som aktivt har registrerat sig.
 - Kontaktformulärets meddelanden hanteras av Netlify Forms och vidarebefordras till min e‑post så att jag kan svara på ditt meddelande.
+- Assistentloggar sparas som ärenden (issues) i sajtens GitHub‑repository och används endast för att förbättra assistenten. Skriv inte personuppgifter till assistenten.
 
 Jag säljer aldrig personuppgifter och delar inte information med data‑mäklare.
 


### PR DESCRIPTION
## Summary

A review of the privacy policy against the actual implementation surfaced several details that no longer matched the code. This updates both the English and Swedish versions so the policy reflects what the site really does.

### Corrections
- **Newsletter: Mailchimp → Brevo.** `netlify/functions/newsletter-subscribe.js` posts sign-ups to the Brevo API.
- **Contact form: Make.com → Netlify Forms.** `layouts/partials/contact_form.html` uses `data-netlify="true"`; there is no Make.com integration.
- **Removed the Google reCAPTCHA / third-party cookie claim.** reCAPTCHA appeared only in the policy text — it exists nowhere in the site. Spam is handled with a honeypot field, and the CSP allows only self + Cloudflare, so no third-party cookies are set.
- **Removed the non-existent "subject" field** from the contact form data list — the form collects name, email, and message only.

### New disclosure
- **On-page assistant logging.** The terminal-style assistant (`assets/js/terminal-ai.js`) posts to the `clanker-report` function, which files reported or unanswered questions as issues in this repository. The policy now discloses what is logged (the visitor's typed text and the reply), where it goes, and what it is used for, plus a note not to enter personal information.

### Unchanged (verified accurate)
- Cloudflare Web Analytics (cookieless) and Google Search Console both match `layouts/partials/head.html`.
- Contact email addresses (hej@ / hi@tor-bjorn.com) match the site partials.

Both language files (`content/english/legal/privacy/index.md` and `content/swedish/legal/privacy/index.md`) are kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Td9t9GgopMMa8Ds9VHp76U)_