### PR TITLE
Méta-Matic: clean ASCII case URLs

### DIFF
--- a/content/english/works/meta-matic/index.md
+++ b/content/english/works/meta-matic/index.md
@@ -4,6 +4,7 @@ date: 2026-08-11
 linktitle: Méta-Matic ∞
 title: "Méta-Matic ∞"
 slug: works
+url: "/works/meta-matic/"
 weight: 1
 tags: ["Digital Product", "Experimental"]
 clients: []

--- a/content/swedish/works/meta-matic/index.md
+++ b/content/swedish/works/meta-matic/index.md
@@ -4,6 +4,7 @@ date: 2026-08-11
 linktitle: Méta-Matic ∞
 title: "Méta-Matic ∞"
 slug: arbeten
+url: "/sv/arbeten/meta-matic/"
 weight: 1
 tags: ["Digitala Produkter", "Experimentellt"]
 clients: []


### PR DESCRIPTION
## What

Pins explicit ASCII URLs for the Méta-Matic ∞ case study on both language versions:

- English: `/works/meta-matic/`
- Swedish: `/sv/arbeten/meta-matic/`

## Why

The permalink template (`works = '/:slug/:title/'`) slugifies the title `Méta-Matic ∞` straight into the path, producing accented URLs (`/works/méta-matic/`, `/sv/arbeten/méta-matic/`). Those are awkward to share, break some link parsers, and don't match the clean-slug convention used everywhere else on the site.

## How

Adds a `url:` field to the front matter of each language's `index.md`, following the existing `content/swedish/works/_index.md` precedent (Swedish URLs include the `/sv/` prefix explicitly; English don't). No content or layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw7qtoZF13e3psvrqjndaA)_