### PR TITLE
Méta-Matic stack: correct KV to D1 + R2

### DIFF
--- a/content/english/works/meta-matic/index.md
+++ b/content/english/works/meta-matic/index.md
@@ -20,7 +20,7 @@ role: "Concept, Design & Engineering (solo)"
 details:
   year: 2026
   platform: "Web · static site on Cloudflare"
-  stack: "Canvas · vanilla JS · Cloudflare Worker + KV · Stripe + Prodigi print"
+  stack: "Canvas · vanilla JS · Cloudflare Worker + D1 + R2 · Stripe + Prodigi print"
   scope: "Concept, framing, design & front-end"
 client_label: "Type"
 client:

--- a/content/swedish/works/meta-matic/index.md
+++ b/content/swedish/works/meta-matic/index.md
@@ -20,7 +20,7 @@ role: "Koncept, design & utveckling (solo)"
 details:
   year: 2026
   platform: "Webb · statisk sida på Cloudflare"
-  stack: "Canvas · vanilla JS · Cloudflare Worker + KV · Stripe + Prodigi print"
+  stack: "Canvas · vanilla JS · Cloudflare Worker + D1 + R2 · Stripe + Prodigi print"
   scope: "Idé, konceptuell inramning, design & frontend"
 client_label: "Typ"
 client:


### PR DESCRIPTION
## What

Fixes the stack line in the Méta-Matic ∞ case study — it listed **KV**, but the order/print API Worker actually uses **D1 + R2** bindings. Corrected in both the English and Swedish content files.

## Why

The case text had drifted from the real deployment. Confirmed against the `meta-matic` repo's `DEPLOY.md` and `api/wrangler.toml`: the site is a Cloudflare Workers (static-assets) project, and the separate `api/` Worker binds **D1 + R2** (Stripe + Prodigi print) — there is no KV.

## Changes

- `content/english/works/meta-matic/index.md` — `stack:` → `Cloudflare Worker + D1 + R2`
- `content/swedish/works/meta-matic/index.md` — same

Content-only; no layout or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChU3WCoMRTUfVMvqb2rj1W)_