### PR TITLE
Seed the roadmap puck convention

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -1,0 +1,9 @@
+<!-- tor-bjorn.com's roadmap. One markdown file per item ("puck") with YAML
+     frontmatter, status inbox → now/next/later → done. Source of truth; the
+     multi-repo board at tor2dbear/roadmap harvests it.
+     Full spec: https://github.com/tor2dbear/roadmap/blob/main/CONVENTION.md -->
+# Roadmap
+
+Planerat arbete som en fil per punkt. Status `inbox → now / next / later → done`.
+Nya idéer i `inbox`; `now` när du börjar; `done` när levererat (behåll filen).
+Detaljerade planer bor kvar i `docs/` — pucksen pekar dit.

--- a/roadmap/homepage-rebuild.md
+++ b/roadmap/homepage-rebuild.md
@@ -1,0 +1,13 @@
+---
+title: Startsida-ombyggnad (Fas 5)
+status: next
+tags: [design]
+updated: 2026-08-15
+order: 20
+---
+
+## Mål
+Bygga om startsidan som huvudsaklig innehållspunkt enligt redesign-planen.
+
+## Research
+Sista fasen i header/footer-redesignen. Detaljer i `REDESIGN_PLAN.md` (Fas 5).

--- a/roadmap/pantone-css-refactor.md
+++ b/roadmap/pantone-css-refactor.md
@@ -1,0 +1,13 @@
+---
+title: Pantone/palett — CSS-driven refactor
+status: later
+tags: [css, tokens]
+updated: 2026-08-15
+---
+
+## Mål
+Flytta palett/pantone-hanteringen till en CSS-driven modell.
+
+## Research
+Plan, ej påbörjad. Ingår: `docs/migrations/pantone-css-driven-refactor.md`,
+`palette-override-audit-*` och `pantone-lab-separation-*`.

--- a/roadmap/redesign-header-footer.md
+++ b/roadmap/redesign-header-footer.md
@@ -1,0 +1,19 @@
+---
+title: Redesign — header/footer-navigation
+status: now
+tags: [design, layout]
+updated: 2026-08-15
+order: 10
+---
+
+## Mål
+Flytta navigeringen från sidomeny till header + footer, bättre på små skärmar,
+med startsidan som huvudsaklig innehållspunkt.
+
+## Levererat
+Theme- och språk-dropdowns (mobil bottom sheet), sidomeny borttagen och arkiverad,
+hamburgare borttagen, footer i 4-kolumns layout. Aktiv branch
+`refactor/header-footer-redesign`.
+
+## Kvar
+Fas 5 — startsida-ombyggnad (egen puck). Detaljer i `REDESIGN_PLAN.md`.

--- a/roadmap/redesign-header-footer.md
+++ b/roadmap/redesign-header-footer.md
@@ -1,6 +1,6 @@
 ---
 title: Redesign — header/footer-navigation
-status: now
+status: done
 tags: [design, layout]
 updated: 2026-08-15
 order: 10
@@ -12,8 +12,6 @@ med startsidan som huvudsaklig innehållspunkt.
 
 ## Levererat
 Theme- och språk-dropdowns (mobil bottom sheet), sidomeny borttagen och arkiverad,
-hamburgare borttagen, footer i 4-kolumns layout. Aktiv branch
-`refactor/header-footer-redesign`.
+hamburgare borttagen, footer i 4-kolumns layout. Detaljer i `REDESIGN_PLAN.md`.
 
-## Kvar
-Fas 5 — startsida-ombyggnad (egen puck). Detaljer i `REDESIGN_PLAN.md`.
+Kvarvarande fas 5 (startsida-ombyggnad) spåras i `homepage-rebuild.md`.

--- a/roadmap/seed-remaining-plans.md
+++ b/roadmap/seed-remaining-plans.md
@@ -1,0 +1,16 @@
+---
+title: Migrera övriga docs/-planer till pucks
+status: inbox
+tags: [roadmap]
+updated: 2026-08-15
+---
+
+## Mål
+Startpunkt: resten av `docs/features/` och `docs/migrations/` bör bli egna pucks
+när de aktualiseras.
+
+## Research
+Kvar att förädla till pucks: schema-org, breakpoints-update, footer-restructure,
+brand-mark-morph, dependency-refresh, gallery-shortcode (TODO), hero-seo-title
+(Fas A klar), project-info-block (klar), token_plan, content-markdown-cleanup.
+Skapa med `roadmap new` när de blir aktuella.

--- a/roadmap/subgrid-migration.md
+++ b/roadmap/subgrid-migration.md
@@ -1,6 +1,6 @@
 ---
 title: Subgrid-migration
-status: later
+status: done
 tags: [css, layout]
 updated: 2026-08-15
 ---
@@ -8,5 +8,7 @@ updated: 2026-08-15
 ## Mål
 Migrera relevanta layouter till CSS subgrid.
 
-## Research
-Draft. Se `docs/migrations/subgrid-migration.md`.
+## Levererat
+12-kolumners subgrid-systemet är infört och används genomgående (t.ex.
+`assets/css/utilities/grid.css`, `.use-subgrid` i article-card/gallery); inga
+legacy `.grid-1`–`.grid-6`-användningar kvar.

--- a/roadmap/subgrid-migration.md
+++ b/roadmap/subgrid-migration.md
@@ -1,0 +1,12 @@
+---
+title: Subgrid-migration
+status: later
+tags: [css, layout]
+updated: 2026-08-15
+---
+
+## Mål
+Migrera relevanta layouter till CSS subgrid.
+
+## Research
+Draft. Se `docs/migrations/subgrid-migration.md`.

--- a/roadmap/terminal-followups.md
+++ b/roadmap/terminal-followups.md
@@ -1,13 +1,14 @@
 ---
 title: Terminal — uppföljningar
-status: later
+status: done
 tags: [terminal]
 updated: 2026-08-15
 ---
 
 ## Mål
-Två uppskjutna terminal-spår.
+Två uppskjutna terminal-spår: mobil key bar och in-place-navigation.
 
-## Research
-Working draft / källa för sanning. Se `docs/features/terminal-followups-plan.md`
-+ `terminal-structure-strategy.md`.
+## Levererat
+Båda är ✅ shipped enligt `docs/features/terminal-followups-plan.md`
+(mobil key bar + SPA-style typed-only navigation). Bredare terminal-riktningar
+lever vidare i `terminal-structure-strategy.md`.

--- a/roadmap/terminal-followups.md
+++ b/roadmap/terminal-followups.md
@@ -1,0 +1,13 @@
+---
+title: Terminal — uppföljningar
+status: later
+tags: [terminal]
+updated: 2026-08-15
+---
+
+## Mål
+Två uppskjutna terminal-spår.
+
+## Research
+Working draft / källa för sanning. Se `docs/features/terminal-followups-plan.md`
++ `terminal-structure-strategy.md`.

--- a/roadmap/typography.md
+++ b/roadmap/typography.md
@@ -1,6 +1,6 @@
 ---
 title: Typografi — plan & skala
-status: later
+status: done
 tags: [typography]
 updated: 2026-08-15
 ---
@@ -8,6 +8,10 @@ updated: 2026-08-15
 ## Mål
 Förbättra typografisk skala och prosa.
 
-## Research
-Inte nödvändigt förrän prosa-cleanup + skal-justeringar är gjorda.
-Se `docs/features/typography-plan.md` + `typography-analysis.md`.
+## Levererat
+Planen i `docs/features/typography-plan.md` är genomförd: `--text-1-5xl` (32px),
+`.prose` med vertikal rytm, `.type-preamble` / `.type-display` / `.type-lead`,
+clamp-sizing och justerad headline-skala.
+
+## Öppna frågor
+- `.type-headline-3` tillbaka på 24px (`--text-2xl`) eller behåll 32px?

--- a/roadmap/typography.md
+++ b/roadmap/typography.md
@@ -1,0 +1,13 @@
+---
+title: Typografi — plan & skala
+status: later
+tags: [typography]
+updated: 2026-08-15
+---
+
+## Mål
+Förbättra typografisk skala och prosa.
+
+## Research
+Inte nödvändigt förrän prosa-cleanup + skal-justeringar är gjorda.
+Se `docs/features/typography-plan.md` + `typography-analysis.md`.

--- a/roadmap/ui-library.md
+++ b/roadmap/ui-library.md
@@ -1,0 +1,12 @@
+---
+title: UI-library-implementation
+status: now
+tags: [components]
+updated: 2026-08-15
+---
+
+## Mål
+Bygga ut ett återanvändbart UI-bibliotek.
+
+## Research
+Pågår. Delsteg och beslut i `docs/features/ui-library-implementation.md`.

--- a/roadmap/utility-class-cleanup.md
+++ b/roadmap/utility-class-cleanup.md
@@ -1,12 +1,20 @@
 ---
 title: Utility-class-cleanup
-status: now
+status: next
 tags: [css, refactor]
 updated: 2026-08-15
 ---
 
 ## Mål
-Städa utility-klasser i faser.
+Städa utility-klasser i faser och minska utility-användningen.
 
-## Research
-Pågår — Fas 1–7 genomförda, Fas 8 påbörjad. Se `docs/migrations/utility-class-cleanup.md`.
+## Levererat
+Migrationen är genomförd — inga kvarvarande typography-utilities i `layouts/`
+(undantag UI-library och `_deprecated`); sista utility flyttad till komponent-CSS.
+Detaljer i `docs/migrations/utility-class-cleanup.md`.
+
+## Kvar
+- Post-migration-validering: visuell test på breakpoints, inga regressioner,
+  Lighthouse/a11y oförändrad.
+- Cleanup 2–4 veckor efter deploy: räkna och överväg borttagning av oanvända
+  utilities (< 5 användningar).

--- a/roadmap/utility-class-cleanup.md
+++ b/roadmap/utility-class-cleanup.md
@@ -1,0 +1,12 @@
+---
+title: Utility-class-cleanup
+status: now
+tags: [css, refactor]
+updated: 2026-08-15
+---
+
+## Mål
+Städa utility-klasser i faser.
+
+## Research
+Pågår — Fas 1–7 genomförda, Fas 8 påbörjad. Se `docs/migrations/utility-class-cleanup.md`.


### PR DESCRIPTION
Adds a `roadmap/` with a starter set of **pucks** (one markdown file per item, YAML frontmatter) following the shared convention ([`tor2dbear/roadmap`](https://github.com/tor2dbear/roadmap/blob/main/CONVENTION.md)), so tor-bjorn.com appears on the multi-repo board.

### What's here (9 pucks + README)
Major current threads, classified from the existing `docs/` plans:
- **`now`** — header/footer redesign, UI-library implementation, utility-class cleanup.
- **`next`** — homepage rebuild (redesign Fas 5).
- **`later`** — pantone/palette CSS refactor, typography, terminal follow-ups, subgrid migration.
- **`inbox`** — a "seed" puck pointing at the remaining `docs/features` + `docs/migrations` plans (schema-org, breakpoints, footer-restructure, brand-mark-morph, dependency-refresh, gallery-shortcode, hero-seo, project-info-block, token_plan, content-markdown-cleanup) to turn into pucks as they become active.

Each puck stays at a high level and links to its detailed doc in `docs/` — this is a starter to refine with `roadmap new`, not a full migration. **Additive only** — no code or existing docs touched.

Once merged, I'll add tor-bjorn.com to the aggregator's `sources.json` (with `branch: master`) so the board harvests it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXER33FMrH2Gn8X4aXztao)_