### PR TITLE
PIA: link the source repo in the project-info box

### DIFF
--- a/content/english/works/pia/index.md
+++ b/content/english/works/pia/index.md
@@ -23,6 +23,7 @@ details:
   platform: "Web · installable PWA"
   stack: "TypeScript · Vite · Vitest · Supabase · Cloudflare Pages"
   scope: "Concept, design, architecture & development"
+repo: "https://github.com/tor2dbear/pia-terminal"
 client_label: "Type"
 client:
   name: "Self-initiated"

--- a/content/swedish/works/pia/index.md
+++ b/content/swedish/works/pia/index.md
@@ -23,6 +23,7 @@ details:
   platform: "Webb · installerbar PWA"
   stack: "TypeScript · Vite · Vitest · Supabase · Cloudflare Pages"
   scope: "Idé, design, arkitektur & utveckling"
+repo: "https://github.com/tor2dbear/pia-terminal"
 client_label: "Typ"
 client:
   name: "Eget initiativ"


### PR DESCRIPTION
## Sammanfattning

PIA:s terminalmotor är nu öppen källkod (`pia-terminal-engine`, MIT på npm) — konkret bevis för casets rena-söm-tes. Ytan det på ett lågmält sätt: en **Källkod / Source-länk i project-info-rutan**, inget nytt stycke.

## Ändringar

- Lägger `repo: "https://github.com/tor2dbear/pia-terminal"` i front matter för PIA (båda språken). Master hade redan ett `repo`-fält i `project-info.html` som renderar en lokaliserad **Källkod / Source**-rad i Details-listan — så **ingen template-ändring** behövs.

## Att bekräfta

- **Länkmål:** pekar på GitHub-repot (etiketten "Källkod/Source" vill ha ett repo). Kunde inte verifiera att repot är publikt från byggmiljön — om det är privat, eller om du hellre vill länka npm-paketet (`npmjs.com/package/pia-terminal-engine`), är det en enradsändring.

## Verifiering

- Rent Hugo-bygge; länkraden renderas i båda språken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012urSgHTxruJ5WpeGfrvWbK

---
_Generated by [Claude Code](https://claude.ai/code/session_012urSgHTxruJ5WpeGfrvWbK)_