### PR TITLE
PIA case study: MCP connector + honest-machine note, and reorder featured

### DIFF
--- a/content/english/works/meta-matic/index.md
+++ b/content/english/works/meta-matic/index.md
@@ -5,7 +5,7 @@ linktitle: Méta-Matic ∞
 title: "Méta-Matic ∞"
 slug: works
 url: "/works/meta-matic/"
-weight: 1
+weight: 3
 tags: ["Digital Product", "Experimental"]
 clients: []
 description: A digital drawing machine after Tinguely — a conveyor belt through a latent space that draws infinitely many works and never anything new.

--- a/content/english/works/pia/index.md
+++ b/content/english/works/pia/index.md
@@ -73,6 +73,8 @@ The hard part is what to do when there's no terminal equivalent. Email and confi
 
 > Flag the deviation and make it a deliberate, documented decision — not a slip.
 
+The rule cuts both ways: where the metaphor _is_ Unix, PIA won't fake it either — `sudo` genuinely elevates, `/etc` is really write-protected, and a `permission denied` always means one.
+
 ### Architecture as a design decision
 
 **The most designed part isn't on screen: the adapters are the seam.** The terminal never touches storage or auth directly — only the `StorageAdapter` / `AuthAdapter` / `ShareStore` interfaces, reached through one small `CommandContext` (print, filesystem, auth, stdin …), never the DOM.
@@ -102,6 +104,8 @@ The hard part is what to do when there's no terminal equivalent. Email and confi
 ![The same computer in your thumb — left, the touch bar; right, the ctrl button unfolded to the full readline set. The bar only appears on a touchscreen.](07-mobile-mockup.png "The same computer in your thumb — left, the touch bar; right, the ctrl button unfolded to the full readline set. The bar only appears on a touchscreen.")
 
 **Same app, different home.** On the iOS home screen there's no browser chrome, so `display-mode: standalone` and real safe-area handling put everything edge to edge — while the browser stays untouched. Push is real too: `remind` and collaboration notices reach the phone via Web Push with the tab closed.
+
+**The terminal stays the source of truth — even for an AI.** PIA speaks MCP: an external AI client connects over OAuth and can read your files, writing only within a per-token scope you set from the prompt (`mcp scope claude --write docs` — the `chmod` of a token). Even the OAuth authorise step is a terminal prompt, not a web form; the idiom holds all the way into an auth flow. It's the app's first server-side piece — everything else stays static.
 
 ### Quality: the test that reads like a tour
 

--- a/content/swedish/works/meta-matic/index.md
+++ b/content/swedish/works/meta-matic/index.md
@@ -5,7 +5,7 @@ linktitle: Méta-Matic ∞
 title: "Méta-Matic ∞"
 slug: arbeten
 url: "/sv/arbeten/meta-matic/"
-weight: 1
+weight: 3
 tags: ["Digitala Produkter", "Experimentellt"]
 clients: []
 description: En digital ritmaskin efter Tinguely — ett löpande band genom ett latent rum som ritar oändligt många verk och aldrig något nytt.

--- a/content/swedish/works/pia/index.md
+++ b/content/swedish/works/pia/index.md
@@ -73,6 +73,8 @@ Det svåra är vad man gör när det inte finns någon terminal-motsvarighet. E-
 
 > Flagga avvikelsen och gör den till ett medvetet, dokumenterat beslut — inte en glidning.
 
+Regeln skär åt båda håll: där metaforen _är_ Unix fejkar PIA inte den heller — `sudo` ger faktiskt förhöjd behörighet, `/etc` är verkligen skrivskyddat, och ett `permission denied` betyder alltid vad det säger.
+
 ### Arkitektur som designbeslut
 
 **Den mest designade delen syns inte på skärmen: adaptrarna är sömmen.** Terminalen rör aldrig lagring eller inloggning direkt — bara gränssnitten `StorageAdapter` / `AuthAdapter` / `ShareStore`, nådda genom ett litet `CommandContext` (skriv ut, filsystem, auth, stdin …), aldrig via DOM:en.
@@ -102,6 +104,8 @@ Det svåra är vad man gör när det inte finns någon terminal-motsvarighet. E-
 ![Samma dator i tummen — till vänster touch-baren, till höger ctrl-knappen utfälld till hela readline-uppsättningen. Baren dyker bara upp på pekskärm.](07-mobile-mockup.png "Samma dator i tummen — till vänster touch-baren, till höger ctrl-knappen utfälld till hela readline-uppsättningen. Baren dyker bara upp på pekskärm.")
 
 **Samma app, olika hem.** På iOS-hemskärmen finns ingen webbläsar-chrome, så `display-mode: standalone` och riktig hantering av "safe area" lägger allt kant-i-kant — medan webbläsarläget lämnas orört. Push är på riktigt också: `remind` och samarbets-notiser når telefonen via Web Push med fliken stängd.
+
+**Terminalen förblir den sanna källan — även för en AI.** PIA talar MCP: en extern AI-klient ansluter via OAuth och kan läsa dina filer, men skriver bara inom ett per-token-scope du sätter från prompten (`mcp scope claude --write docs` — en tokens `chmod`). Till och med OAuth-godkännandet är en terminal-prompt, inte ett webbformulär; idiomet håller hela vägen in i ett auth-flöde. Det är appens första server-sida-bit — allt annat förblir statiskt.
 
 ### Kvalitet: testet som läses som en rundtur
 


### PR DESCRIPTION
## Sammanfattning

Små, tes-centrala tillägg i PIA-caset efter appens nyare släpp (0.12–0.16), plus en omsortering av Featured-sektionen. Båda språken.

## Ändringar

- **MCP-connectorn** — ett nytt "utvalt designbeslut" sist i den sektionen: en extern AI-klient ansluter via OAuth och kan läsa dina filer, men skriver bara inom ett per-token-scope du sätter från prompten (`mcp scope … --write` — "en tokens `chmod`"), och till och med OAuth-godkännandet är en terminal-prompt. Förlänger casets "två världar krockar"-tes (terminal ↔ webb) till en tredje: terminal ↔ AI. Det är också appens första server-sida-bit.
- **Den ärliga maskinen** — en mening som avslutar idiom-sektionen: regeln skär åt båda håll — där metaforen *är* Unix fejkar PIA inte heller (`sudo` höjer på riktigt, `/etc` är verkligen skrivskyddat).
- **Reordering av Featured** — Méta-Matic låg först (nyast, `weight: 1`, och sektionen sorteras på vikt → datum). Bumpad till `weight: 3` så ordningen blir **Cadence, PIA, Utblick no.2, A Cut up World, Méta-Matic, Utblick no.4**.

Medvetet utelämnat ur texten (produktdjup, inte tes): history, margin, `sh`, roller på delade listor, magic-link-login, easter eggs, brew-ceremonin.

## Verifiering

- Rent Hugo-bygge (mot senaste master); featured-ordningen bekräftad i den byggda startsidan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012urSgHTxruJ5WpeGfrvWbK