### PR TITLE
Brand mark: draw the curl with the same stroke model as its lines

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -232,11 +232,14 @@ html[data-grid-overlay] .top-menu {
   width: 1.5rem;
   color: var(--text-default);
   max-width: 100%;
+  /* One source of truth for the mark's stroke: the two lines and the loop
+     must never drift apart. */
+  --brand-mark-stroke: 2;
 }
 
 .brand__mark-line {
   stroke: currentColor;
-  stroke-width: 2;
+  stroke-width: var(--brand-mark-stroke);
   fill: none;
   stroke-linecap: round;
 }
@@ -245,13 +248,20 @@ html[data-grid-overlay] .top-menu {
   transform-origin: 12px 12px;
 }
 
+/* The loop must draw at the same weight as the two straight lines, so it
+   carries the same plain, scaling stroke. It used to opt out with
+   `vector-effect: non-scaling-stroke`, which pins the stroke to CSS pixels
+   while the lines keep scaling with the SVG viewport. The two only agree while
+   that viewport scale is exactly 1 — any page zoom, root font-size other than
+   16px, or `max-width` clamp pulls them apart, and the loop then renders
+   visibly thinner (or fatter) than the lines it joins. Nothing here scales the
+   loop group, so the opt-out bought nothing. */
 .brand__mark-loop-path {
   fill: none;
   stroke: currentColor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2;
-  vector-effect: non-scaling-stroke;
+  stroke-width: var(--brand-mark-stroke);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Fixes the curl rendering at a different stroke weight than the two straight lines it joins — reported in Arc, where it looks noticeably lighter than the lines.

## The cause

The loop path opted out of viewport scaling with `vector-effect: non-scaling-stroke`, while the two straight lines kept a plain, scaling stroke:

- plain stroke = 2 **viewBox units**, scales with the SVG viewport
- `non-scaling-stroke` = 2 **CSS pixels**, regardless of the viewport

The two agree only while the mark's SVG scale is exactly 1 — which it is in the normal case (`progressbar.js` sets `viewBox="0 0 <width> 24"` and the height is `1.5rem` = 24px at a 16px root font-size). Any deviation — page zoom, a root font-size other than 16px, or the `max-width: 100%` clamp — pulls the two weights apart, and the curl then renders visibly lighter or heavier than the lines.

Nothing in the CSS or JS scales the loop group, so the opt-out bought nothing. It was also the only use of `vector-effect` in the whole codebase, which lines up with the curl being the only element that renders wrong.

## The change

All three strokes now use the same plain, scaling stroke, off one `--brand-mark-stroke` custom property on `.brand__mark` so they can't drift apart again.

## Verification

Measured in headless Chromium on the real markup and CSS, comparing the painted thickness of the curl against the lines:

| Condition | curl/line before | after |
| --- | --- | --- |
| root 16px, zoom 100% | 1.00 | 1.00 |
| root 16px, zoom 125% | 1.00 | 1.00 |
| root 12px (scale 0.75) | **1.33** | 1.00 |
| root 14px, zoom 110% | **1.13** | 1.00 |

At scale 1 nothing changes, so Chrome and Safari render exactly as before. `jest` (710 tests) and `prettier --check` pass.

Opened mainly to get a deploy preview, so the Arc rendering can be confirmed against the real header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws2sJwAh9ZEpv9hq2QJ83F)_