### PR TITLE
Méta-Matic case: add the print-on-demand beat

### DIFF
--- a/content/english/works/meta-matic/index.md
+++ b/content/english/works/meta-matic/index.md
@@ -20,7 +20,7 @@ role: "Concept, Design & Engineering (solo)"
 details:
   year: 2026
   platform: "Web · static site on Cloudflare"
-  stack: "Canvas · vanilla JS · Cloudflare Worker + KV"
+  stack: "Canvas · vanilla JS · Cloudflare Worker + KV · Stripe + Prodigi print"
   scope: "Concept, framing, design & front-end"
 client_label: "Type"
 client:
@@ -42,6 +42,8 @@ The only thing you can do is make a work yours: inspect it enlarged and **certif
 And the irony outlives the exclusivity: what you own is the only copy, entirely genuine — yet its neighbour, a near-duplicate that keeps recurring, can't be told apart from it. An original that is nonetheless visually banal.
 
 You can certify straight in the browser, or with a wallet signature — free, no gas, a verifiable and optional nod to NFTs, never a gate. A counter shows how many have been certified in total, and _The Space_, the coordinate map, plots everyone's certified points alongside yours: no edges, everything recurs; one path, everyone walks it. If two try to certify the same work at once, one wins; the other learns it was taken 40 ms earlier — and that infinitely many others remain.
+
+And in the end the machine does what Tinguely's did first: it leaves the screen and becomes paper. A work can be ordered as a physical print, straight from the page — the digital critique of the original lands in something you can hold. And still: what hangs on the wall is no more unique than the coordinate it came from; your neighbour can print the near-duplicate beside it.
 
 An honest footnote, because it belongs to the work: the "latent space" is mathematically simulated, not a real model. It doesn't matter to the point — and saying so out loud is part of it.
 

--- a/content/swedish/works/meta-matic/index.md
+++ b/content/swedish/works/meta-matic/index.md
@@ -20,7 +20,7 @@ role: "Koncept, design & utveckling (solo)"
 details:
   year: 2026
   platform: "Webb · statisk sida på Cloudflare"
-  stack: "Canvas · vanilla JS · Cloudflare Worker + KV"
+  stack: "Canvas · vanilla JS · Cloudflare Worker + KV · Stripe + Prodigi print"
   scope: "Idé, konceptuell inramning, design & frontend"
 client_label: "Typ"
 client:
@@ -42,6 +42,8 @@ Det enda du kan göra är att göra ett verk till ditt: granska det stort och **
 Och ironin överlever exklusiviteten: det du äger är det enda exemplaret, helt äkta — men grannpunkten, en nära-dubblett som ständigt återkommer, går inte att skilja från det. Ett original som ändå är visuellt banalt.
 
 Att certifiera går på två sätt, samma ägande oavsett vilket: direkt i webbläsaren, eller med en plånbokssignatur — gratis, ingen gas, en verifierbar och frivillig nick åt NFT, aldrig en grind. En räknare visar hur många som certifierats totalt, och _The Space_, koordinatsystemet, ritar ut allas certifierade punkter jämte dina: inga kanter, allt återkommer; en väg, som alla går. Försöker två certifiera samma verk samtidigt vinner en; den andra får veta att det togs 40 ms tidigare — oändligt många andra återstår.
+
+Och till slut gör maskinen det Tinguelys gjorde först: den lämnar skärmen och blir papper. Ett verk kan beställas som fysisk print, direkt från sidan — den digitala kritiken av originalet landar i något man kan hålla i handen. Och ändå: det som hänger på väggen är inte mer unikt än koordinaten det kom ur; grannen kan trycka nära-dubbletten bredvid.
 
 En ärlig fotnot, för den hör till verket: det "latenta rummet" är matematiskt simulerat, inte en riktig modell. Det spelar ingen roll för poängen — och att säga det högt är en del av den.
 


### PR DESCRIPTION
## What

Adds one closing beat to the Méta-Matic ∞ case study — the piece now lets a visitor order their work as a physical print (Stripe checkout, Prodigi fulfillment). Both languages (EN + SV).

## Why

The print is the concept's physical endpoint, not a shop bolt-on: the digital machine that critiques originality now leaves the screen and becomes paper — the loop back to Tinguely's actual 1959 drawings — and the print is still *no more unique than the coordinate it came from*. Framed as the closing turn of the ownership arc, understated, just before the honest footnote.

## How

- New paragraph inserted after the "two ways to certify / The Space" paragraph, before the honest footnote, in both `content/english/…` and `content/swedish/…`.
- `details.stack` gains `Stripe + Prodigi print` so the real payment + fulfillment integrations read for technical viewers.
- No image yet — the physical-print photo will follow; no placeholder, so nothing incomplete shows live.

Local Hugo 0.154.2 build (exact deploy-preview command) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw7qtoZF13e3psvrqjndaA)_